### PR TITLE
chore(lint): drop 41 unused simp arguments

### DIFF
--- a/QEC/Stabilizer/Codes/ToricCodeNDistance.lean
+++ b/QEC/Stabilizer/Codes/ToricCodeNDistance.lean
@@ -121,7 +121,7 @@ private lemma edgeToQubitIdx_surjective (L : ℕ) [Fact (0 < L)] :
   classical
   have hcard_edge : Fintype.card (Stabilizer.Lattice.EdgeIdx L) =
       Fintype.card (Fin (Stabilizer.Lattice.toricNumQubits L)) := by
-    simp [Stabilizer.Lattice.toricNumQubits, two_mul, mul_comm]
+    simp [Stabilizer.Lattice.toricNumQubits, mul_comm]
   exact (Fintype.bijective_iff_injective_and_card _).mpr
     ⟨Stabilizer.Lattice.edgeToQubitIdx_injective L, hcard_edge⟩ |>.2
 
@@ -175,7 +175,7 @@ private lemma anticommutesAt_vertexStab_g_iff_xChain
       simp [PauliOperator.mulOp]
   · simp only [NQubitPauliGroupElement.anticommutesAt, hZ, heq]
     cases hgi : g.operators i <;>
-      simp [PauliOperator.mulOp, hgi]
+      simp [PauliOperator.mulOp]
 
 /-- The Z-only encoding `toricZOperatorOfChain (zChainOf g)` has, at each qubit, a Z
 exactly when `g` has Z or Y. -/
@@ -227,7 +227,7 @@ private lemma anticommutesAt_faceStab_g_iff_zChain
       simp [PauliOperator.mulOp]
   · simp only [NQubitPauliGroupElement.anticommutesAt, hX, heq]
     cases hgi : g.operators i <;>
-      simp [PauliOperator.mulOp, hgi]
+      simp [PauliOperator.mulOp]
 
 /-- If `g` is in the centralizer, its X-chain is a primal cycle. -/
 private lemma xChain_mem_toricCycles_of_centralizer (L : ℕ) [Fact (2 ≤ L)]

--- a/QEC/Stabilizer/Codes/ToricCodeNStabilizerCode.lean
+++ b/QEC/Stabilizer/Codes/ToricCodeNStabilizerCode.lean
@@ -905,7 +905,7 @@ private lemma edgeToQubitIdx_bijective (L : ℕ) [Fact (0 < L)] :
     Function.Bijective (Stabilizer.Lattice.edgeToQubitIdx L) := by
   rw [Fintype.bijective_iff_injective_and_card]
   refine ⟨Stabilizer.Lattice.edgeToQubitIdx_injective L, ?_⟩
-  simp [numQubits, Stabilizer.Lattice.toricNumQubits]
+  simp [Stabilizer.Lattice.toricNumQubits]
 
 /-- The right-inverse of `edgeToQubitIdx`: maps a qubit back to its edge. -/
 private noncomputable def qubitToEdgeIdx (L : ℕ) [Fact (0 < L)] :
@@ -1279,7 +1279,7 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
         simp at hab
         exact Fin.ext hab
       · intros b _
-        refine ⟨⟨b.val, ?_⟩, ?_, by simp [Fin.ext_iff]⟩
+        refine ⟨⟨b.val, ?_⟩, ?_, by simp⟩
         · have hb_lt := b.isLt
           have : nZ + nZ = (generatorsListPackaged L).length := hlen.symm
           omega
@@ -1426,7 +1426,7 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
       -- Align indices: nZ + k.val - nZ = k.val.
       have hidx_eq : (⟨nZ + k.val - nZ, hsub⟩ : Fin nZ) = k := by
         apply Fin.ext
-        simp [Nat.add_sub_cancel_left]
+        simp
       have hcoord_eq : (coordsTrimmed L)[nZ + k.val - nZ]'hsub = (coordsTrimmed L).get k := by
         rw [List.get_eq_getElem]
         congr 1

--- a/QEC/Stabilizer/Homological/LogicalCorrespondence.lean
+++ b/QEC/Stabilizer/Homological/LogicalCorrespondence.lean
@@ -160,7 +160,7 @@ private lemma c2_eq_sum_singleFace_filter (f : X.C2 → ZMod 2) :
   · rw [Finset.sum_eq_single q]
     · simp [singleFace, hq]
     · intros r _ hne
-      simp [singleFace, Pi.single_apply, hne.symm]
+      simp [singleFace, hne.symm]
     · intro hcontra
       exact absurd (Finset.mem_filter.mpr ⟨Finset.mem_univ q, hq⟩) hcontra
   · have hq0 : f q = 0 := (zmod2_dichotomy_local (f q)).resolve_right hq
@@ -169,7 +169,7 @@ private lemma c2_eq_sum_singleFace_filter (f : X.C2 → ZMod 2) :
     intros r hr
     rw [Finset.mem_filter] at hr
     have hne : r ≠ q := fun heq => hq (heq ▸ hr.2)
-    simp [singleFace, Pi.single_apply, hne]
+    simp [singleFace, hne]
 
 /-- For any 2-chain `f`, `chainXOperator (∂₂ f)` is in the X-closure. -/
 lemma chainXOperator_boundary2_mem_XClosure (f : X.C2 → ZMod 2) :
@@ -411,7 +411,7 @@ private lemma c0_eq_sum_singleVtx_filter (s : X.C0 → ZMod 2) :
   · rw [Finset.sum_eq_single q]
     · simp [singleVtx, hq]
     · intros r _ hne
-      simp [singleVtx, Pi.single_apply, hne.symm]
+      simp [singleVtx, hne.symm]
     · intro hcontra
       exact absurd (Finset.mem_filter.mpr ⟨Finset.mem_univ q, hq⟩) hcontra
   · have hq0 : s q = 0 := (zmod2_dichotomy_local (s q)).resolve_right hq
@@ -420,7 +420,7 @@ private lemma c0_eq_sum_singleVtx_filter (s : X.C0 → ZMod 2) :
     intros r hr
     rw [Finset.mem_filter] at hr
     have hne : r ≠ q := fun heq => hq (heq ▸ hr.2)
-    simp [singleVtx, Pi.single_apply, hne]
+    simp [singleVtx, hne]
 
 /-- For any 0-chain `s`, `chainZOperator (cutMap s)` is in the Z-closure. -/
 lemma chainZOperator_cutMap_mem_ZClosure (s : X.C0 → ZMod 2) :

--- a/QEC/Stabilizer/Lattice/ToricDualWrappingInvariants.lean
+++ b/QEC/Stabilizer/Lattice/ToricDualWrappingInvariants.lean
@@ -106,7 +106,7 @@ theorem vColAt_independent_on_dualCycles (c : toricDualCycles (L := L)) (x0 x1 :
       exact Finset.sum_eq_zero fun y _ => h_sum y;
     simp_all +decide [ Finset.sum_add_distrib, vColAt ];
     have h_sum_h : ∑ y : Fin L, c.val (EdgeIdx.h x y) = ∑ y : Fin L, c.val (EdgeIdx.h x (next L y)) := by
-      rcases L with ( _ | _ | L ) <;> simp_all +decide [ Finset.sum_add_distrib, Finset.mul_sum _ _ _, Finset.sum_mul _ _ _, next ];
+      rcases L with ( _ | _ | L ) <;> simp_all +decide [ next ];
       rw [ ← Equiv.sum_comp ( Equiv.addRight 1 ) ] ; norm_num [ Fin.add_def, Nat.mod_eq_of_lt ];
     grind;
   -- By induction on $k$, we can show that $vColAt x = vColAt (x + k)$ for any $k$.
@@ -214,7 +214,7 @@ theorem phiDual_surjective :
   obtain ⟨c, hc⟩ : ∃ c : toricDualCycles (L := L), hRowAt (L := L) (zeroCoord L) c.1 = a ∧ vColAt (L := L) (zeroCoord L) c.1 = b := by
     -- Define the chain $c$ such that it has $a$ horizontal edges and $b$ vertical edges.
     obtain ⟨c, hc⟩ : ∃ c : C1 L, (∑ x : Fin L, c (EdgeIdx.h x (zeroCoord L))) = a ∧ (∑ y : Fin L, c (EdgeIdx.v (zeroCoord L) y)) = b := by
-      refine' ⟨ fun e => if e = EdgeIdx.h ( zeroCoord L ) ( zeroCoord L ) then a else if e = EdgeIdx.v ( zeroCoord L ) ( zeroCoord L ) then b else 0, _, _ ⟩ <;> simp +decide [ Finset.sum_ite, Finset.filter_eq', Finset.filter_ne' ]
+      refine' ⟨ fun e => if e = EdgeIdx.h ( zeroCoord L ) ( zeroCoord L ) then a else if e = EdgeIdx.v ( zeroCoord L ) ( zeroCoord L ) then b else 0, _, _ ⟩ <;> simp +decide
     generalize_proofs at *; (
     -- Define the chain $c'$ such that it has $a$ horizontal edges and $b$ vertical edges.
     obtain ⟨c', hc'⟩ : ∃ c' : C1 L, (∀ x y, c' (EdgeIdx.h x y) = c (EdgeIdx.h x (zeroCoord L))) ∧ (∀ x y, c' (EdgeIdx.v x y) = c (EdgeIdx.v (zeroCoord L) y)) ∧ (∀ p : FaceIdx L, toricDualBoundary L c' p = 0) := by
@@ -233,7 +233,7 @@ Dimension of the dual cycle space.
 -/
 theorem toric_finrank_dualCycles :
     Module.finrank (ZMod 2) (toricDualCycles (L := L)) = L * L + 1 := by
-  have := LinearMap.finrank_range_add_finrank_ker ( toricDualBoundary L ) ; simp_all +decide [ toric_finrank_C1 ] ;
+  have := LinearMap.finrank_range_add_finrank_ker ( toricDualBoundary L ) ; simp_all +decide ;
   have h_dual_boundary_range : Module.finrank (ZMod 2) (LinearMap.range (toricDualBoundary L)) = Module.finrank (ZMod 2) (LinearMap.range (toricBoundary2 (L := L))) := by
     have h_dual_boundary : LinearMap.rank (toricDualBoundary L) = LinearMap.rank (toricBoundary2 (L := L)) := by
       have h_dual_boundary : (toricDualBoundary L).toMatrix' = (toricBoundary2 (L := L)).toMatrix'.transpose := by
@@ -248,7 +248,7 @@ theorem toric_finrank_dualCycles :
       simp +decide [ ← Module.finrank_eq_rank ];
       convert Iff.rfl;
       all_goals ext; simp +decide [ LinearMap.toMatrix' ];
-    simp +decide [ Module.finrank, Cardinal.mk_fintype ];
+    simp +decide [ Module.finrank ];
     grind +splitImp;
   have := toric_finrank_boundaries ( L := L ) ; simp_all +decide [ mul_assoc ] ;
   linarith! [ Nat.sub_add_cancel ( show 1 ≤ L * L from Nat.mul_pos ( Fact.out ) ( Fact.out ) ) ]

--- a/QEC/Stabilizer/Lattice/ToricLogicalCorrespondenceZ.lean
+++ b/QEC/Stabilizer/Lattice/ToricLogicalCorrespondenceZ.lean
@@ -282,8 +282,7 @@ theorem faceCheckCommutes_iff_dualBoundaryAt
     clear hfilt_eq hanti_iff
     split_ifs <;>
       simp_all +decide [Finset.filter_eq', Finset.filter_or, Finset.card_insert_of_notMem,
-        Finset.mem_insert, Finset.mem_singleton,
-        hd1, hd2, hd3, hd4, hd5, hd6, hd1', hd2', hd3', hd4', hd5', hd6']
+        Finset.mem_insert, Finset.mem_singleton]
   -- Parity bridge: even indicator sum ↔ ZMod 2 sum = 0
   have hbridge : ∀ (a b c d : ZMod 2),
       Even (((if a = 1 then 1 else 0) + (if b = 1 then 1 else 0) +
@@ -413,7 +412,7 @@ lemma toricZOperatorOfChain_cutMap_singleVtx (L : ℕ) [Fact (2 ≤ L)]
     rcases e with ⟨ex, ey⟩ | ⟨ex, ey⟩
     · -- h-edge case: cutMap (singleVtx (xv,yv)) at h(ex,ey) = 1 means
       -- ((ex,ey) = (xv,yv)) XOR (next L ex = xv ∧ ey = yv)
-      simp only [toricVertexCutMap, singleVtx] at he
+      simp only [toricVertexCutMap] at he
       have hxL : (xv : ℕ) < L := xv.isLt
       have hyL : (yv : ℕ) < L := yv.isLt
       have hexL : (ex : ℕ) < L := ex.isLt
@@ -441,7 +440,7 @@ lemma toricZOperatorOfChain_cutMap_singleVtx (L : ℕ) [Fact (2 ≤ L)]
           simp [h1, h2] at he
     · -- v-edge case: cutMap (singleVtx (xv,yv)) at v(ex,ey) = 1 means
       -- ((ex,ey) = (xv,yv)) XOR (ex = xv ∧ next L ey = yv)
-      simp only [toricVertexCutMap, singleVtx] at he
+      simp only [toricVertexCutMap] at he
       have hxL : (xv : ℕ) < L := xv.isLt
       have hyL : (yv : ℕ) < L := yv.isLt
       have hexL : (ex : ℕ) < L := ex.isLt
@@ -474,14 +473,14 @@ lemma toricZOperatorOfChain_cutMap_singleVtx (L : ℕ) [Fact (2 ≤ L)]
       · have hne : (StabilizerGroup.ToricCodeN.prev L yv) ≠ yv :=
           Stabilizer.Lattice.prev_ne_self L yv
         simp [toricVertexCutMap, singleVtx, StabilizerGroup.ToricCodeN.prev,
-          Stabilizer.Lattice.next_prev, hne, hne.symm]
+          Stabilizer.Lattice.next_prev, hne]
     · rename_i h₁ h₂ h₃
       contrapose! h₁
       refine ⟨EdgeIdx.v xv yv, ?_, ?_⟩
       · rfl
       · have hne : StabilizerGroup.ToricCodeN.next L yv ≠ yv :=
           Stabilizer.Lattice.next_ne_self L yv
-        simp [toricVertexCutMap, singleVtx, hne, hne.symm]
+        simp [toricVertexCutMap, singleVtx, hne]
     · rename_i h₁ h₂ h₃ h₄
       contrapose! h₁
       refine ⟨EdgeIdx.h (StabilizerGroup.ToricCodeN.prev L xv) yv, ?_, ?_⟩
@@ -489,14 +488,14 @@ lemma toricZOperatorOfChain_cutMap_singleVtx (L : ℕ) [Fact (2 ≤ L)]
       · have hne : (StabilizerGroup.ToricCodeN.prev L xv) ≠ xv :=
           Stabilizer.Lattice.prev_ne_self L xv
         simp [toricVertexCutMap, singleVtx, StabilizerGroup.ToricCodeN.prev,
-          Stabilizer.Lattice.next_prev, hne, hne.symm]
+          Stabilizer.Lattice.next_prev, hne]
     · rename_i h₁ h₂ h₃ h₄ h₅
       contrapose! h₁
       refine ⟨EdgeIdx.h xv yv, ?_, ?_⟩
       · rfl
       · have hne : StabilizerGroup.ToricCodeN.next L xv ≠ xv :=
           Stabilizer.Lattice.next_ne_self L xv
-        simp [toricVertexCutMap, singleVtx, hne, hne.symm]
+        simp [toricVertexCutMap, singleVtx, hne]
     · unfold NQubitPauliOperator.identity; aesop
 
 /-- Z-chain is a star product iff the chain is a dual boundary. -/
@@ -533,9 +532,9 @@ theorem zIsStarProduct_iff_mem_toricDualBoundaries (L : ℕ) [Fact (2 ≤ L)] (c
     simp only [map_sum]
     induction' (Finset.univ.filter fun v : VtxIdx L => s v = 1) using Finset.induction
       with a fs ha ih
-    · simp only [Finset.sum_empty, map_zero, toricZOperatorOfChain_zero]
+    · simp only [Finset.sum_empty, toricZOperatorOfChain_zero]
       exact OneMemClass.one_mem _
-    · simp only [Finset.sum_insert ha, map_add, toricZOperatorOfChain_add]
+    · simp only [Finset.sum_insert ha, toricZOperatorOfChain_add]
       exact Subgroup.mul_mem _
         (by rcases a with ⟨xv, yv⟩
             rw [toricZOperatorOfChain_cutMap_singleVtx]

--- a/QEC/Stabilizer/PauliGroup/Commutation.lean
+++ b/QEC/Stabilizer/PauliGroup/Commutation.lean
@@ -219,7 +219,7 @@ lemma commutes_iff_even_anticommutes (p q : NQubitPauliGroupElement n) :
         erw [ Fin.val_mk ];
         induction Exists.choose (even_iff_two_dvd.mp h_even) with
         | zero => simp_all [nsmulRec];
-        | succ k ih => simp_all [Nat.mul_succ, nsmulRec];  omega
+        | succ k ih => simp_all [nsmulRec];  omega
     exact (commutes_iff_mulOp_phasePower p q).mpr h_cancel
 
 /-!
@@ -304,7 +304,7 @@ lemma anticommutes_iff_odd_anticommutes (p q : NQubitPauliGroupElement n) :
       erw [ Fin.val_mk ] at * ; simp_all ;
       erw [ show ( nsmulRec ( 2 * k ) 2 : Fin 4 ) = 0 from
       by exact Nat.recOn k ( by rfl ) fun n ihn => by simp_all
-      [ Nat.mul_succ, nsmulRec ] ] at * ;
+      [ nsmulRec ] ] at * ;
       simp_all
     convert h_odd using 4
   · intro h_odd
@@ -331,7 +331,7 @@ lemma anticommutes_iff_odd_anticommutes (p q : NQubitPauliGroupElement n) :
     2 then 1 else 0 ) 2 ] ; simp_all ;
     simp_all  [ Fin.ext_iff, Quantum.NQubitPauliGroupElement.anticommutesAt ];
     erw [ Fin.val_mk ];
-    induction ( Finset.card _ / 2 ) <;> simp_all  [ Nat.mul_succ, nsmulRec ];
+    induction ( Finset.card _ / 2 ) <;> simp_all  [ nsmulRec ];
     simp_all  [ Fin.val_add]
 
 /-- Symmetry of anticommutation: if P anticommutes with Q, then Q anticommutes with P. -/


### PR DESCRIPTION
## Summary

PR 2 of 10 in the linter-cleanup plan.

Removes 41 named simp/simp_all arguments flagged by `linter.unusedSimpArgs` as not firing during simplification.

| File | Removed |
|------|---------|
| `ToricLogicalCorrespondenceZ.lean` | 20: `hd1..hd6`, `hd1'..hd6'`, `singleVtx` (×2), `hne.symm` (×4), `map_zero`, `map_add` |
| `ToricDualWrappingInvariants.lean` | 8: `Finset.sum_add_distrib`, `Finset.mul_sum`, `Finset.sum_mul`, `Finset.sum_ite`, `Finset.filter_eq'`, `Finset.filter_ne'`, `toric_finrank_C1`, `Cardinal.mk_fintype` |
| `LogicalCorrespondence.lean` | 4: `Pi.single_apply` (×4) |
| `PauliGroup/Commutation.lean` | 3: `Nat.mul_succ` (×3) |
| `ToricCodeNStabilizerCode.lean` | 3: `numQubits`, `Fin.ext_iff`, `Nat.add_sub_cancel_left` |
| `ToricCodeNDistance.lean` | 3: `two_mul`, `hgi` (×2) |

Note: the cluster of distinctness hypotheses (`hd1..hd6'`) in `ToricLogicalCorrespondenceZ.lean` matches a pattern from CLAUDE.md ("pass both directions of every distinctness hypothesis"), but `simp_all` now picks them up from context automatically, making the explicit listing redundant.

## Verification

- `lake build` succeeds.
- Warning count: **627 → 584** (drop of 43: all 41 `unusedSimpArgs` eliminated, plus 2 `longLine` bonuses from shorter simp lists).
- `linter.unusedSimpArgs` count: **41 → 0**.

## Test plan

- [x] `lake build` clean
- [x] `grep -c "linter.unusedSimpArgs" build.log` == 0
- [x] No new warning category introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)