### PR TITLE
chore(lint): retire mathlib deprecations (push_neg, Matrix.*, Finset.*)

### DIFF
--- a/QEC/Foundations/Gates.lean
+++ b/QEC/Foundations/Gates.lean
@@ -330,7 +330,7 @@ by
     -- Since $G$ is unitary, we have $G.val * star G.val = 1$, which implies
     -- that $(star G.val) * G.val = 1$ as well.
     have h_unitary : (star G.val) * G.val = 1 := by
-      convert Matrix.mul_eq_one_comm.mp ( G.2.2 ) using 1;
+      convert mul_eq_one_comm.mp ( G.2.2 ) using 1;
     exact fun v => by rw [ Matrix.mulVec_mulVec, h_unitary, Matrix.one_mulVec ] ;
   -- By definition of norm, we have that ‖Gv‖^2 = ⟨Gv, Gv⟩.
   have h_norm_sq : ∀ (v : Quantum.Vector α),
@@ -422,7 +422,7 @@ lemma involutary_inv_eq
   M⁻¹ = M := by
   have h_mul : M * M = 1 := h
   have h_unit : IsUnit M.det :=
-    (Matrix.isUnit_iff_isUnit_det M).1 (Matrix.isUnit_of_right_inverse h_mul)
+    (Matrix.isUnit_iff_isUnit_det M).1 (IsUnit.of_mul_eq_one M h_mul)
   calc M⁻¹
       = M⁻¹ * 1 := by rw [mul_one]
     _ = M⁻¹ * (M * M) := by rw [← h_mul]

--- a/QEC/Stabilizer/BinarySymplectic/WeightTwoInSpan.lean
+++ b/QEC/Stabilizer/BinarySymplectic/WeightTwoInSpan.lean
@@ -63,7 +63,7 @@ theorem weight_2_pair_by_enum (L : List (NQubitPauliGroupElement n)) (i j : Fin 
     · by_cases hkj : k = j
       · subst hkj; simp [hki]
       · have hk_not_supp : k ∉ NQubitPauliOperator.support op := by
-          rw [h_supp, Finset.mem_insert, Finset.mem_singleton]; push_neg; exact ⟨hki, hkj⟩
+          rw [h_supp, Finset.mem_insert, Finset.mem_singleton]; push Not; exact ⟨hki, hkj⟩
         have : op k = .I := by
           by_contra h_ne; exact hk_not_supp ((NQubitPauliOperator.mem_support op k).mpr h_ne)
         simp [hki, hkj, this]

--- a/QEC/Stabilizer/Codes/ToricCodeNDistance.lean
+++ b/QEC/Stabilizer/Codes/ToricCodeNDistance.lean
@@ -73,7 +73,7 @@ private lemma weight_ge_edgeWeight_xChain (L : ℕ) [Fact (2 ≤ L)]
     have : g.operators (Stabilizer.Lattice.edgeToQubitIdx L e) = PauliOperator.X ∨
         g.operators (Stabilizer.Lattice.edgeToQubitIdx L e) = PauliOperator.Y := by
       by_contra h
-      push_neg at h
+      push Not at h
       simp [xChainOf, h.1, h.2] at hne
     rcases this with hX | hY
     · simp [NQubitPauliOperator.support, hX]
@@ -103,7 +103,7 @@ private lemma weight_ge_edgeWeight_zChain (L : ℕ) [Fact (2 ≤ L)]
     have : g.operators (Stabilizer.Lattice.edgeToQubitIdx L e) = PauliOperator.Z ∨
         g.operators (Stabilizer.Lattice.edgeToQubitIdx L e) = PauliOperator.Y := by
       by_contra h
-      push_neg at h
+      push Not at h
       simp [zChainOf, h.1, h.2] at hne
     rcases this with hZ | hY
     · simp [NQubitPauliOperator.support, hZ]
@@ -142,7 +142,7 @@ private lemma toricXOf_xChain_operators_eq (L : ℕ) [Fact (0 < L)]
     have hex : ∃ e : Stabilizer.Lattice.EdgeIdx L,
         Stabilizer.Lattice.edgeToQubitIdx L e = i ∧ xChainOf L g e = 1 := ⟨e, hei, he1⟩
     simp [Stabilizer.Lattice.toricXOperatorOfChain, hex, hxy]
-  · push_neg at hxy
+  · push Not at hxy
     have hex : ¬ ∃ e : Stabilizer.Lattice.EdgeIdx L,
         Stabilizer.Lattice.edgeToQubitIdx L e = i ∧ xChainOf L g e = 1 := by
       rintro ⟨e, hei, he1⟩
@@ -194,7 +194,7 @@ private lemma toricZOf_zChain_operators_eq (L : ℕ) [Fact (0 < L)]
     have hex : ∃ e : Stabilizer.Lattice.EdgeIdx L,
         Stabilizer.Lattice.edgeToQubitIdx L e = i ∧ zChainOf L g e = 1 := ⟨e, hei, he1⟩
     simp [Stabilizer.Lattice.toricZOperatorOfChain, hex, hzy]
-  · push_neg at hzy
+  · push Not at hzy
     have hex : ¬ ∃ e : Stabilizer.Lattice.EdgeIdx L,
         Stabilizer.Lattice.edgeToQubitIdx L e = i ∧ zChainOf L g e = 1 := by
       rintro ⟨e, hei, he1⟩
@@ -586,7 +586,7 @@ theorem toricCodeN_distance_eq_min_dX_dZ (L dX dZ : ℕ) [Fact (2 ≤ L)]
     · obtain ⟨g, _, hg_logical, hg_weight⟩ := hxWit
       refine ⟨g, (h_iff g).mpr hg_logical, ?_⟩
       rw [hg_weight]; exact (Nat.min_eq_left hle).symm
-    · push_neg at hle
+    · push Not at hle
       obtain ⟨g, _, hg_logical, hg_weight⟩ := hzWit
       refine ⟨g, (h_iff g).mpr hg_logical, ?_⟩
       rw [hg_weight]; exact (Nat.min_eq_right (le_of_lt hle)).symm

--- a/QEC/Stabilizer/Codes/ToricCodeNStabilizerCode.lean
+++ b/QEC/Stabilizer/Codes/ToricCodeNStabilizerCode.lean
@@ -1246,11 +1246,11 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
       have hpartition : (Finset.univ : Finset (Fin (generatorsListPackaged L).length)) =
           (Finset.univ.filter (fun k => k.val < nZ)) ∪
           (Finset.univ.filter (fun k => ¬ k.val < nZ)) := by
-        rw [Finset.filter_union_filter_neg_eq]
+        rw [Finset.filter_union_filter_not_eq]
       have hdisj : Disjoint
           ((Finset.univ : Finset (Fin (generatorsListPackaged L).length)).filter (fun k => k.val < nZ))
           (Finset.univ.filter (fun k => ¬ k.val < nZ)) :=
-        Finset.disjoint_filter_filter_neg _ _ _
+        Finset.disjoint_filter_filter_not _ _ _
       rw [hpartition, Finset.sum_union hdisj]
       -- The "right" sum (X-block) is 0.
       have hX_zero : ∑ k ∈ (Finset.univ : Finset (Fin (generatorsListPackaged L).length)).filter
@@ -1355,11 +1355,11 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
       have hpartition : (Finset.univ : Finset (Fin (generatorsListPackaged L).length)) =
           (Finset.univ.filter (fun k => k.val < nZ)) ∪
           (Finset.univ.filter (fun k => ¬ k.val < nZ)) := by
-        rw [Finset.filter_union_filter_neg_eq]
+        rw [Finset.filter_union_filter_not_eq]
       have hdisj : Disjoint
           ((Finset.univ : Finset (Fin (generatorsListPackaged L).length)).filter (fun k => k.val < nZ))
           (Finset.univ.filter (fun k => ¬ k.val < nZ)) :=
-        Finset.disjoint_filter_filter_neg _ _ _
+        Finset.disjoint_filter_filter_not _ _ _
       rw [hpartition, Finset.sum_union hdisj]
       -- The "left" sum (Z-block) is 0 in X-half.
       have hZ_zero : ∑ k ∈ (Finset.univ : Finset (Fin (generatorsListPackaged L).length)).filter
@@ -1460,7 +1460,7 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
     rw [← hj_eq]
     exact hzj
   · -- X-block index
-    push_neg at h
+    push Not at h
     have hlen : (generatorsListPackaged L).length =
         (coordsTrimmed L).length + (coordsTrimmed L).length := by
       unfold generatorsListPackaged

--- a/QEC/Stabilizer/Core/LogicalGateGroup.lean
+++ b/QEC/Stabilizer/Core/LogicalGateGroup.lean
@@ -178,7 +178,7 @@ private lemma maps_to_codespace_of_conjugation (U : NQubitGate n) (S : Stabilize
   have h_conj : ∀ ψ : NQubitState n, IsInCodespace ψ S → IsInCodespace (U • ψ) S := by
     apply Classical.byContradiction
     intro h_contra;
-    push_neg at h_contra;
+    push Not at h_contra;
     obtain ⟨ ψ, hψ₁, hψ₂ ⟩ := h_contra;
     apply hψ₂;
     convert StabilizerGroup.conjugation_iff_maps_codespace U S |>.1 _ ψ hψ₁ using 1;

--- a/QEC/Stabilizer/Core/LogicalOperators.lean
+++ b/QEC/Stabilizer/Core/LogicalOperators.lean
@@ -51,7 +51,7 @@ lemma anticommutes_imp_not_isPauliLogicalOperator (g : NQubitPauliGroupElement n
       ¬IsInCodespace ψ S ∨ ¬IsInCodespace (g.toGate • ψ) S := by
     intro ψ
     by_contra h_contra
-    push_neg at h_contra
+    push Not at h_contra
     obtain ⟨hψ, hgψ⟩ := h_contra
     unfold NQubitPauliGroupElement.Anticommute at h_anti
     have h_sg := NQubitPauliGroupElement.Anticommute.toMatrix_mul_neg s g h_anti

--- a/QEC/Stabilizer/Homological/Distance.lean
+++ b/QEC/Stabilizer/Homological/Distance.lean
@@ -99,7 +99,7 @@ lemma weight_ge_chainWeight_xChainOf (g : NQubitPauliGroupElement X.numQubits) :
     have h_op : g.operators (X.edgeEquiv e) = PauliOperator.X ∨
         g.operators (X.edgeEquiv e) = PauliOperator.Y := by
       by_contra hcontr
-      push_neg at hcontr
+      push Not at hcontr
       simp [xChainOf, hcontr.1, hcontr.2] at hne
     rcases h_op with hX | hY
     · simp [NQubitPauliOperator.support, hX]
@@ -124,7 +124,7 @@ lemma weight_ge_chainWeight_zChainOf (g : NQubitPauliGroupElement X.numQubits) :
     have h_op : g.operators (X.edgeEquiv e) = PauliOperator.Z ∨
         g.operators (X.edgeEquiv e) = PauliOperator.Y := by
       by_contra hcontr
-      push_neg at hcontr
+      push Not at hcontr
       simp [zChainOf, hcontr.1, hcontr.2] at hne
     rcases h_op with hZ | hY
     · simp [NQubitPauliOperator.support, hZ]
@@ -156,7 +156,7 @@ lemma chainXOperator_xChainOf_op_at
       simp [hxy]
     have hex : ∃ e' : X.C1, X.edgeEquiv e' = i ∧ X.xChainOf g e' = 1 := ⟨e, hei, hx1⟩
     rw [if_pos hex, if_pos hxy]
-  · push_neg at hxy
+  · push Not at hxy
     have hex : ¬ ∃ e' : X.C1, X.edgeEquiv e' = i ∧ X.xChainOf g e' = 1 := by
       rintro ⟨e', hei, he1⟩
       have h0 : X.xChainOf g e' = 0 := by
@@ -167,7 +167,7 @@ lemma chainXOperator_xChainOf_op_at
       exact absurd he1 (by decide)
     rw [if_neg hex]
     rw [if_neg]
-    push_neg
+    push Not
     exact hxy
 
 /-- Z-only mirror. -/
@@ -187,7 +187,7 @@ lemma chainZOperator_zChainOf_op_at
       simp [hzy]
     have hex : ∃ e' : X.C1, X.edgeEquiv e' = i ∧ X.zChainOf g e' = 1 := ⟨e, hei, hz1⟩
     rw [if_pos hex, if_pos hzy]
-  · push_neg at hzy
+  · push Not at hzy
     have hex : ¬ ∃ e' : X.C1, X.edgeEquiv e' = i ∧ X.zChainOf g e' = 1 := by
       rintro ⟨e', hei, he1⟩
       have h0 : X.zChainOf g e' = 0 := by
@@ -198,7 +198,7 @@ lemma chainZOperator_zChainOf_op_at
       exact absurd he1 (by decide)
     rw [if_neg hex]
     rw [if_neg]
-    push_neg
+    push Not
     exact hzy
 
 /-! ## not_both_boundary_of_nontrivial


### PR DESCRIPTION
## Summary

PR 1 of 10 in the linter-cleanup plan (covers everything except `linter.flexible`).

Replaces 21 sites flagged by mathlib v4.30 deprecation warnings with their non-deprecated equivalents:

- `push_neg` → `push Not` — 15 sites across 6 files
- `Matrix.mul_eq_one_comm` → `mul_eq_one_comm` — [Gates.lean:333](../blob/cleanup/deprecation-renames/QEC/Foundations/Gates.lean#L333)
- `Matrix.isUnit_of_right_inverse` → `IsUnit.of_mul_eq_one` — [Gates.lean:425](../blob/cleanup/deprecation-renames/QEC/Foundations/Gates.lean#L425) (needed an explicit `b` argument since the new signature differs)
- `Finset.filter_union_filter_neg_eq` → `Finset.filter_union_filter_not_eq` (×2 in `ToricCodeNStabilizerCode.lean`)
- `Finset.disjoint_filter_filter_neg` → `Finset.disjoint_filter_filter_not` (×2 in `ToricCodeNStabilizerCode.lean`)

## Verification

- `lake build` succeeds.
- Warning count: **627 → 606** (drop of exactly 21, matches expected count).
- All `deprecated` warnings eliminated; no other linter category affected.

## Test plan

- [x] `lake build` clean (no errors)
- [x] `grep -c "^warning:" build.log` == 606
- [x] `grep -c deprecated build.log` == 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)