### PR TITLE
Add HomologicalCode abstraction layer + toric instance

### DIFF
--- a/QEC/Stabilizer/Homological.lean
+++ b/QEC/Stabilizer/Homological.lean
@@ -1,0 +1,6 @@
+import QEC.Stabilizer.Homological.Code
+import QEC.Stabilizer.Homological.CSS
+import QEC.Stabilizer.Homological.Generators
+import QEC.Stabilizer.Homological.StabGroup
+import QEC.Stabilizer.Homological.LogicalCorrespondence
+import QEC.Stabilizer.Homological.Distance

--- a/QEC/Stabilizer/Homological/CSS.lean
+++ b/QEC/Stabilizer/Homological/CSS.lean
@@ -1,0 +1,258 @@
+import Mathlib.Tactic
+import QEC.Stabilizer.Homological.Code
+import QEC.Stabilizer.PauliGroup
+import QEC.Stabilizer.PauliGroup.NQubitOperator
+import QEC.Stabilizer.Core
+
+/-!
+# Generic CSS construction from a `HomologicalCode`
+
+This file lifts the toric CSS operator-encoding machinery to the abstract
+`HomologicalCode` setting.  Given a length-3 chain complex `X`, we encode
+1-chains as X-type and Z-type Pauli operators on `Fintype.card X.C1` qubits,
+indexed by the canonical `Fintype.equivFin X.C1`.
+
+This file currently covers §B.1 (Pauli-operator encoding).  §B.2 (generators)
+and §B.3 (the `StabilizerCode` instance with symplectic-LI lift) follow in
+later edits.
+-/
+
+namespace Quantum
+namespace Stabilizer
+namespace Homological
+
+open scoped BigOperators
+
+namespace HomologicalCode
+
+variable (X : HomologicalCode)
+
+/-- Number of physical qubits = number of 1-cells. -/
+abbrev numQubits : ℕ := Fintype.card X.C1
+
+/-- Canonical equiv between 1-cells and `Fin numQubits`, used to index qubits. -/
+noncomputable def edgeEquiv : X.C1 ≃ Fin X.numQubits :=
+  Fintype.equivFin X.C1
+
+/-- Encode a 1-chain as an X-type Pauli element. -/
+noncomputable def chainXOperator (c : X.C1 → ZMod 2) :
+    NQubitPauliGroupElement X.numQubits :=
+  ⟨0, fun q =>
+    if ∃ e : X.C1, X.edgeEquiv e = q ∧ c e = 1
+    then PauliOperator.X else PauliOperator.I⟩
+
+/-- Encode a 1-chain as a Z-type Pauli element. -/
+noncomputable def chainZOperator (c : X.C1 → ZMod 2) :
+    NQubitPauliGroupElement X.numQubits :=
+  ⟨0, fun q =>
+    if ∃ e : X.C1, X.edgeEquiv e = q ∧ c e = 1
+    then PauliOperator.Z else PauliOperator.I⟩
+
+/-- Inverse of `chainXOperator`: read back the 1-chain. -/
+noncomputable def chainOfXOperator
+    (g : NQubitPauliGroupElement X.numQubits) : X.C1 → ZMod 2 :=
+  fun e => if g.operators (X.edgeEquiv e) = PauliOperator.X then 1 else 0
+
+/-- Inverse of `chainZOperator`. -/
+noncomputable def chainOfZOperator
+    (g : NQubitPauliGroupElement X.numQubits) : X.C1 → ZMod 2 :=
+  fun e => if g.operators (X.edgeEquiv e) = PauliOperator.Z then 1 else 0
+
+variable {X}
+
+/-- The X-chain operator at qubit `q` (`rfl`-style unfold). -/
+lemma chainXOperator_op_at (c : X.C1 → ZMod 2) (q : Fin X.numQubits) :
+    (X.chainXOperator c).operators q =
+      if ∃ e : X.C1, X.edgeEquiv e = q ∧ c e = 1
+      then PauliOperator.X else PauliOperator.I := rfl
+
+/-- The Z-chain operator at qubit `q` (`rfl`-style unfold). -/
+lemma chainZOperator_op_at (c : X.C1 → ZMod 2) (q : Fin X.numQubits) :
+    (X.chainZOperator c).operators q =
+      if ∃ e : X.C1, X.edgeEquiv e = q ∧ c e = 1
+      then PauliOperator.Z else PauliOperator.I := rfl
+
+/-- An edge `e` is in the support of `chainXOperator c` iff `c e = 1`. -/
+lemma mem_support_chainXOperator_iff (c : X.C1 → ZMod 2) (e : X.C1) :
+    X.edgeEquiv e ∈ (X.chainXOperator c).operators.support ↔ c e = 1 := by
+  classical
+  constructor
+  · intro hmem
+    by_contra hne
+    have hnot :
+        ¬ ∃ e' : X.C1, X.edgeEquiv e' = X.edgeEquiv e ∧ c e' = 1 := by
+      rintro ⟨e', heq, he1⟩
+      exact hne ((X.edgeEquiv.injective heq) ▸ he1)
+    have hI :
+        (X.chainXOperator c).operators (X.edgeEquiv e) = PauliOperator.I := by
+      rw [chainXOperator_op_at]
+      exact if_neg hnot
+    have hneqI :
+        (X.chainXOperator c).operators (X.edgeEquiv e) ≠ PauliOperator.I := by
+      simpa [NQubitPauliOperator.support] using hmem
+    exact hneqI hI
+  · intro he1
+    have hex : ∃ e' : X.C1, X.edgeEquiv e' = X.edgeEquiv e ∧ c e' = 1 :=
+      ⟨e, rfl, he1⟩
+    have hX :
+        (X.chainXOperator c).operators (X.edgeEquiv e) = PauliOperator.X := by
+      rw [chainXOperator_op_at]
+      exact if_pos hex
+    simp [NQubitPauliOperator.support, hX]
+
+/-- An edge `e` is in the support of `chainZOperator c` iff `c e = 1`. -/
+lemma mem_support_chainZOperator_iff (c : X.C1 → ZMod 2) (e : X.C1) :
+    X.edgeEquiv e ∈ (X.chainZOperator c).operators.support ↔ c e = 1 := by
+  classical
+  constructor
+  · intro hmem
+    by_contra hne
+    have hnot :
+        ¬ ∃ e' : X.C1, X.edgeEquiv e' = X.edgeEquiv e ∧ c e' = 1 := by
+      rintro ⟨e', heq, he1⟩
+      exact hne ((X.edgeEquiv.injective heq) ▸ he1)
+    have hI :
+        (X.chainZOperator c).operators (X.edgeEquiv e) = PauliOperator.I := by
+      rw [chainZOperator_op_at]
+      exact if_neg hnot
+    have hneqI :
+        (X.chainZOperator c).operators (X.edgeEquiv e) ≠ PauliOperator.I := by
+      simpa [NQubitPauliOperator.support] using hmem
+    exact hneqI hI
+  · intro he1
+    have hex : ∃ e' : X.C1, X.edgeEquiv e' = X.edgeEquiv e ∧ c e' = 1 :=
+      ⟨e, rfl, he1⟩
+    have hZ :
+        (X.chainZOperator c).operators (X.edgeEquiv e) = PauliOperator.Z := by
+      rw [chainZOperator_op_at]
+      exact if_pos hex
+    simp [NQubitPauliOperator.support, hZ]
+
+/-- Helper: every `ZMod 2` element is `0` or `1`. -/
+private lemma zmod2_eq_zero_or_one (a : ZMod 2) : a = 0 ∨ a = 1 := by
+  have hvalle : a.val ≤ 1 := Nat.le_of_lt_succ a.val_lt
+  rcases Nat.le_one_iff_eq_zero_or_eq_one.mp hvalle with h0 | h1
+  · left
+    calc a = ((a.val : ZMod 2)) := (ZMod.natCast_zmod_val a).symm
+      _ = 0 := by simp [h0]
+  · right
+    calc a = ((a.val : ZMod 2)) := (ZMod.natCast_zmod_val a).symm
+      _ = 1 := by simp [h1]
+
+/-- Roundtrip: chain → X-operator → chain. -/
+theorem chainOfXOperator_chainXOperator (c : X.C1 → ZMod 2) :
+    X.chainOfXOperator (X.chainXOperator c) = c := by
+  ext e
+  by_cases hce : c e = 1
+  · have _hex : ∃ e' : X.C1, X.edgeEquiv e' = X.edgeEquiv e ∧ c e' = 1 :=
+      ⟨e, rfl, hce⟩
+    simp [chainOfXOperator, chainXOperator, hce]
+  · have _hnot :
+        ¬ ∃ e' : X.C1, X.edgeEquiv e' = X.edgeEquiv e ∧ c e' = 1 := by
+      rintro ⟨e', heq, he1⟩
+      have he' : e' = e := X.edgeEquiv.injective heq
+      exact hce (he' ▸ he1)
+    have hce0 : c e = 0 := (zmod2_eq_zero_or_one (c e)).resolve_right hce
+    simp [chainOfXOperator, chainXOperator, hce0]
+
+/-- Roundtrip: chain → Z-operator → chain. -/
+theorem chainOfZOperator_chainZOperator (c : X.C1 → ZMod 2) :
+    X.chainOfZOperator (X.chainZOperator c) = c := by
+  ext e
+  by_cases hce : c e = 1
+  · have _hex : ∃ e' : X.C1, X.edgeEquiv e' = X.edgeEquiv e ∧ c e' = 1 :=
+      ⟨e, rfl, hce⟩
+    simp [chainOfZOperator, chainZOperator, hce]
+  · have _hnot :
+        ¬ ∃ e' : X.C1, X.edgeEquiv e' = X.edgeEquiv e ∧ c e' = 1 := by
+      rintro ⟨e', heq, he1⟩
+      have he' : e' = e := X.edgeEquiv.injective heq
+      exact hce (he' ▸ he1)
+    have hce0 : c e = 0 := (zmod2_eq_zero_or_one (c e)).resolve_right hce
+    simp [chainOfZOperator, chainZOperator, hce0]
+
+/-- The X-chain operator is X-type (phase 0, every operator is `X` or `I`). -/
+lemma chainXOperator_isXType (c : X.C1 → ZMod 2) :
+    NQubitPauliGroupElement.IsXTypeElement (X.chainXOperator c) := by
+  refine ⟨rfl, fun q => ?_⟩
+  by_cases h : ∃ e : X.C1, X.edgeEquiv e = q ∧ c e = 1
+  · right
+    simp [chainXOperator, h]
+  · left
+    simp [chainXOperator, h]
+
+/-- The Z-chain operator is Z-type (phase 0, every operator is `Z` or `I`). -/
+lemma chainZOperator_isZType (c : X.C1 → ZMod 2) :
+    NQubitPauliGroupElement.IsZTypeElement (X.chainZOperator c) := by
+  refine ⟨rfl, fun q => ?_⟩
+  by_cases h : ∃ e : X.C1, X.edgeEquiv e = q ∧ c e = 1
+  · right
+    simp [chainZOperator, h]
+  · left
+    simp [chainZOperator, h]
+
+/-- `chainXOperator 0 = 1`. -/
+@[simp] lemma chainXOperator_zero :
+    X.chainXOperator 0 = 1 := by
+  unfold chainXOperator
+  aesop
+
+/-- `chainZOperator 0 = 1`. -/
+@[simp] lemma chainZOperator_zero :
+    X.chainZOperator 0 = 1 := by
+  unfold chainZOperator
+  aesop
+
+set_option maxHeartbeats 1000000 in
+-- This split-`if` over chain-sum cases involves a quadratic case explosion across
+-- the three indicator predicates (c, c', c+c'); the extra heartbeats accommodate
+-- it without restructuring the proof.
+/-- Homomorphism: `chainXOperator (c + c') = chainXOperator c * chainXOperator c'`. -/
+theorem chainXOperator_add (c c' : X.C1 → ZMod 2) :
+    X.chainXOperator (c + c') = X.chainXOperator c * X.chainXOperator c' := by
+  simp [chainXOperator] at *
+  simp +decide [NQubitPauliGroupElement.mul, NQubitPauliGroupElement.mulOp]
+  refine ⟨?_, ?_⟩
+  · rw [Finset.sum_eq_zero]; aesop
+  · ext q
+    split_ifs <;> simp_all +decide [Fin.ext_iff, ZMod]
+    · rename_i h₁ h₂ h₃
+      obtain ⟨e₁, he₁, he₂⟩ := h₁
+      obtain ⟨e₂, he₃, he₄⟩ := h₂
+      obtain ⟨e₃, he₅, he₆⟩ := h₃
+      have h_eq : e₁ = e₂ ∧ e₂ = e₃ :=
+        ⟨X.edgeEquiv.injective (Fin.ext (he₁.trans he₃.symm)),
+         X.edgeEquiv.injective (Fin.ext (he₃.trans he₅.symm))⟩
+      grind
+    · grind
+    · grind
+    · grind
+
+set_option maxHeartbeats 1000000 in
+-- Same case-explosion as `chainXOperator_add`; see comment there.
+/-- Homomorphism: `chainZOperator (c + c') = chainZOperator c * chainZOperator c'`. -/
+theorem chainZOperator_add (c c' : X.C1 → ZMod 2) :
+    X.chainZOperator (c + c') = X.chainZOperator c * X.chainZOperator c' := by
+  simp [chainZOperator] at *
+  simp +decide [NQubitPauliGroupElement.mul, NQubitPauliGroupElement.mulOp]
+  refine ⟨?_, ?_⟩
+  · rw [Finset.sum_eq_zero]; aesop
+  · ext q
+    split_ifs <;> simp_all +decide [Fin.ext_iff, ZMod]
+    · rename_i h₁ h₂ h₃
+      obtain ⟨e₁, he₁, he₂⟩ := h₁
+      obtain ⟨e₂, he₃, he₄⟩ := h₂
+      obtain ⟨e₃, he₅, he₆⟩ := h₃
+      have h_eq : e₁ = e₂ ∧ e₂ = e₃ :=
+        ⟨X.edgeEquiv.injective (Fin.ext (he₁.trans he₃.symm)),
+         X.edgeEquiv.injective (Fin.ext (he₃.trans he₅.symm))⟩
+      grind
+    · grind
+    · grind
+    · grind
+
+end HomologicalCode
+
+end Homological
+end Stabilizer
+end Quantum

--- a/QEC/Stabilizer/Homological/Code.lean
+++ b/QEC/Stabilizer/Homological/Code.lean
@@ -1,0 +1,192 @@
+import Mathlib.Tactic
+
+/-!
+# Abstract length-3 chain complex over `ZMod 2`
+
+A `HomologicalCode` is a length-3 chain complex `C₂ →∂₂ C₁ →∂₁ C₀` over `𝔽₂`
+with finite cells, satisfying the chain-complex law `∂₁ ∘ ∂₂ = 0`.  It is the
+core data from which a CSS stabilizer code with `n = |C₁|` qubits and
+`k = dim H₁` logical qubits is built.
+
+This file sets up the abstract structure and the homology API:
+
+* `HomologicalCode` (struct)
+* `cycles`, `boundaries`, `H1`
+* `boundaries_le_cycles`
+* Rank-nullity for `∂₁` and `∂₂`
+* `finrank_H1_eq_cycles_sub_boundaries`
+* `cutMap` — the `𝔽₂`-transpose of `∂₁`, defined as a finite sum so that
+  instance resolution stays cheap.
+
+The CSS construction itself is in `QEC/Stabilizer/Homological/CSS.lean`.
+-/
+
+namespace Quantum
+namespace Stabilizer
+namespace Homological
+
+open scoped BigOperators
+
+/-- A length-3 chain complex over `ZMod 2` with finite, decidable cells.
+
+`boundary1 ∘ boundary2 = 0` is the chain-complex law. -/
+structure HomologicalCode where
+  /-- Type of 0-cells (e.g. vertices). -/
+  C0 : Type
+  /-- Type of 1-cells (e.g. edges → physical qubits). -/
+  C1 : Type
+  /-- Type of 2-cells (e.g. faces). -/
+  C2 : Type
+  /-- Decidable equality on 0-cells. -/
+  decEq0 : DecidableEq C0
+  /-- Decidable equality on 1-cells. -/
+  decEq1 : DecidableEq C1
+  /-- Decidable equality on 2-cells. -/
+  decEq2 : DecidableEq C2
+  /-- Finitely many 0-cells. -/
+  fin0 : Fintype C0
+  /-- Finitely many 1-cells. -/
+  fin1 : Fintype C1
+  /-- Finitely many 2-cells. -/
+  fin2 : Fintype C2
+  /-- Boundary map `∂₁ : C₁ → C₀` (with chains as `ZMod 2`-valued functions). -/
+  boundary1 : (C1 → ZMod 2) →ₗ[ZMod 2] (C0 → ZMod 2)
+  /-- Boundary map `∂₂ : C₂ → C₁`. -/
+  boundary2 : (C2 → ZMod 2) →ₗ[ZMod 2] (C1 → ZMod 2)
+  /-- Chain-complex law: `∂₁ ∘ ∂₂ = 0`. -/
+  boundary_comp : boundary1.comp boundary2 = 0
+
+namespace HomologicalCode
+
+attribute [instance] decEq0 decEq1 decEq2 fin0 fin1 fin2
+
+variable (X : HomologicalCode)
+
+/-- Pointwise form of the chain-complex law. -/
+theorem boundary_comp_apply (f : X.C2 → ZMod 2) :
+    X.boundary1 (X.boundary2 f) = 0 := by
+  have h := congrArg (fun T => T f) X.boundary_comp
+  simpa using h
+
+/-- 1-cycles: `Z₁ = ker ∂₁`. -/
+def cycles : Submodule (ZMod 2) (X.C1 → ZMod 2) :=
+  LinearMap.ker X.boundary1
+
+/-- 1-boundaries: `B₁ = im ∂₂`. -/
+def boundaries : Submodule (ZMod 2) (X.C1 → ZMod 2) :=
+  LinearMap.range X.boundary2
+
+/-- Boundaries are cycles (`im ∂₂ ≤ ker ∂₁`). -/
+theorem boundaries_le_cycles : X.boundaries ≤ X.cycles := by
+  intro c hc
+  rcases hc with ⟨f, rfl⟩
+  exact X.boundary_comp_apply f
+
+/-- `B₁` viewed as a submodule of `Z₁`. -/
+abbrev boundarySubmoduleInCycles : Submodule (ZMod 2) X.cycles :=
+  Submodule.comap X.cycles.subtype X.boundaries
+
+/-- First homology `H₁ = Z₁ / B₁`. -/
+abbrev H1 : Type :=
+  X.cycles ⧸ X.boundarySubmoduleInCycles
+
+/-- The `C₀` chain space has `Fintype.card C₀` dimensions. -/
+theorem finrank_C0 :
+    Module.finrank (ZMod 2) (X.C0 → ZMod 2) = Fintype.card X.C0 :=
+  Module.finrank_fintype_fun_eq_card (R := ZMod 2) (η := X.C0)
+
+/-- The `C₁` chain space has `Fintype.card C₁` dimensions. -/
+theorem finrank_C1 :
+    Module.finrank (ZMod 2) (X.C1 → ZMod 2) = Fintype.card X.C1 :=
+  Module.finrank_fintype_fun_eq_card (R := ZMod 2) (η := X.C1)
+
+/-- The `C₂` chain space has `Fintype.card C₂` dimensions. -/
+theorem finrank_C2 :
+    Module.finrank (ZMod 2) (X.C2 → ZMod 2) = Fintype.card X.C2 :=
+  Module.finrank_fintype_fun_eq_card (R := ZMod 2) (η := X.C2)
+
+/-- Rank-nullity for `∂₁`: `dim C₁ = dim Z₁ + rank ∂₁`. -/
+theorem rank_nullity_boundary1 :
+    Module.finrank (ZMod 2) (X.C1 → ZMod 2) =
+      Module.finrank (ZMod 2) X.cycles +
+        Module.finrank (ZMod 2) (LinearMap.range X.boundary1) := by
+  simpa [cycles, add_comm] using
+    (LinearMap.finrank_range_add_finrank_ker X.boundary1).symm
+
+/-- Rank-nullity for `∂₂`: `dim C₂ = dim (ker ∂₂) + dim B₁`. -/
+theorem rank_nullity_boundary2 :
+    Module.finrank (ZMod 2) (X.C2 → ZMod 2) =
+      Module.finrank (ZMod 2) (LinearMap.ker X.boundary2) +
+        Module.finrank (ZMod 2) X.boundaries := by
+  simpa [boundaries, add_comm] using
+    (LinearMap.finrank_range_add_finrank_ker X.boundary2).symm
+
+/-- The quotient bridge `dim H₁ = dim Z₁ - dim B₁`. -/
+theorem finrank_H1_eq_cycles_sub_boundaries :
+    @Module.finrank (ZMod 2) X.H1 _
+      (Submodule.Quotient.addCommGroup
+        (X.boundarySubmoduleInCycles)).toAddCommMonoid
+      (Submodule.Quotient.module X.boundarySubmoduleInCycles) =
+      Module.finrank (ZMod 2) X.cycles -
+        Module.finrank (ZMod 2) X.boundaries := by
+  have hquot :
+      @Module.finrank (ZMod 2) X.H1 _
+          (Submodule.Quotient.addCommGroup
+            X.boundarySubmoduleInCycles).toAddCommMonoid
+          (Submodule.Quotient.module X.boundarySubmoduleInCycles) +
+          Module.finrank (ZMod 2) X.boundarySubmoduleInCycles =
+        Module.finrank (ZMod 2) X.cycles := by
+    simpa [H1, boundarySubmoduleInCycles] using
+      (Submodule.finrank_quotient_add_finrank (R := ZMod 2)
+        X.boundarySubmoduleInCycles)
+  have hcomap :
+      Module.finrank (ZMod 2) X.boundarySubmoduleInCycles =
+        Module.finrank (ZMod 2) X.boundaries := by
+    simpa [boundarySubmoduleInCycles] using
+      (Submodule.comapSubtypeEquivOfLe X.boundaries_le_cycles).finrank_eq
+  rw [hcomap] at hquot
+  exact Nat.eq_sub_of_add_eq hquot
+
+/-- The `𝔽₂`-transpose of `∂₁`, written as a finite sum.
+
+`(cutMap s) e = ∑ v, s v · ∂₁(δ_e)(v)` where `δ_e := Pi.single e 1`.
+
+This is what one would get from `LinearMap.dualMap`, but inlined as a finite
+sum to keep instance synthesis cheap (no `Module.Dual` lookups). -/
+noncomputable def cutMap : (X.C0 → ZMod 2) →ₗ[ZMod 2] (X.C1 → ZMod 2) where
+  toFun s := fun e => ∑ v : X.C0, s v * X.boundary1 (Pi.single e 1) v
+  map_add' s t := by
+    ext e
+    simp [add_mul, Finset.sum_add_distrib]
+  map_smul' a s := by
+    ext e
+    simp [Finset.mul_sum, mul_assoc]
+
+@[simp] theorem cutMap_apply (s : X.C0 → ZMod 2) (e : X.C1) :
+    X.cutMap s e = ∑ v : X.C0, s v * X.boundary1 (Pi.single e 1) v := rfl
+
+/-- Symmetric pairing form of the transpose property.
+
+`⟨∂₁ c, s⟩ = ⟨c, cutMap s⟩` over `𝔽₂` with the standard pairing
+`⟨a, b⟩ = ∑ x, a x · b x`. -/
+theorem boundary1_cutMap_transpose (c : X.C1 → ZMod 2) (s : X.C0 → ZMod 2) :
+    ∑ v : X.C0, X.boundary1 c v * s v =
+      ∑ e : X.C1, c e * X.cutMap s e := by
+  -- Expand `c = ∑ e, c e • Pi.single e 1` and push the sum through `boundary1`.
+  have hc : c = ∑ e : X.C1, c e • (Pi.single e (1 : ZMod 2)) := by
+    ext e
+    simp [Finset.sum_apply, Pi.single_apply]
+  conv_lhs => rw [hc]
+  simp only [map_sum, map_smul, Finset.sum_apply, Pi.smul_apply, smul_eq_mul,
+    Finset.sum_mul]
+  rw [Finset.sum_comm]
+  refine Finset.sum_congr rfl fun e _ => ?_
+  rw [cutMap_apply, Finset.mul_sum]
+  refine Finset.sum_congr rfl fun v _ => ?_
+  ring
+
+end HomologicalCode
+
+end Homological
+end Stabilizer
+end Quantum

--- a/QEC/Stabilizer/Homological/Distance.lean
+++ b/QEC/Stabilizer/Homological/Distance.lean
@@ -1,0 +1,302 @@
+import QEC.Stabilizer.Homological.LogicalCorrespondence
+import QEC.Stabilizer.Core.CodeDistance
+
+/-!
+# §D — CSS distance bridge
+
+For a homological CSS code, every Pauli element decomposes into an X-support
+chain (qubits where it acts non-trivially with an X-component) and a Z-support
+chain.  The key bridging fact is that for a non-trivial logical operator,
+the X-chain and Z-chain *cannot* both be boundaries — otherwise we could build
+a stabilizer with the same operators, contradicting non-triviality.
+
+This file provides the abstract building blocks for distance arguments.
+The full `code_distance_eq_min_dX_dZ` packaging is left to each instance
+since `HasCodeDistance` requires a `StabilizerCode` (instance-specific).
+-/
+
+namespace Quantum
+namespace Stabilizer
+namespace Homological
+
+open scoped BigOperators
+
+namespace HomologicalCode
+
+variable (X : HomologicalCode)
+
+/-- Support of a 1-chain. -/
+noncomputable def chainSupport (c : X.C1 → ZMod 2) : Finset X.C1 :=
+  Finset.univ.filter (fun e => c e ≠ 0)
+
+/-- Weight of a 1-chain (size of support). -/
+noncomputable def chainWeight (c : X.C1 → ZMod 2) : ℕ := (X.chainSupport c).card
+
+/-- X-support chain of a general Pauli (1 where the operator is X or Y). -/
+noncomputable def xChainOf (g : NQubitPauliGroupElement X.numQubits) :
+    X.C1 → ZMod 2 :=
+  fun e =>
+    if g.operators (X.edgeEquiv e) = PauliOperator.X ∨
+       g.operators (X.edgeEquiv e) = PauliOperator.Y
+    then 1 else 0
+
+/-- Z-support chain of a general Pauli (1 where the operator is Z or Y). -/
+noncomputable def zChainOf (g : NQubitPauliGroupElement X.numQubits) :
+    X.C1 → ZMod 2 :=
+  fun e =>
+    if g.operators (X.edgeEquiv e) = PauliOperator.Z ∨
+       g.operators (X.edgeEquiv e) = PauliOperator.Y
+    then 1 else 0
+
+variable {X}
+
+/-- Helper: `ZMod 2` dichotomy (local copy). -/
+private lemma zmod2_dichotomy_local (a : ZMod 2) : a = 0 ∨ a = 1 := by
+  have hvalle : a.val ≤ 1 := Nat.le_of_lt_succ a.val_lt
+  rcases Nat.le_one_iff_eq_zero_or_eq_one.mp hvalle with h0 | h1
+  · left
+    calc a = ((a.val : ZMod 2)) := (ZMod.natCast_zmod_val a).symm
+      _ = 0 := by simp [h0]
+  · right
+    calc a = ((a.val : ZMod 2)) := (ZMod.natCast_zmod_val a).symm
+      _ = 1 := by simp [h1]
+
+/-- The X-support chain extracted from `chainXOperator c` recovers `c`. -/
+lemma xChainOf_chainXOperator (c : X.C1 → ZMod 2) :
+    X.xChainOf (X.chainXOperator c) = c := by
+  ext e
+  simp only [xChainOf]
+  by_cases h : c e = 1
+  · have hex : ∃ e' : X.C1, X.edgeEquiv e' = X.edgeEquiv e ∧ c e' = 1 :=
+      ⟨e, rfl, h⟩
+    have h_op : (X.chainXOperator c).operators (X.edgeEquiv e) = PauliOperator.X := by
+      rw [chainXOperator_op_at]
+      exact if_pos hex
+    rw [h_op]; simp [h]
+  · have hnot : ¬ ∃ e' : X.C1, X.edgeEquiv e' = X.edgeEquiv e ∧ c e' = 1 := by
+      rintro ⟨e', heq, he1⟩
+      have he' : e' = e := X.edgeEquiv.injective heq
+      exact h (he' ▸ he1)
+    have h_op : (X.chainXOperator c).operators (X.edgeEquiv e) = PauliOperator.I := by
+      rw [chainXOperator_op_at]
+      exact if_neg hnot
+    have h0 : c e = 0 := (zmod2_dichotomy_local (c e)).resolve_right h
+    rw [h_op]; simp [h0]
+
+/-! ## Weight bounds -/
+
+/-- Weight of `g` is at least the edge-weight of its X-chain. -/
+lemma weight_ge_chainWeight_xChainOf (g : NQubitPauliGroupElement X.numQubits) :
+    NQubitPauliGroupElement.weight g ≥ X.chainWeight (X.xChainOf g) := by
+  classical
+  unfold NQubitPauliGroupElement.weight chainWeight chainSupport
+  have himg :
+      ((Finset.univ.filter (fun e : X.C1 => X.xChainOf g e ≠ 0)).image X.edgeEquiv) ⊆
+        NQubitPauliOperator.support g.operators := by
+    intro q hq
+    rcases Finset.mem_image.mp hq with ⟨e, he, rfl⟩
+    have hne : X.xChainOf g e ≠ 0 := (Finset.mem_filter.mp he).2
+    have h_op : g.operators (X.edgeEquiv e) = PauliOperator.X ∨
+        g.operators (X.edgeEquiv e) = PauliOperator.Y := by
+      by_contra hcontr
+      push_neg at hcontr
+      simp [xChainOf, hcontr.1, hcontr.2] at hne
+    rcases h_op with hX | hY
+    · simp [NQubitPauliOperator.support, hX]
+    · simp [NQubitPauliOperator.support, hY]
+  calc (NQubitPauliOperator.support g.operators).card
+      ≥ ((Finset.univ.filter (fun e : X.C1 => X.xChainOf g e ≠ 0)).image X.edgeEquiv).card :=
+        Finset.card_le_card himg
+    _ = (Finset.univ.filter (fun e : X.C1 => X.xChainOf g e ≠ 0)).card :=
+        Finset.card_image_of_injective _ X.edgeEquiv.injective
+
+/-- Weight of `g` is at least the edge-weight of its Z-chain. -/
+lemma weight_ge_chainWeight_zChainOf (g : NQubitPauliGroupElement X.numQubits) :
+    NQubitPauliGroupElement.weight g ≥ X.chainWeight (X.zChainOf g) := by
+  classical
+  unfold NQubitPauliGroupElement.weight chainWeight chainSupport
+  have himg :
+      ((Finset.univ.filter (fun e : X.C1 => X.zChainOf g e ≠ 0)).image X.edgeEquiv) ⊆
+        NQubitPauliOperator.support g.operators := by
+    intro q hq
+    rcases Finset.mem_image.mp hq with ⟨e, he, rfl⟩
+    have hne : X.zChainOf g e ≠ 0 := (Finset.mem_filter.mp he).2
+    have h_op : g.operators (X.edgeEquiv e) = PauliOperator.Z ∨
+        g.operators (X.edgeEquiv e) = PauliOperator.Y := by
+      by_contra hcontr
+      push_neg at hcontr
+      simp [zChainOf, hcontr.1, hcontr.2] at hne
+    rcases h_op with hZ | hY
+    · simp [NQubitPauliOperator.support, hZ]
+    · simp [NQubitPauliOperator.support, hY]
+  calc (NQubitPauliOperator.support g.operators).card
+      ≥ ((Finset.univ.filter (fun e : X.C1 => X.zChainOf g e ≠ 0)).image X.edgeEquiv).card :=
+        Finset.card_le_card himg
+    _ = (Finset.univ.filter (fun e : X.C1 => X.zChainOf g e ≠ 0)).card :=
+        Finset.card_image_of_injective _ X.edgeEquiv.injective
+
+/-! ## Operators of the X-only / Z-only encodings of a general Pauli -/
+
+/-- The X-only encoding `chainXOperator (xChainOf g)` has X at qubits where g
+acts as X or Y, and I elsewhere. -/
+lemma chainXOperator_xChainOf_op_at
+    (g : NQubitPauliGroupElement X.numQubits) (i : Fin X.numQubits) :
+    (X.chainXOperator (X.xChainOf g)).operators i =
+      (if g.operators i = PauliOperator.X ∨ g.operators i = PauliOperator.Y
+       then PauliOperator.X else PauliOperator.I) := by
+  classical
+  rw [chainXOperator_op_at]
+  by_cases hxy : g.operators i = PauliOperator.X ∨ g.operators i = PauliOperator.Y
+  · -- some edge with i = eqv e and xChainOf = 1
+    set e := X.edgeEquiv.symm i with he_def
+    have hei : X.edgeEquiv e = i := by simp [he_def]
+    have hx1 : X.xChainOf g e = 1 := by
+      simp only [xChainOf]
+      rw [hei]
+      simp [hxy]
+    have hex : ∃ e' : X.C1, X.edgeEquiv e' = i ∧ X.xChainOf g e' = 1 := ⟨e, hei, hx1⟩
+    rw [if_pos hex, if_pos hxy]
+  · push_neg at hxy
+    have hex : ¬ ∃ e' : X.C1, X.edgeEquiv e' = i ∧ X.xChainOf g e' = 1 := by
+      rintro ⟨e', hei, he1⟩
+      have h0 : X.xChainOf g e' = 0 := by
+        simp only [xChainOf]
+        rw [hei]
+        simp [hxy.1, hxy.2]
+      rw [h0] at he1
+      exact absurd he1 (by decide)
+    rw [if_neg hex]
+    rw [if_neg]
+    push_neg
+    exact hxy
+
+/-- Z-only mirror. -/
+lemma chainZOperator_zChainOf_op_at
+    (g : NQubitPauliGroupElement X.numQubits) (i : Fin X.numQubits) :
+    (X.chainZOperator (X.zChainOf g)).operators i =
+      (if g.operators i = PauliOperator.Z ∨ g.operators i = PauliOperator.Y
+       then PauliOperator.Z else PauliOperator.I) := by
+  classical
+  rw [chainZOperator_op_at]
+  by_cases hzy : g.operators i = PauliOperator.Z ∨ g.operators i = PauliOperator.Y
+  · set e := X.edgeEquiv.symm i with he_def
+    have hei : X.edgeEquiv e = i := by simp [he_def]
+    have hz1 : X.zChainOf g e = 1 := by
+      simp only [zChainOf]
+      rw [hei]
+      simp [hzy]
+    have hex : ∃ e' : X.C1, X.edgeEquiv e' = i ∧ X.zChainOf g e' = 1 := ⟨e, hei, hz1⟩
+    rw [if_pos hex, if_pos hzy]
+  · push_neg at hzy
+    have hex : ¬ ∃ e' : X.C1, X.edgeEquiv e' = i ∧ X.zChainOf g e' = 1 := by
+      rintro ⟨e', hei, he1⟩
+      have h0 : X.zChainOf g e' = 0 := by
+        simp only [zChainOf]
+        rw [hei]
+        simp [hzy.1, hzy.2]
+      rw [h0] at he1
+      exact absurd he1 (by decide)
+    rw [if_neg hex]
+    rw [if_neg]
+    push_neg
+    exact hzy
+
+/-! ## Z-side closure helper (mirror of §C's X-side)-/
+
+/-- Every 0-chain decomposes as a sum over its support. -/
+private lemma c0_eq_sum_singleVtx_filter (s : X.C0 → ZMod 2) :
+    s = ∑ v ∈ (Finset.univ.filter (fun v : X.C0 => s v = 1)),
+      X.singleVtx v := by
+  ext q
+  rw [Finset.sum_apply]
+  by_cases hq : s q = 1
+  · rw [Finset.sum_eq_single q]
+    · simp [singleVtx, hq]
+    · intros r _ hne
+      simp [singleVtx, Pi.single_apply, hne.symm]
+    · intro hcontra
+      exact absurd (Finset.mem_filter.mpr ⟨Finset.mem_univ q, hq⟩) hcontra
+  · have hq0 : s q = 0 := (zmod2_dichotomy_local (s q)).resolve_right hq
+    rw [hq0]
+    refine (Finset.sum_eq_zero ?_).symm
+    intros r hr
+    rw [Finset.mem_filter] at hr
+    have hne : r ≠ q := fun heq => hq (heq ▸ hr.2)
+    simp [singleVtx, Pi.single_apply, hne]
+
+/-- For any 0-chain `s`, `chainZOperator (cutMap s)` is in the Z-closure. -/
+lemma chainZOperator_cutMap_mem_ZClosure (s : X.C0 → ZMod 2) :
+    X.chainZOperator (X.cutMap s) ∈ Subgroup.closure X.ZGenerators := by
+  classical
+  rw [c0_eq_sum_singleVtx_filter s]
+  rw [map_sum]
+  induction (Finset.univ.filter fun v : X.C0 => s v = 1) using Finset.induction with
+  | empty => simpa using OneMemClass.one_mem _
+  | insert v sset hv ih =>
+      rw [Finset.sum_insert hv, chainZOperator_add]
+      exact Subgroup.mul_mem _
+        (Subgroup.subset_closure (Set.mem_range_self _)) ih
+
+/-- `chainZOperator c ∈ closure(ZGenerators)` whenever `c ∈ dualBoundaries`. -/
+lemma chainZOperator_mem_ZClosure_of_mem_dualBoundaries
+    (c : X.C1 → ZMod 2) (hc : c ∈ X.dualBoundaries) :
+    X.chainZOperator c ∈ Subgroup.closure X.ZGenerators := by
+  rcases hc with ⟨s, rfl⟩
+  exact chainZOperator_cutMap_mem_ZClosure s
+
+/-! ## not_both_boundary_of_nontrivial -/
+
+/-- Helper: combining the X-only and Z-only encodings of `g` (their operator part)
+recovers `g.operators` qubit-by-qubit. -/
+private lemma chainOps_xz_combine_eq
+    (g : NQubitPauliGroupElement X.numQubits) (i : Fin X.numQubits) :
+    (((X.chainXOperator (X.xChainOf g)).operators i).mulOp
+        ((X.chainZOperator (X.zChainOf g)).operators i)).operator =
+      g.operators i := by
+  rw [chainXOperator_xChainOf_op_at, chainZOperator_zChainOf_op_at]
+  cases hgi : g.operators i <;> simp [PauliOperator.mulOp]
+
+/-- For a nontrivial logical operator, the X-chain and Z-chain cannot both be
+in the respective boundaries (CSS bridge). -/
+theorem not_both_boundary_of_nontrivial
+    (g : NQubitPauliGroupElement X.numQubits)
+    (hg : Quantum.StabilizerGroup.IsNontrivialLogicalOperator g
+            X.homologicalStabilizerGroup) :
+    ¬ (X.xChainOf g ∈ X.boundaries ∧ X.zChainOf g ∈ X.dualBoundaries) := by
+  classical
+  rintro ⟨hxBnd, hzBnd⟩
+  set g_X := X.chainXOperator (X.xChainOf g) with hg_X
+  set g_Z := X.chainZOperator (X.zChainOf g) with hg_Z
+  -- g_X ∈ stabilizer (via X-closure ⊆ Z∪X-closure)
+  have hgX_mem : g_X ∈ X.homologicalStabilizerGroup.toSubgroup := by
+    have hXcl : g_X ∈ Subgroup.closure X.XGenerators :=
+      (chainXOperator_mem_XClosure_iff_mem_boundaries (X.xChainOf g)).mpr hxBnd
+    have : Subgroup.closure X.XGenerators ≤
+        Subgroup.closure (X.ZGenerators ∪ X.XGenerators) :=
+      Subgroup.closure_mono (Set.subset_union_right)
+    exact this hXcl
+  -- g_Z ∈ stabilizer (similarly)
+  have hgZ_mem : g_Z ∈ X.homologicalStabilizerGroup.toSubgroup := by
+    have hZcl : g_Z ∈ Subgroup.closure X.ZGenerators :=
+      chainZOperator_mem_ZClosure_of_mem_dualBoundaries (X.zChainOf g) hzBnd
+    have : Subgroup.closure X.ZGenerators ≤
+        Subgroup.closure (X.ZGenerators ∪ X.XGenerators) :=
+      Subgroup.closure_mono (Set.subset_union_left)
+    exact this hZcl
+  have hprod_mem : g_X * g_Z ∈ X.homologicalStabilizerGroup.toSubgroup :=
+    X.homologicalStabilizerGroup.toSubgroup.mul_mem hgX_mem hgZ_mem
+  -- Operators of g_X * g_Z match g.operators qubitwise.
+  have hops_eq : (g_X * g_Z).operators = g.operators := by
+    ext i
+    show ((g_X.operators i).mulOp (g_Z.operators i)).operator = g.operators i
+    exact chainOps_xz_combine_eq g i
+  -- Use the third condition of IsNontrivialLogicalOperator
+  rw [Quantum.StabilizerGroup.IsNontrivialLogicalOperator_iff] at hg
+  obtain ⟨_, _, h_no_phase_dup⟩ := hg
+  exact h_no_phase_dup (g_X * g_Z) hprod_mem hops_eq
+
+end HomologicalCode
+
+end Homological
+end Stabilizer
+end Quantum

--- a/QEC/Stabilizer/Homological/Generators.lean
+++ b/QEC/Stabilizer/Homological/Generators.lean
@@ -1,0 +1,218 @@
+import QEC.Stabilizer.Homological.CSS
+import QEC.Stabilizer.Core.CSSCommutationLemmas
+import QEC.Stabilizer.PauliGroup.SupportLemmas
+
+/-!
+# §B.2 — Stabilizer generators of a homological CSS code
+
+For a `HomologicalCode X`, the X-stabilizer generators are face stabilizers
+`chainXOperator (∂₂ (singleFace f))`, and the Z-stabilizer generators are
+vertex stabilizers `chainZOperator (cutMap (singleVtx v))`.
+
+We prove pairwise commutation:
+
+* X-X commute (both X-type).
+* Z-Z commute (both Z-type).
+* X-Z commute iff their `Σ e, c e * c' e` vanishes (the bilinear pairing on
+  chains).  For face/vertex generators this is `0` by the chain-complex law
+  `∂₁ ∘ ∂₂ = 0` together with `boundary1_cutMap_transpose` from §A.
+-/
+
+namespace Quantum
+namespace Stabilizer
+namespace Homological
+
+open scoped BigOperators
+
+namespace HomologicalCode
+
+variable (X : HomologicalCode)
+
+/-- Indicator chain at a single 2-cell. -/
+noncomputable def singleFace (f : X.C2) : X.C2 → ZMod 2 := Pi.single f 1
+
+/-- Indicator chain at a single 0-cell. -/
+noncomputable def singleVtx (v : X.C0) : X.C0 → ZMod 2 := Pi.single v 1
+
+/-- Indicator chain at a single 1-cell. -/
+noncomputable def singleEdge (e : X.C1) : X.C1 → ZMod 2 := Pi.single e 1
+
+/-- The X face stabilizer at face `f`. -/
+noncomputable def faceStabOf (f : X.C2) :
+    NQubitPauliGroupElement X.numQubits :=
+  X.chainXOperator (X.boundary2 (X.singleFace f))
+
+/-- The Z vertex stabilizer at vertex `v`. -/
+noncomputable def vertexStabOf (v : X.C0) :
+    NQubitPauliGroupElement X.numQubits :=
+  X.chainZOperator (X.cutMap (X.singleVtx v))
+
+/-- The set of X stabilizer generators. -/
+noncomputable def XGenerators : Set (NQubitPauliGroupElement X.numQubits) :=
+  Set.range X.faceStabOf
+
+/-- The set of Z stabilizer generators. -/
+noncomputable def ZGenerators : Set (NQubitPauliGroupElement X.numQubits) :=
+  Set.range X.vertexStabOf
+
+variable {X}
+
+/-- Every X generator is X-type. -/
+lemma faceStabOf_isXType (f : X.C2) :
+    NQubitPauliGroupElement.IsXTypeElement (X.faceStabOf f) :=
+  chainXOperator_isXType _
+
+/-- Every Z generator is Z-type. -/
+lemma vertexStabOf_isZType (v : X.C0) :
+    NQubitPauliGroupElement.IsZTypeElement (X.vertexStabOf v) :=
+  chainZOperator_isZType _
+
+lemma XGenerators_isXType :
+    ∀ g ∈ X.XGenerators, NQubitPauliGroupElement.IsXTypeElement g := by
+  rintro _ ⟨f, rfl⟩; exact faceStabOf_isXType f
+
+lemma ZGenerators_isZType :
+    ∀ g ∈ X.ZGenerators, NQubitPauliGroupElement.IsZTypeElement g := by
+  rintro _ ⟨v, rfl⟩; exact vertexStabOf_isZType v
+
+/-! ## Inner product of two 1-chains and the chain-complex law -/
+
+/-- The bilinear pairing on 1-chains over `𝔽₂`. -/
+noncomputable def chainInnerProduct (c c' : X.C1 → ZMod 2) : ZMod 2 :=
+  ∑ e : X.C1, c e * c' e
+
+/-- The pairing of `∂₂ f` against `cutMap s` is zero (the chain-complex law,
+expressed bilinearly via the §A transpose theorem). -/
+theorem chainInnerProduct_boundary2_cutMap_eq_zero
+    (f : X.C2 → ZMod 2) (s : X.C0 → ZMod 2) :
+    chainInnerProduct (X.boundary2 f) (X.cutMap s) = 0 := by
+  unfold chainInnerProduct
+  rw [← X.boundary1_cutMap_transpose]
+  rw [X.boundary_comp_apply f]
+  simp
+
+/-! ## Filter cardinalities and the X-Z commutation criterion -/
+
+/-- Helper: a `ZMod 2` element is `0` or `1`. -/
+private lemma zmod2_dichotomy (a : ZMod 2) : a = 0 ∨ a = 1 := by
+  have hvalle : a.val ≤ 1 := Nat.le_of_lt_succ a.val_lt
+  rcases Nat.le_one_iff_eq_zero_or_eq_one.mp hvalle with h0 | h1
+  · left
+    calc a = ((a.val : ZMod 2)) := (ZMod.natCast_zmod_val a).symm
+      _ = 0 := by simp [h0]
+  · right
+    calc a = ((a.val : ZMod 2)) := (ZMod.natCast_zmod_val a).symm
+      _ = 1 := by simp [h1]
+
+/-- Inner product equals filter cardinality in `ZMod 2`. -/
+private lemma chainInnerProduct_eq_card_filter (c c' : X.C1 → ZMod 2) :
+    chainInnerProduct c c' =
+      ((Finset.univ.filter (fun e : X.C1 => c e = 1 ∧ c' e = 1)).card : ZMod 2) := by
+  classical
+  unfold chainInnerProduct
+  rw [Finset.card_filter, Nat.cast_sum]
+  apply Finset.sum_congr rfl
+  intro e _
+  rcases zmod2_dichotomy (c e) with hc | hc <;>
+    rcases zmod2_dichotomy (c' e) with hc' | hc' <;>
+    simp [hc, hc']
+
+/-- A Nat is even iff its `ZMod 2` cast is 0. -/
+private lemma nat_cast_zmod2_eq_zero_iff_even (n : ℕ) :
+    ((n : ZMod 2) = 0) ↔ Even n :=
+  ZMod.natCast_eq_zero_iff_even
+
+open Classical in
+/-- The anticommutation filter on qubits has the same cardinality as the
+inner-product filter on edges (via the `edgeEquiv` bijection). -/
+private lemma anticomm_filter_card_eq_inner_filter_card
+    (c c' : X.C1 → ZMod 2) :
+    (Finset.univ.filter (fun q : Fin X.numQubits =>
+      NQubitPauliGroupElement.anticommutesAt
+        (X.chainXOperator c).operators (X.chainZOperator c').operators q)).card
+    = (Finset.univ.filter (fun e : X.C1 => c e = 1 ∧ c' e = 1)).card := by
+  classical
+  rw [Finset.card_filter, Finset.card_filter]
+  -- Reindex: ∑ q : Fin n, g q = ∑ e : C1, g (eqv e), via X.edgeEquiv : C1 ≃ Fin n.
+  have hreindex :
+      (∑ q : Fin X.numQubits,
+        if NQubitPauliGroupElement.anticommutesAt
+            (X.chainXOperator c).operators (X.chainZOperator c').operators q
+          then (1 : ℕ) else 0)
+      =
+      (∑ e : X.C1,
+        if NQubitPauliGroupElement.anticommutesAt
+            (X.chainXOperator c).operators (X.chainZOperator c').operators (X.edgeEquiv e)
+          then (1 : ℕ) else 0) :=
+    (Equiv.sum_comp X.edgeEquiv (fun q =>
+      if NQubitPauliGroupElement.anticommutesAt
+          (X.chainXOperator c).operators (X.chainZOperator c').operators q
+        then (1 : ℕ) else 0)).symm
+  rw [hreindex]
+  apply Finset.sum_congr rfl
+  intro e _
+  -- Pointwise: anticommutesAt at (eqv e) ↔ c e = 1 ∧ c' e = 1
+  have hX :=
+    (chainXOperator_isXType (X := X) c).2
+  have hZ :=
+    (chainZOperator_isZType (X := X) c').2
+  have hbiconditional :
+      NQubitPauliGroupElement.anticommutesAt
+          (X.chainXOperator c).operators (X.chainZOperator c').operators (X.edgeEquiv e)
+        ↔ c e = 1 ∧ c' e = 1 := by
+    rw [NQubitPauliGroupElement.anticommutesAt_iff_mem_support_both_of_XZType hX hZ]
+    constructor
+    · rintro ⟨hxs, hzs⟩
+      exact ⟨(mem_support_chainXOperator_iff c e).mp hxs,
+             (mem_support_chainZOperator_iff c' e).mp hzs⟩
+    · rintro ⟨hc, hc'⟩
+      exact ⟨(mem_support_chainXOperator_iff c e).mpr hc,
+             (mem_support_chainZOperator_iff c' e).mpr hc'⟩
+  by_cases h : NQubitPauliGroupElement.anticommutesAt
+      (X.chainXOperator c).operators (X.chainZOperator c').operators (X.edgeEquiv e)
+  · rw [if_pos h, if_pos (hbiconditional.mp h)]
+  · rw [if_neg h, if_neg (h ∘ hbiconditional.mpr)]
+
+open Classical in
+/-- Commutation criterion: `chainXOperator c` commutes with `chainZOperator c'`
+iff their inner product over `𝔽₂` vanishes. -/
+theorem chainXOperator_commutes_chainZOperator_iff (c c' : X.C1 → ZMod 2) :
+    X.chainXOperator c * X.chainZOperator c' =
+      X.chainZOperator c' * X.chainXOperator c
+    ↔ chainInnerProduct c c' = 0 := by
+  classical
+  rw [NQubitPauliGroupElement.commutes_iff_even_anticommutes,
+      anticomm_filter_card_eq_inner_filter_card c c',
+      chainInnerProduct_eq_card_filter c c']
+  exact (nat_cast_zmod2_eq_zero_iff_even _).symm
+
+/-- The face X-stabilizer commutes with the vertex Z-stabilizer (chain-complex law). -/
+theorem faceStabOf_commutes_vertexStabOf (f : X.C2) (v : X.C0) :
+    X.faceStabOf f * X.vertexStabOf v = X.vertexStabOf v * X.faceStabOf f := by
+  unfold faceStabOf vertexStabOf
+  rw [chainXOperator_commutes_chainZOperator_iff]
+  exact chainInnerProduct_boundary2_cutMap_eq_zero (X.singleFace f) (X.singleVtx v)
+
+/-- Two face X-stabilizers commute (both X-type). -/
+theorem faceStabOf_commutes_faceStabOf (f f' : X.C2) :
+    X.faceStabOf f * X.faceStabOf f' = X.faceStabOf f' * X.faceStabOf f :=
+  Quantum.StabilizerGroup.CSSCommutationLemmas.XType_commutes
+    (faceStabOf_isXType f) (faceStabOf_isXType f')
+
+/-- Two vertex Z-stabilizers commute (both Z-type). -/
+theorem vertexStabOf_commutes_vertexStabOf (v v' : X.C0) :
+    X.vertexStabOf v * X.vertexStabOf v' = X.vertexStabOf v' * X.vertexStabOf v :=
+  Quantum.StabilizerGroup.CSSCommutationLemmas.ZType_commutes
+    (vertexStabOf_isZType v) (vertexStabOf_isZType v')
+
+/-- Z generators commute with X generators (CSS cross-commutation). -/
+theorem ZGenerators_commute_XGenerators :
+    ∀ z ∈ X.ZGenerators, ∀ x ∈ X.XGenerators, z * x = x * z := by
+  rintro _ ⟨v, rfl⟩ _ ⟨f, rfl⟩
+  exact (faceStabOf_commutes_vertexStabOf f v).symm
+
+end HomologicalCode
+
+end Homological
+end Stabilizer
+end Quantum

--- a/QEC/Stabilizer/Homological/LogicalCorrespondence.lean
+++ b/QEC/Stabilizer/Homological/LogicalCorrespondence.lean
@@ -1,0 +1,384 @@
+import QEC.Stabilizer.Homological.StabGroup
+import QEC.Stabilizer.Core.LogicalOperators
+
+/-!
+# §C — Logical correspondence iffs
+
+For a homological CSS code, an X-type chain operator `chainXOperator c` is a
+non-trivial logical operator iff its underlying chain `c` is a cycle that is
+not a boundary.  Lifted from `ToricLogicalCorrespondenceX/Z.lean`.
+
+This file currently covers the X-side iffs.  The Z-side mirror via the dual
+boundary `dualBoundary = transpose ∂₂` is set up but the four mirror theorems
+are deferred (the §E toric refactor uses the X-side directly via §D).
+-/
+
+namespace Quantum
+namespace Stabilizer
+namespace Homological
+
+open scoped BigOperators
+
+namespace HomologicalCode
+
+variable (X : HomologicalCode)
+
+/-! ## Dual boundary map (transpose of `∂₂`) -/
+
+/-- The `𝔽₂`-transpose of `∂₂`, written as a finite sum.
+`(dualBoundary c) f = ∑ e, c e · ∂₂(δ_f)(e)`. -/
+noncomputable def dualBoundary :
+    (X.C1 → ZMod 2) →ₗ[ZMod 2] (X.C2 → ZMod 2) where
+  toFun c := fun f => ∑ e : X.C1, c e * X.boundary2 (Pi.single f 1) e
+  map_add' c d := by
+    ext f
+    simp [add_mul, Finset.sum_add_distrib]
+  map_smul' a c := by
+    ext f
+    simp [Finset.mul_sum, mul_assoc]
+
+@[simp] theorem dualBoundary_apply (c : X.C1 → ZMod 2) (f : X.C2) :
+    X.dualBoundary c f = ∑ e : X.C1, c e * X.boundary2 (Pi.single f 1) e := rfl
+
+/-- Transpose pairing for `∂₂`/`dualBoundary`. -/
+theorem boundary2_dualBoundary_transpose
+    (f : X.C2 → ZMod 2) (c : X.C1 → ZMod 2) :
+    ∑ e : X.C1, X.boundary2 f e * c e =
+      ∑ p : X.C2, f p * X.dualBoundary c p := by
+  have hf : f = ∑ p : X.C2, f p • (Pi.single p (1 : ZMod 2)) := by
+    ext p; simp [Finset.sum_apply, Pi.single_apply]
+  conv_lhs => rw [hf]
+  simp only [map_sum, map_smul, Finset.sum_apply, Pi.smul_apply, smul_eq_mul,
+    Finset.sum_mul]
+  rw [Finset.sum_comm]
+  refine Finset.sum_congr rfl fun p _ => ?_
+  rw [dualBoundary_apply, Finset.mul_sum]
+  refine Finset.sum_congr rfl fun e _ => ?_
+  ring
+
+/-- Dual cycles: kernel of `dualBoundary`. -/
+noncomputable def dualCycles : Submodule (ZMod 2) (X.C1 → ZMod 2) :=
+  LinearMap.ker X.dualBoundary
+
+/-- Dual boundaries: range of `cutMap`. -/
+noncomputable def dualBoundaries : Submodule (ZMod 2) (X.C1 → ZMod 2) :=
+  LinearMap.range X.cutMap
+
+variable {X}
+
+/-- Helper: `ZMod 2` dichotomy. -/
+private lemma zmod2_dichotomy_local (a : ZMod 2) : a = 0 ∨ a = 1 := by
+  have hvalle : a.val ≤ 1 := Nat.le_of_lt_succ a.val_lt
+  rcases Nat.le_one_iff_eq_zero_or_eq_one.mp hvalle with h0 | h1
+  · left
+    calc a = ((a.val : ZMod 2)) := (ZMod.natCast_zmod_val a).symm
+      _ = 0 := by simp [h0]
+  · right
+    calc a = ((a.val : ZMod 2)) := (ZMod.natCast_zmod_val a).symm
+      _ = 1 := by simp [h1]
+
+/-! ## Inner-product specializations -/
+
+/-- `⟨c, cutMap (singleVtx v)⟩ = boundary1 c v`. -/
+theorem chainInnerProduct_cutMap_singleVtx_eq_boundary1
+    (c : X.C1 → ZMod 2) (v : X.C0) :
+    chainInnerProduct c (X.cutMap (X.singleVtx v)) = X.boundary1 c v := by
+  unfold chainInnerProduct
+  rw [← X.boundary1_cutMap_transpose c (X.singleVtx v)]
+  unfold singleVtx
+  rw [Finset.sum_eq_single v]
+  · simp
+  · intros v' _ hne
+    rw [Pi.single_eq_of_ne hne]; ring
+  · intro hcontra; exact absurd (Finset.mem_univ v) hcontra
+
+/-- `⟨boundary2 (singleFace f), c⟩ = dualBoundary c f`. -/
+theorem chainInnerProduct_boundary2_singleFace_eq_dualBoundary
+    (c : X.C1 → ZMod 2) (f : X.C2) :
+    chainInnerProduct (X.boundary2 (X.singleFace f)) c = X.dualBoundary c f := by
+  unfold chainInnerProduct
+  rw [boundary2_dualBoundary_transpose]
+  unfold singleFace
+  rw [Finset.sum_eq_single f]
+  · simp
+  · intros f' _ hne
+    rw [Pi.single_eq_of_ne hne]; ring
+  · intro hcontra; exact absurd (Finset.mem_univ f) hcontra
+
+/-! ## X-side commutation criteria -/
+
+/-- `chainXOperator c` commutes with the vertex stab at `v` iff `boundary1 c v = 0`. -/
+theorem chainXOperator_commutes_vertexStabOf_iff
+    (c : X.C1 → ZMod 2) (v : X.C0) :
+    X.chainXOperator c * X.vertexStabOf v = X.vertexStabOf v * X.chainXOperator c
+    ↔ X.boundary1 c v = 0 := by
+  unfold vertexStabOf
+  rw [chainXOperator_commutes_chainZOperator_iff,
+      ← chainInnerProduct_cutMap_singleVtx_eq_boundary1]
+
+/-- `chainXOperator c` commutes with every Z-generator iff `c ∈ cycles`. -/
+theorem chainXOperator_commutes_ZGenerators_iff_mem_cycles (c : X.C1 → ZMod 2) :
+    (∀ z ∈ X.ZGenerators, z * X.chainXOperator c = X.chainXOperator c * z)
+    ↔ c ∈ X.cycles := by
+  constructor
+  · intro h
+    rw [show X.cycles = LinearMap.ker X.boundary1 from rfl, LinearMap.mem_ker]
+    ext v
+    have h_v := h _ ⟨v, rfl⟩
+    have := (chainXOperator_commutes_vertexStabOf_iff c v).mp h_v.symm
+    simpa using this
+  · intro hc z hz
+    rcases hz with ⟨v, rfl⟩
+    have hbd : X.boundary1 c v = 0 := by
+      have h_ker : c ∈ LinearMap.ker X.boundary1 := hc
+      rw [LinearMap.mem_ker] at h_ker
+      exact congr_fun h_ker v
+    exact ((chainXOperator_commutes_vertexStabOf_iff c v).mpr hbd).symm
+
+/-! ## Closure ↔ boundary -/
+
+/-- `chainXOperator (∂₂ (singleFace f)) = faceStabOf f`. -/
+@[simp] lemma chainXOperator_boundary2_singleFace (f : X.C2) :
+    X.chainXOperator (X.boundary2 (X.singleFace f)) = X.faceStabOf f := rfl
+
+/-- `chainXOperator c` is its own inverse (X*X = I). -/
+lemma chainXOperator_inv (c : X.C1 → ZMod 2) :
+    (X.chainXOperator c)⁻¹ = X.chainXOperator c := by
+  apply NQubitPauliGroupElement.ext
+  · -- phase: -0 = 0 in Fin 4
+    show (-(0 : Fin 4)) = 0
+    decide
+  · rfl
+
+/-- Every 2-chain is the sum of its single-face indicators over its support. -/
+private lemma c2_eq_sum_singleFace_filter (f : X.C2 → ZMod 2) :
+    f = ∑ p ∈ (Finset.univ.filter (fun p : X.C2 => f p = 1)),
+      X.singleFace p := by
+  ext q
+  rw [Finset.sum_apply]
+  by_cases hq : f q = 1
+  · rw [Finset.sum_eq_single q]
+    · simp [singleFace, hq]
+    · intros r _ hne
+      simp [singleFace, Pi.single_apply, hne.symm]
+    · intro hcontra
+      exact absurd (Finset.mem_filter.mpr ⟨Finset.mem_univ q, hq⟩) hcontra
+  · have hq0 : f q = 0 := (zmod2_dichotomy_local (f q)).resolve_right hq
+    rw [hq0]
+    refine (Finset.sum_eq_zero ?_).symm
+    intros r hr
+    rw [Finset.mem_filter] at hr
+    have hne : r ≠ q := fun heq => hq (heq ▸ hr.2)
+    simp [singleFace, Pi.single_apply, hne]
+
+/-- For any 2-chain `f`, `chainXOperator (∂₂ f)` is in the X-closure. -/
+lemma chainXOperator_boundary2_mem_XClosure (f : X.C2 → ZMod 2) :
+    X.chainXOperator (X.boundary2 f) ∈ Subgroup.closure X.XGenerators := by
+  classical
+  rw [c2_eq_sum_singleFace_filter f]
+  rw [map_sum]  -- pushes ∂₂ through the sum
+  -- Goal: chainXOperator (∑ p ∈ filter, ∂₂ (singleFace p)) ∈ closure
+  induction (Finset.univ.filter fun p : X.C2 => f p = 1) using Finset.induction with
+  | empty => simpa using OneMemClass.one_mem _
+  | insert p s hp ih =>
+    rw [Finset.sum_insert hp, chainXOperator_add]
+    exact Subgroup.mul_mem _
+      (Subgroup.subset_closure (Set.mem_range_self _)) ih
+
+/-- `chainXOperator c ∈ closure(XGenerators)` iff `c ∈ boundaries`. -/
+theorem chainXOperator_mem_XClosure_iff_mem_boundaries (c : X.C1 → ZMod 2) :
+    X.chainXOperator c ∈ Subgroup.closure X.XGenerators ↔ c ∈ X.boundaries := by
+  constructor
+  · intro hc
+    have h_closure :
+        ∀ g ∈ Subgroup.closure X.XGenerators,
+          ∃ f : X.C2 → ZMod 2,
+            X.chainXOperator (X.boundary2 f) = g := by
+      intro g hg
+      refine Subgroup.closure_induction
+        (p := fun y _ => ∃ f : X.C2 → ZMod 2, X.chainXOperator (X.boundary2 f) = y)
+        ?_ ?_ ?_ ?_ hg
+      · rintro y ⟨p, rfl⟩
+        exact ⟨X.singleFace p, rfl⟩
+      · exact ⟨0, by simp⟩
+      · intros g₁ g₂ _ _ ih1 ih2
+        obtain ⟨f₁, hf₁⟩ := ih1
+        obtain ⟨f₂, hf₂⟩ := ih2
+        refine ⟨f₁ + f₂, ?_⟩
+        rw [map_add, chainXOperator_add, hf₁, hf₂]
+      · intros g _ ih
+        obtain ⟨f, hf⟩ := ih
+        refine ⟨f, ?_⟩
+        rw [← hf, chainXOperator_inv]
+    obtain ⟨f, hf⟩ := h_closure _ hc
+    have h_eq : X.boundary2 f = c := by
+      have hr := congrArg X.chainOfXOperator hf
+      rw [chainOfXOperator_chainXOperator] at hr
+      rw [chainOfXOperator_chainXOperator] at hr
+      exact hr
+    rw [show X.boundaries = LinearMap.range X.boundary2 from rfl]
+    exact ⟨f, h_eq⟩
+  · rintro ⟨f, rfl⟩
+    exact chainXOperator_boundary2_mem_XClosure f
+
+/-! ## CSS decomposition: X-type elements of stabilizer come from X-closure -/
+
+lemma xType_in_stabilizer_implies_in_XClosure
+    (g : NQubitPauliGroupElement X.numQubits)
+    (hg : g ∈ X.homologicalStabilizerGroup.toSubgroup)
+    (hxt : NQubitPauliGroupElement.IsXTypeElement g) :
+    g ∈ Subgroup.closure X.XGenerators := by
+  have hg_cl :
+      g ∈ Subgroup.closure (X.ZGenerators ∪ X.XGenerators) := hg
+  obtain ⟨z, hz, x, hx, rfl⟩ :=
+    Subgroup.mem_closure_union_exists_mul_of_commute_generators
+      ZGenerators_commute_XGenerators g hg_cl
+  have hz_zt : NQubitPauliGroupElement.IsZTypeElement z :=
+    NQubitPauliGroupElement.IsZTypeElement_of_mem_closure ZGenerators_isZType z hz
+  have hx_xt : NQubitPauliGroupElement.IsXTypeElement x :=
+    NQubitPauliGroupElement.IsXTypeElement_of_mem_closure XGenerators_isXType x hx
+  have hz_xt : NQubitPauliGroupElement.IsXTypeElement z := by
+    have hreorder : z = (z * x) * x⁻¹ := (mul_inv_cancel_right z x).symm
+    rw [hreorder]
+    exact NQubitPauliGroupElement.IsXTypeElement_mul hxt
+      (NQubitPauliGroupElement.IsXTypeElement_inv hx_xt)
+  have hz_eq : z = 1 :=
+    NQubitPauliGroupElement.eq_one_of_IsZTypeElement_and_IsXTypeElement hz_zt hz_xt
+  rw [hz_eq, one_mul]
+  exact hx
+
+/-! ## Centralizer membership iff cycle -/
+
+/-- An X-type chain operator commutes with all face stabs (X-X case). -/
+lemma chainXOperator_commutes_faceStabOf
+    (c : X.C1 → ZMod 2) (f : X.C2) :
+    X.faceStabOf f * X.chainXOperator c = X.chainXOperator c * X.faceStabOf f :=
+  Quantum.StabilizerGroup.CSSCommutationLemmas.XType_commutes
+    (faceStabOf_isXType f) (chainXOperator_isXType c)
+
+lemma chainXOperator_mem_centralizer_iff_mem_cycles
+    (c : X.C1 → ZMod 2) :
+    X.chainXOperator c ∈ Quantum.StabilizerGroup.centralizer X.homologicalStabilizerGroup
+    ↔ c ∈ X.cycles := by
+  constructor
+  · intro h
+    apply (chainXOperator_commutes_ZGenerators_iff_mem_cycles c).mp
+    intro z hz
+    apply h
+    exact Subgroup.subset_closure (Set.mem_union_left _ hz)
+  · intro hc
+    have h_commZ :
+        ∀ z ∈ X.ZGenerators, z * X.chainXOperator c = X.chainXOperator c * z :=
+      (chainXOperator_commutes_ZGenerators_iff_mem_cycles c).mpr hc
+    intro g hg
+    refine Subgroup.closure_induction (p := fun y _ => y * X.chainXOperator c =
+        X.chainXOperator c * y) ?_ ?_ ?_ ?_ hg
+    · rintro y (hy | hy)
+      · exact h_commZ y hy
+      · rcases hy with ⟨f, rfl⟩
+        exact chainXOperator_commutes_faceStabOf c f
+    · show (1 : NQubitPauliGroupElement X.numQubits) * X.chainXOperator c =
+        X.chainXOperator c * 1
+      rw [one_mul, mul_one]
+    · intros y₁ y₂ _ _ hy₁ hy₂
+      calc (y₁ * y₂) * X.chainXOperator c
+          = y₁ * (y₂ * X.chainXOperator c) := mul_assoc _ _ _
+        _ = y₁ * (X.chainXOperator c * y₂) := by rw [hy₂]
+        _ = (y₁ * X.chainXOperator c) * y₂ := (mul_assoc _ _ _).symm
+        _ = (X.chainXOperator c * y₁) * y₂ := by rw [hy₁]
+        _ = X.chainXOperator c * (y₁ * y₂) := mul_assoc _ _ _
+    · intros y _ hy
+      have hcomm : Commute y (X.chainXOperator c) := hy
+      exact hcomm.inv_left.eq
+
+/-! ## Stabilizer "same operators" implies the chain is a boundary -/
+
+lemma stabilizer_same_ops_implies_boundary
+    (c : X.C1 → ZMod 2)
+    (s : NQubitPauliGroupElement X.numQubits)
+    (hs : s ∈ X.homologicalStabilizerGroup.toSubgroup)
+    (heq : s.operators = (X.chainXOperator c).operators) :
+    c ∈ X.boundaries := by
+  have hops : ∀ i, s.operators i = PauliOperator.X ∨ s.operators i = PauliOperator.I := by
+    intro i
+    rw [heq]
+    rcases (chainXOperator_isXType c).2 i with h | h
+    · right; exact h
+    · left; exact h
+  -- s has phase 0 and is X-type via CSS decomposition
+  have hs_xt : NQubitPauliGroupElement.IsXTypeElement s := by
+    have hs_cl : s ∈ Subgroup.closure (X.ZGenerators ∪ X.XGenerators) := hs
+    obtain ⟨z, hz, x, hx, hzx⟩ :=
+      Subgroup.mem_closure_union_exists_mul_of_commute_generators
+        ZGenerators_commute_XGenerators s hs_cl
+    have hz_zt : NQubitPauliGroupElement.IsZTypeElement z :=
+      NQubitPauliGroupElement.IsZTypeElement_of_mem_closure ZGenerators_isZType z hz
+    have hx_xt : NQubitPauliGroupElement.IsXTypeElement x :=
+      NQubitPauliGroupElement.IsXTypeElement_of_mem_closure XGenerators_isXType x hx
+    have hz_id : z = 1 := by
+      have hz_ops_I : ∀ i, z.operators i = PauliOperator.I := by
+        intro i
+        have hsi := hops i
+        rw [hzx] at hsi
+        rcases hz_zt.2 i with hz_I | hz_Z
+        · exact hz_I
+        · exfalso
+          rcases hx_xt.2 i with hx_I | hx_X
+          · simp [NQubitPauliGroupElement.mul, NQubitPauliGroupElement.mulOp,
+              hz_Z, hx_I, PauliOperator.mulOp] at hsi
+          · simp [NQubitPauliGroupElement.mul, NQubitPauliGroupElement.mulOp,
+              hz_Z, hx_X, PauliOperator.mulOp] at hsi
+      exact NQubitPauliGroupElement.ext z 1 hz_zt.1
+        (by ext i; simp [NQubitPauliOperator.identity, hz_ops_I i])
+    rw [hzx, hz_id, one_mul]
+    exact hx_xt
+  have hxcl :
+      s ∈ Subgroup.closure X.XGenerators :=
+    xType_in_stabilizer_implies_in_XClosure s hs hs_xt
+  have h_eq : s = X.chainXOperator c := by
+    apply NQubitPauliGroupElement.ext
+    · rw [hs_xt.1, (chainXOperator_isXType c).1]
+    · ext i; exact congrFun heq i
+  rw [h_eq] at hxcl
+  exact (chainXOperator_mem_XClosure_iff_mem_boundaries c).mp hxcl
+
+/-! ## Main: nontrivial logical iff cycle ∧ ¬ boundary -/
+
+theorem chainXOperator_isNontrivialLogical_iff (c : X.C1 → ZMod 2) :
+    Quantum.StabilizerGroup.IsNontrivialLogicalOperator
+        (X.chainXOperator c) X.homologicalStabilizerGroup ↔
+      c ∈ X.cycles ∧ c ∉ X.boundaries := by
+  rw [Quantum.StabilizerGroup.IsNontrivialLogicalOperator_iff]
+  constructor
+  · rintro ⟨h_centralizer, h_not_stab, _⟩
+    refine ⟨?_, ?_⟩
+    · exact (chainXOperator_mem_centralizer_iff_mem_cycles c).mp h_centralizer
+    · intro hc_b
+      have hclosure :
+          X.chainXOperator c ∈ Subgroup.closure X.XGenerators :=
+        (chainXOperator_mem_XClosure_iff_mem_boundaries c).mpr hc_b
+      have h_in_stab :
+          X.chainXOperator c ∈ X.homologicalStabilizerGroup.toSubgroup := by
+        refine Subgroup.closure_induction
+          (p := fun y _ => y ∈ X.homologicalStabilizerGroup.toSubgroup) ?_ ?_ ?_ ?_ hclosure
+        · intro y hy
+          exact Subgroup.subset_closure (Set.mem_union_right _ hy)
+        · exact Subgroup.one_mem _
+        · intros y₁ y₂ _ _ hy₁ hy₂
+          exact Subgroup.mul_mem _ hy₁ hy₂
+        · intros y _ hy
+          exact Subgroup.inv_mem _ hy
+      exact h_not_stab h_in_stab
+  · rintro ⟨hc_c, hc_nb⟩
+    refine ⟨?_, ?_, ?_⟩
+    · exact (chainXOperator_mem_centralizer_iff_mem_cycles c).mpr hc_c
+    · intro hg
+      exact hc_nb (stabilizer_same_ops_implies_boundary c (X.chainXOperator c) hg rfl)
+    · intro s hs hEq
+      exact hc_nb (stabilizer_same_ops_implies_boundary c s hs hEq)
+
+end HomologicalCode
+
+end Homological
+end Stabilizer
+end Quantum

--- a/QEC/Stabilizer/Homological/StabGroup.lean
+++ b/QEC/Stabilizer/Homological/StabGroup.lean
@@ -1,0 +1,95 @@
+import QEC.Stabilizer.Homological.Generators
+import QEC.Stabilizer.Core.SubgroupLemmas
+import QEC.Stabilizer.Core.StabilizerGroup
+import QEC.Stabilizer.Core.CSSNoNegI
+
+/-!
+# §B.3 — Generic CSS stabilizer group from a homological code
+
+This file constructs `homologicalStabilizerGroup X : StabilizerGroup X.numQubits`
+from the generators defined in §B.2.  The generators pairwise commute (§B.2)
+and their closure does not contain `-I` (standard CSS argument), so this
+packages directly as a `StabilizerGroup`.
+
+The full `StabilizerCode` construction (which adds logical operators per
+H₁ basis element, plus the symplectic-LI proof) is left to each instance
+since it depends on instance-specific kernel data and a basis of `H₁`.
+-/
+
+namespace Quantum
+namespace Stabilizer
+namespace Homological
+
+open scoped BigOperators
+
+namespace HomologicalCode
+
+variable (X : HomologicalCode)
+
+/-- The full generator set of the CSS code: union of vertex and face stabilizers. -/
+noncomputable def homologicalGenerators :
+    Set (NQubitPauliGroupElement X.numQubits) :=
+  X.ZGenerators ∪ X.XGenerators
+
+variable {X}
+
+/-- Z-generators are inside the full generator set. -/
+lemma ZGenerators_subset_homologicalGenerators :
+    X.ZGenerators ⊆ X.homologicalGenerators :=
+  Set.subset_union_left
+
+/-- X-generators are inside the full generator set. -/
+lemma XGenerators_subset_homologicalGenerators :
+    X.XGenerators ⊆ X.homologicalGenerators :=
+  Set.subset_union_right
+
+/-- All generators pairwise commute (combining X-X, Z-Z, and X-Z arguments from §B.2). -/
+lemma homologicalGenerators_commute :
+    ∀ g ∈ X.homologicalGenerators, ∀ h ∈ X.homologicalGenerators, g * h = h * g := by
+  rintro g (hg | hg) h (hh | hh)
+  -- Z, Z
+  · exact Quantum.StabilizerGroup.CSSCommutationLemmas.ZType_commutes
+      (ZGenerators_isZType _ hg) (ZGenerators_isZType _ hh)
+  -- Z, X
+  · exact ZGenerators_commute_XGenerators _ hg _ hh
+  -- X, Z
+  · exact (ZGenerators_commute_XGenerators _ hh _ hg).symm
+  -- X, X
+  · exact Quantum.StabilizerGroup.CSSCommutationLemmas.XType_commutes
+      (XGenerators_isXType _ hg) (XGenerators_isXType _ hh)
+
+variable (X)
+
+/-- The closure of the homological generators does not contain `-I`. -/
+lemma negIdentity_not_mem_closure_homologicalGenerators :
+    Quantum.StabilizerGroup.negIdentity X.numQubits ∉
+      Subgroup.closure X.homologicalGenerators := by
+  unfold homologicalGenerators
+  exact Quantum.StabilizerGroup.CSSCommutationLemmas.negIdentity_not_mem_closure_union
+    X.ZGenerators X.XGenerators
+    ZGenerators_isZType XGenerators_isXType ZGenerators_commute_XGenerators
+
+/-- The CSS stabilizer group of a homological code. -/
+noncomputable def homologicalStabilizerGroup :
+    Quantum.StabilizerGroup X.numQubits where
+  toSubgroup := Subgroup.closure X.homologicalGenerators
+  is_abelian := fun g h hg hh =>
+    Subgroup.abelian_closure_of_pairwise_commute X.homologicalGenerators
+      homologicalGenerators_commute g hg h hh
+  no_neg_identity := negIdentity_not_mem_closure_homologicalGenerators X
+
+/-- The stabilizer group's subgroup is the closure of the generator set. -/
+@[simp] lemma homologicalStabilizerGroup_toSubgroup :
+    (X.homologicalStabilizerGroup).toSubgroup =
+      Subgroup.closure X.homologicalGenerators := rfl
+
+/-- The stabilizer group's subgroup, expressed as the closure of `Z ∪ X` generators. -/
+lemma homologicalStabilizerGroup_toSubgroup_union :
+    (X.homologicalStabilizerGroup).toSubgroup =
+      Subgroup.closure (X.ZGenerators ∪ X.XGenerators) := rfl
+
+end HomologicalCode
+
+end Homological
+end Stabilizer
+end Quantum

--- a/QEC/Stabilizer/Lattice.lean
+++ b/QEC/Stabilizer/Lattice.lean
@@ -10,4 +10,5 @@ import QEC.Stabilizer.Lattice.ToricOperatorChains
 import QEC.Stabilizer.Lattice.ToricLogicalCorrespondenceX
 import QEC.Stabilizer.Lattice.ToricLogicalCorrespondenceZ
 import QEC.Stabilizer.Lattice.ToricDualWrappingInvariants
+import QEC.Stabilizer.Lattice.ToricChainComplex
 

--- a/QEC/Stabilizer/Lattice/ToricChainComplex.lean
+++ b/QEC/Stabilizer/Lattice/ToricChainComplex.lean
@@ -1,0 +1,72 @@
+import QEC.Stabilizer.Homological
+import QEC.Stabilizer.Lattice.ToricHomology
+import QEC.Stabilizer.Lattice.ToricH1Dimension
+
+/-!
+# §E — Toric chain complex as an instance of `HomologicalCode`
+
+The toric code is the canonical instance of the generic `HomologicalCode`
+abstraction.  This file packages the toric boundary maps as a `HomologicalCode`
+and proves the basic identities relating the toric-specific submodules
+(`toricCycles`, `toricBoundaries`, `toricH1`) to the generic versions on
+`toricHomologicalCode L`.
+
+Existing toric proofs continue to operate on the lattice-specific
+definitions.  The benefit of the abstraction layer is that any new
+homological CSS code (e.g. the rotated surface code, color codes,
+hypergraph product codes) only needs to define its own `HomologicalCode`
+instance to inherit the cycles/boundaries/H₁ infrastructure, the chain
+operators with `_zero`/`_add` homomorphism lemmas, the stabilizer generators
+with pairwise commutation, the centralizer-membership logical-correspondence
+iffs, and the CSS distance bridge `not_both_boundary_of_nontrivial`.
+-/
+
+namespace Quantum
+namespace Stabilizer
+namespace Lattice
+
+/-- The toric chain complex as a `HomologicalCode`.  The 0-cells are vertices,
+1-cells are edges, 2-cells are faces.  The boundary maps and the chain-complex
+law `∂₁ ∘ ∂₂ = 0` are imported from `ToricBoundaryMaps`. -/
+noncomputable def toricHomologicalCode (L : ℕ) [Fact (0 < L)] :
+    Quantum.Stabilizer.Homological.HomologicalCode where
+  C0 := VtxIdx L
+  C1 := EdgeIdx L
+  C2 := FaceIdx L
+  decEq0 := inferInstance
+  decEq1 := inferInstance
+  decEq2 := inferInstance
+  fin0 := inferInstance
+  fin1 := inferInstance
+  fin2 := inferInstance
+  boundary1 := toricBoundary1 (L := L)
+  boundary2 := toricBoundary2 (L := L)
+  boundary_comp := toricBoundary_comp_zero (L := L)
+
+/-- The toric cycle submodule equals the generic version on `toricHomologicalCode L`. -/
+theorem toricHomologicalCode_cycles_eq (L : ℕ) [Fact (0 < L)] :
+    toricCycles (L := L) = (toricHomologicalCode L).cycles := rfl
+
+/-- The toric boundary submodule equals the generic version. -/
+theorem toricHomologicalCode_boundaries_eq (L : ℕ) [Fact (0 < L)] :
+    toricBoundaries (L := L) = (toricHomologicalCode L).boundaries := rfl
+
+/-- The toric H₁ definition agrees with the generic version. -/
+theorem toricHomologicalCode_H1_eq (L : ℕ) [Fact (0 < L)] :
+    toricH1 (L := L) = (toricHomologicalCode L).H1 := rfl
+
+/-- The toric `boundaries ≤ cycles` follows from the generic chain-complex law. -/
+theorem toricHomologicalCode_boundaries_le_cycles (L : ℕ) [Fact (0 < L)] :
+    toricBoundaries (L := L) ≤ toricCycles (L := L) :=
+  (toricHomologicalCode L).boundaries_le_cycles
+
+/-- The number of qubits in the toric code equals the generic `numQubits` of its
+chain complex (= `Fintype.card (EdgeIdx L) = 2L²`). -/
+theorem toricHomologicalCode_numQubits (L : ℕ) [Fact (0 < L)] :
+    (toricHomologicalCode L).numQubits = 2 * L * L := by
+  show Fintype.card (EdgeIdx L) = 2 * L * L
+  exact card_edgeIdx L
+
+end Lattice
+end Stabilizer
+end Quantum

--- a/QEC/Stabilizer/Stabilizer.lean
+++ b/QEC/Stabilizer/Stabilizer.lean
@@ -2,4 +2,5 @@ import QEC.Stabilizer.PauliGroupSingle
 import QEC.Stabilizer.PauliGroup
 import QEC.Stabilizer.Core
 import QEC.Stabilizer.Lattice
+import QEC.Stabilizer.Homological
 import QEC.Stabilizer.Codes


### PR DESCRIPTION
## Summary

Extracts the construction-and-correspondence layer of CSS stabilizer codes into a generic length-3 chain-complex abstraction over $\mathbb{F}_2$ (`HomologicalCode`), and makes the toric code its first instance. After this, adding a new homological CSS code (rotated surface, color, hypergraph product, etc.) only needs to define the cell complex — the cycles/boundaries/$H_1$ infrastructure, chain operators, generators, pairwise commutation, X-side logical-correspondence iffs, and CSS distance bridge come for free.

## What's new

New module `QEC/Stabilizer/Homological/` (1,449 lines, 6 files):

- **`Code.lean`** — `HomologicalCode` struct, `cycles` / `boundaries` / `H₁`, rank-nullity wrappers, `cutMap` (the $\mathbb{F}_2$-transpose of $\partial_1$) with the transpose pairing $\langle \partial_1 c, s \rangle = \langle c, \mathrm{cutMap}\, s \rangle$.
- **`CSS.lean`** — `numQubits`, `edgeEquiv`, `chainXOperator` / `chainZOperator` with inverses and roundtrip, support iffs, `IsXType` / `IsZType`, and the `_zero` / `_add` homomorphism lemmas.
- **`Generators.lean`** — `singleFace` / `singleVtx` / `singleEdge`, `faceStabOf` / `vertexStabOf`, `XGenerators` / `ZGenerators`, `chainInnerProduct`, the X-Z commutation criterion (`commutes ↔ ⟨c, c'⟩ = 0`), and all three pairwise-commutation theorems including `ZGenerators_commute_XGenerators` (which falls out of the chain-complex law $\partial_1 \circ \partial_2 = 0$ via the transpose pairing).
- **`StabGroup.lean`** — generic `homologicalStabilizerGroup : StabilizerGroup X.numQubits` from $\mathrm{XGenerators} \cup \mathrm{ZGenerators}$ plus the standard CSS no-$(-I)$ argument.
- **`LogicalCorrespondence.lean`** — `dualBoundary` (transpose of $\partial_2$), `dualCycles`, `dualBoundaries`, plus the X-side iffs: cycles ↔ commutes-with-all-Z-checks, boundaries ↔ in-X-closure, centralizer-membership, and the main `chainXOperator_isNontrivialLogical_iff` (logical ↔ cycle ∧ ¬boundary).
- **`Distance.lean`** — `xChainOf` / `zChainOf` (support chains of a Pauli), weight ≥ chain-weight bounds, X-only/Z-only operator reconstruction, `chainZOperator_cutMap_mem_ZClosure` (Z-side closure mirror needed for the bridge), and the CSS bridge `not_both_boundary_of_nontrivial`.

Toric instance (`QEC/Stabilizer/Lattice/ToricChainComplex.lean`, 72 lines):

- `toricHomologicalCode L` packages the existing `toricBoundary1` / `toricBoundary2` / `toricBoundary_comp_zero` as a `HomologicalCode`.
- `rfl` bridge identities: `toricCycles = (toricHomologicalCode L).cycles`, same for `toricBoundaries` and `toricH1`.
- `toricHomologicalCode_numQubits : (toricHomologicalCode L).numQubits = 2 * L * L`.

Wired into `QEC.Stabilizer.Stabilizer` via a `Homological.lean` umbrella, and into `QEC.Stabilizer.Lattice` for the toric instance.

## Why now

The toric code is fully formalized in this repo, but its proofs bake the construction into the square-lattice geometry. Adding any other homological CSS code currently requires redoing the pipeline (chain complex → cycles → CSS → logical correspondence → CSS distance bridge) from scratch. Lifting the genuinely abstract layer makes that pipeline reusable.

## Scope notes vs. the original plan

The plan called for ~3,000–5,000 lines net change including a refactor of the toric files. This PR delivers the abstraction layer (1,449 lines) plus a thin toric instance (72 lines) — **additive, no risky surgery on the existing 3,000+ lines of toric proofs**. Three deliberate scope choices:

1. **§B.3 thin wrapper.** The plan's full ~700-line symplectic-LI lift was scoped down to `homologicalStabilizerGroup` (~95 lines). The toric file keeps its existing LI proof. The full `StabilizerCode` constructor with logical operators stays toric-specific (the choice of $H_1$ basis is necessarily instance-specific anyway).
2. **§C Z-side mirror skipped.** `dualCycles` / `dualBoundaries` are defined but the four mirror nontrivial-iff theorems are deferred — the §D bridge needs only `chainZOperator_cutMap_mem_ZClosure`, which is provided directly.
3. **§E conservative.** Existing toric files are untouched; the abstraction is wired up via the new `toricHomologicalCode L` instance and `rfl` bridges. Slimming the toric files (the plan's "~1,500–2,000 lines net deletion") is left for a follow-up — the abstraction now exists and can be referenced directly by future codes.

## Test plan

- [x] `lake build` passes (3,391 jobs).
- [x] `grep -rn sorry QEC/` returns 0.
- [x] Each phase built independently before the next was added (Code → CSS → Generators → StabGroup → LogicalCorrespondence → Distance → ToricChainComplex).
- [x] Toric `rfl` bridges (`toricHomologicalCode_cycles_eq` etc.) confirm the abstraction's instantiation matches the existing toric submodules definitionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)