### PR TITLE
chore(lint): wrap 40 lines exceeding the 100-char limit

### DIFF
--- a/QEC/Stabilizer/Codes/ToricCodeNStabilizerCode.lean
+++ b/QEC/Stabilizer/Codes/ToricCodeNStabilizerCode.lean
@@ -595,7 +595,8 @@ private lemma toricXZ_commute_of_disjoint_supports (L : ℕ) [Fact (0 < L)]
         Stabilizer.Lattice.toricXOperatorOfChain L cX := by
   apply NQubitPauliGroupElement.commutes_of_componentwise_commutes
   intro q
-  rw [Stabilizer.Lattice.toricXOperatorOfChain_op_at, Stabilizer.Lattice.toricZOperatorOfChain_op_at]
+  rw [Stabilizer.Lattice.toricXOperatorOfChain_op_at,
+    Stabilizer.Lattice.toricZOperatorOfChain_op_at]
   by_cases hX : ∃ e, Stabilizer.Lattice.edgeToQubitIdx L e = q ∧ cX e = 1
   · by_cases hZ : ∃ e, Stabilizer.Lattice.edgeToQubitIdx L e = q ∧ cZ e = 1
     · -- both X and Z at q: derive contradiction from disjoint supports
@@ -661,7 +662,8 @@ private theorem horizontalLoopX_anticommute_horizontalHRowZ (L : ℕ) [Fact (2 �
     simp only [Finset.mem_filter, Finset.mem_singleton, Finset.mem_univ, true_and]
     unfold NQubitPauliGroupElement.anticommutesAt
     unfold horizontalLoopXOperator horizontalHRowZOperator
-    rw [Stabilizer.Lattice.toricXOperatorOfChain_op_at, Stabilizer.Lattice.toricZOperatorOfChain_op_at]
+    rw [Stabilizer.Lattice.toricXOperatorOfChain_op_at,
+      Stabilizer.Lattice.toricZOperatorOfChain_op_at]
     by_cases hX : ∃ e, Stabilizer.Lattice.edgeToQubitIdx L e = q ∧ horizontalLoopChain L e = 1
     · by_cases hZ : ∃ e, Stabilizer.Lattice.edgeToQubitIdx L e = q ∧
           horizontalHRowChain L e = 1
@@ -726,7 +728,8 @@ private theorem verticalLoopX_anticommute_verticalVRowZ (L : ℕ) [Fact (2 ≤ L
     simp only [Finset.mem_filter, Finset.mem_singleton, Finset.mem_univ, true_and]
     unfold NQubitPauliGroupElement.anticommutesAt
     unfold verticalLoopXOperator verticalVRowZOperator
-    rw [Stabilizer.Lattice.toricXOperatorOfChain_op_at, Stabilizer.Lattice.toricZOperatorOfChain_op_at]
+    rw [Stabilizer.Lattice.toricXOperatorOfChain_op_at,
+      Stabilizer.Lattice.toricZOperatorOfChain_op_at]
     by_cases hX : ∃ e, Stabilizer.Lattice.edgeToQubitIdx L e = q ∧ verticalLoopChain L e = 1
     · by_cases hZ : ∃ e, Stabilizer.Lattice.edgeToQubitIdx L e = q ∧
           verticalVRowChain L e = 1
@@ -1248,7 +1251,8 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
           (Finset.univ.filter (fun k => ¬ k.val < nZ)) := by
         rw [Finset.filter_union_filter_not_eq]
       have hdisj : Disjoint
-          ((Finset.univ : Finset (Fin (generatorsListPackaged L).length)).filter (fun k => k.val < nZ))
+          ((Finset.univ : Finset (Fin (generatorsListPackaged L).length)).filter
+            (fun k => k.val < nZ))
           (Finset.univ.filter (fun k => ¬ k.val < nZ)) :=
         Finset.disjoint_filter_filter_not _ _ _
       rw [hpartition, Finset.sum_union hdisj]
@@ -1357,7 +1361,8 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
           (Finset.univ.filter (fun k => ¬ k.val < nZ)) := by
         rw [Finset.filter_union_filter_not_eq]
       have hdisj : Disjoint
-          ((Finset.univ : Finset (Fin (generatorsListPackaged L).length)).filter (fun k => k.val < nZ))
+          ((Finset.univ : Finset (Fin (generatorsListPackaged L).length)).filter
+            (fun k => k.val < nZ))
           (Finset.univ.filter (fun k => ¬ k.val < nZ)) :=
         Finset.disjoint_filter_filter_not _ _ _
       rw [hpartition, Finset.sum_union hdisj]

--- a/QEC/Stabilizer/Lattice/ToricDualWrappingInvariants.lean
+++ b/QEC/Stabilizer/Lattice/ToricDualWrappingInvariants.lean
@@ -74,51 +74,76 @@ theorem hRowAt_independent_on_dualCycles (c : toricDualCycles (L := L)) (y0 y1 :
     exact c.2;
   have h_row_eq : ∀ y : Fin L, hRowAt L y c.1 + hRowAt L (next L y) c.1 = 0 := by
     intro y
-    have h_sum_zero : ∑ x : Fin L, (c.val (EdgeIdx.h x y) + c.val (EdgeIdx.h x (next L y)) + c.val (EdgeIdx.v x y) + c.val (EdgeIdx.v (next L x) y)) = 0 := by
-      convert congr_arg ( fun f : FaceIdx L → ZMod 2 => ∑ x : Fin L, f ( x, y ) ) h_dual_boundary_zero using 1;
+    have h_sum_zero : ∑ x : Fin L,
+        (c.val (EdgeIdx.h x y) + c.val (EdgeIdx.h x (next L y)) +
+          c.val (EdgeIdx.v x y) + c.val (EdgeIdx.v (next L x) y)) = 0 := by
+      convert congr_arg
+        ( fun f : FaceIdx L → ZMod 2 => ∑ x : Fin L, f ( x, y ) )
+        h_dual_boundary_zero using 1;
       norm_num;
-    have h_sum_zero : ∑ x : Fin L, c.val (EdgeIdx.v x y) = ∑ x : Fin L, c.val (EdgeIdx.v (next L x) y) := by
+    have h_sum_zero :
+        ∑ x : Fin L, c.val (EdgeIdx.v x y) =
+          ∑ x : Fin L, c.val (EdgeIdx.v (next L x) y) := by
       rcases L with ( _ | _ | L ) <;> norm_num at *;
       · fin_cases y ; rfl;
       · rw [ ← Equiv.sum_comp ( Equiv.addRight 1 ) ] ; norm_num [ Fin.add_def, next ];
     simp_all +decide [ Finset.sum_add_distrib, hRowAt ];
     grind;
   -- By induction on $k$, we can show that $hRowAt L y c = hRowAt L (y + k) c$ for any $k$.
-  have h_induction : ∀ k : ℕ, ∀ y : Fin L, hRowAt L y c.1 = hRowAt L (Fin.mk ((y.val + k) % L) (Nat.mod_lt _ (Fact.out))) c.1 := by
+  have h_induction : ∀ k : ℕ, ∀ y : Fin L,
+      hRowAt L y c.1 =
+        hRowAt L (Fin.mk ((y.val + k) % L) (Nat.mod_lt _ (Fact.out))) c.1 := by
     intro k y; induction' k with k ih <;> simp_all +decide [ ← add_assoc, Nat.mod_eq_of_lt ] ;
-    specialize h_row_eq ⟨ ( y + k ) % L, Nat.mod_lt _ ( Fact.out ) ⟩ ; simp_all +decide [ ← eq_sub_iff_add_eq', next ] ;
+    specialize h_row_eq ⟨ ( y + k ) % L, Nat.mod_lt _ ( Fact.out ) ⟩ ;
+    simp_all +decide [ ← eq_sub_iff_add_eq', next ] ;
   convert h_induction ( y1.val + L - y0.val ) y0 using 1;
-  simp +decide [ add_tsub_cancel_of_le ( show ( y0 : ℕ ) ≤ y1 + L from by linarith [ Fin.is_lt y0, Fin.is_lt y1 ] ), Nat.mod_eq_of_lt ]
+  simp +decide [ add_tsub_cancel_of_le
+    ( show ( y0 : ℕ ) ≤ y1 + L from by linarith [ Fin.is_lt y0, Fin.is_lt y1 ] ),
+    Nat.mod_eq_of_lt ]
 
 /-
 `vColAt` is independent of the chosen column on dual cycles.
 -/
 theorem vColAt_independent_on_dualCycles (c : toricDualCycles (L := L)) (x0 x1 : Fin L) :
     vColAt (L := L) x0 c.1 = vColAt (L := L) x1 c.1 := by
-  have hvColAt_linear : ∀ x : Fin L, vColAt (L := L) x c.1 + vColAt (L := L) (next L x) c.1 = 0 := by
+  have hvColAt_linear : ∀ x : Fin L,
+      vColAt (L := L) x c.1 + vColAt (L := L) (next L x) c.1 = 0 := by
     intro x
-    have h_sum : ∑ y : Fin L, (c.val (EdgeIdx.h x y) + c.val (EdgeIdx.h x (next L y)) + c.val (EdgeIdx.v x y) + c.val (EdgeIdx.v (next L x) y)) = 0 := by
-      have h_sum : ∀ y : Fin L, c.val (EdgeIdx.h x y) + c.val (EdgeIdx.h x (next L y)) + c.val (EdgeIdx.v x y) + c.val (EdgeIdx.v (next L x) y) = 0 := by
+    have h_sum : ∑ y : Fin L,
+        (c.val (EdgeIdx.h x y) + c.val (EdgeIdx.h x (next L y)) +
+          c.val (EdgeIdx.v x y) + c.val (EdgeIdx.v (next L x) y)) = 0 := by
+      have h_sum : ∀ y : Fin L,
+          c.val (EdgeIdx.h x y) + c.val (EdgeIdx.h x (next L y)) +
+            c.val (EdgeIdx.v x y) + c.val (EdgeIdx.v (next L x) y) = 0 := by
         intro y
         have := c.2
         simp [toricDualCycles] at this;
         convert congr_arg ( fun f : C2 L => f ( x, y ) ) c.2 using 1;
       exact Finset.sum_eq_zero fun y _ => h_sum y;
     simp_all +decide [ Finset.sum_add_distrib, vColAt ];
-    have h_sum_h : ∑ y : Fin L, c.val (EdgeIdx.h x y) = ∑ y : Fin L, c.val (EdgeIdx.h x (next L y)) := by
+    have h_sum_h :
+        ∑ y : Fin L, c.val (EdgeIdx.h x y) =
+          ∑ y : Fin L, c.val (EdgeIdx.h x (next L y)) := by
       rcases L with ( _ | _ | L ) <;> simp_all +decide [ next ];
-      rw [ ← Equiv.sum_comp ( Equiv.addRight 1 ) ] ; norm_num [ Fin.add_def, Nat.mod_eq_of_lt ];
+      rw [ ← Equiv.sum_comp ( Equiv.addRight 1 ) ] ;
+      norm_num [ Fin.add_def, Nat.mod_eq_of_lt ];
     grind;
   -- By induction on $k$, we can show that $vColAt x = vColAt (x + k)$ for any $k$.
-  have hvColAt_induction : ∀ k : ℕ, ∀ x : Fin L, vColAt (L := L) x c.1 = vColAt (L := L) (Nat.rec x (fun _ x => next L x) k) c.1 := by
+  have hvColAt_induction : ∀ k : ℕ, ∀ x : Fin L,
+      vColAt (L := L) x c.1 =
+        vColAt (L := L) (Nat.rec x (fun _ x => next L x) k) c.1 := by
     intro k x; induction k <;> simp_all +decide [ ← eq_sub_iff_add_eq' ] ;
-  -- By induction on $k$, we can show that $vColAt x = vColAt (x + k)$ for any $k$. Hence, $vColAt x0 = vColAt x1$.
+  -- By induction on $k$, we can show that $vColAt x = vColAt (x + k)$ for any $k$.
+  -- Hence, $vColAt x0 = vColAt x1$.
   have hvColAt_eq : ∃ k : ℕ, Nat.rec x0 (fun _ x => next L x) k = x1 := by
     use (x1.val + L - x0.val) % L;
-    have hvColAt_eq : ∀ k : ℕ, Nat.rec x0 (fun _ x => next L x) k = Fin.mk ((x0.val + k) % L) (Nat.mod_lt _ (Fact.out : 0 < L)) := by
+    have hvColAt_eq : ∀ k : ℕ,
+        Nat.rec x0 (fun _ x => next L x) k =
+          Fin.mk ((x0.val + k) % L) (Nat.mod_lt _ (Fact.out : 0 < L)) := by
       intro k; induction k <;> simp_all +decide [ Nat.mod_eq_of_lt, Fin.ext_iff, next ] ;
       ring;
-    simp +decide [ hvColAt_eq, Nat.add_sub_of_le ( show ( x0 : ℕ ) ≤ x1 + L from by linarith [ Fin.is_lt x0, Fin.is_lt x1 ] ) ];
+    simp +decide [ hvColAt_eq, Nat.add_sub_of_le
+      ( show ( x0 : ℕ ) ≤ x1 + L from by linarith [ Fin.is_lt x0, Fin.is_lt x1 ] ) ];
     exact Fin.ext ( Nat.mod_eq_of_lt x1.2 );
   exact hvColAt_eq.elim fun k hk => hvColAt_induction k x0 ▸ hk ▸ rfl
 
@@ -165,7 +190,8 @@ theorem vColAt_dualBoundary_zero (b : toricDualBoundaries (L := L)) :
 -- ---------------------------------------------------------------------------
 
 /-- Dual homology quotient: toricDualCycles / toricDualBoundaries (as submodule in cycles). -/
-noncomputable abbrev toricDualBoundarySubmoduleInCycles : Submodule (ZMod 2) (toricDualCycles (L := L)) :=
+noncomputable abbrev toricDualBoundarySubmoduleInCycles :
+    Submodule (ZMod 2) (toricDualCycles (L := L)) :=
   Submodule.comap (toricDualCycles (L := L)).subtype (toricDualBoundaries (L := L))
 
 /-- The dual H¹ quotient type. -/
@@ -211,14 +237,27 @@ theorem phiDual_surjective :
   intro p
   obtain ⟨a, b⟩ := p
   generalize_proofs at *;
-  obtain ⟨c, hc⟩ : ∃ c : toricDualCycles (L := L), hRowAt (L := L) (zeroCoord L) c.1 = a ∧ vColAt (L := L) (zeroCoord L) c.1 = b := by
+  obtain ⟨c, hc⟩ : ∃ c : toricDualCycles (L := L),
+      hRowAt (L := L) (zeroCoord L) c.1 = a ∧
+        vColAt (L := L) (zeroCoord L) c.1 = b := by
     -- Define the chain $c$ such that it has $a$ horizontal edges and $b$ vertical edges.
-    obtain ⟨c, hc⟩ : ∃ c : C1 L, (∑ x : Fin L, c (EdgeIdx.h x (zeroCoord L))) = a ∧ (∑ y : Fin L, c (EdgeIdx.v (zeroCoord L) y)) = b := by
-      refine' ⟨ fun e => if e = EdgeIdx.h ( zeroCoord L ) ( zeroCoord L ) then a else if e = EdgeIdx.v ( zeroCoord L ) ( zeroCoord L ) then b else 0, _, _ ⟩ <;> simp +decide
+    obtain ⟨c, hc⟩ : ∃ c : C1 L,
+        (∑ x : Fin L, c (EdgeIdx.h x (zeroCoord L))) = a ∧
+          (∑ y : Fin L, c (EdgeIdx.v (zeroCoord L) y)) = b := by
+      refine' ⟨ fun e =>
+        if e = EdgeIdx.h ( zeroCoord L ) ( zeroCoord L ) then a
+        else if e = EdgeIdx.v ( zeroCoord L ) ( zeroCoord L ) then b else 0, _, _ ⟩ <;>
+        simp +decide
     generalize_proofs at *; (
     -- Define the chain $c'$ such that it has $a$ horizontal edges and $b$ vertical edges.
-    obtain ⟨c', hc'⟩ : ∃ c' : C1 L, (∀ x y, c' (EdgeIdx.h x y) = c (EdgeIdx.h x (zeroCoord L))) ∧ (∀ x y, c' (EdgeIdx.v x y) = c (EdgeIdx.v (zeroCoord L) y)) ∧ (∀ p : FaceIdx L, toricDualBoundary L c' p = 0) := by
-      refine' ⟨ fun e => match e with | EdgeIdx.h x y => c ( EdgeIdx.h x ( zeroCoord L ) ) | EdgeIdx.v x y => c ( EdgeIdx.v ( zeroCoord L ) y ), _, _, _ ⟩ <;> simp +decide [ toricDualBoundary ];
+    obtain ⟨c', hc'⟩ : ∃ c' : C1 L,
+        (∀ x y, c' (EdgeIdx.h x y) = c (EdgeIdx.h x (zeroCoord L))) ∧
+          (∀ x y, c' (EdgeIdx.v x y) = c (EdgeIdx.v (zeroCoord L) y)) ∧
+            (∀ p : FaceIdx L, toricDualBoundary L c' p = 0) := by
+      refine' ⟨ fun e => match e with
+        | EdgeIdx.h x y => c ( EdgeIdx.h x ( zeroCoord L ) )
+        | EdgeIdx.v x y => c ( EdgeIdx.v ( zeroCoord L ) y ), _, _, _ ⟩ <;>
+        simp +decide [ toricDualBoundary ];
       grind +ring
     generalize_proofs at *; (
     use ⟨c', by
@@ -233,15 +272,24 @@ Dimension of the dual cycle space.
 -/
 theorem toric_finrank_dualCycles :
     Module.finrank (ZMod 2) (toricDualCycles (L := L)) = L * L + 1 := by
-  have := LinearMap.finrank_range_add_finrank_ker ( toricDualBoundary L ) ; simp_all +decide ;
-  have h_dual_boundary_range : Module.finrank (ZMod 2) (LinearMap.range (toricDualBoundary L)) = Module.finrank (ZMod 2) (LinearMap.range (toricBoundary2 (L := L))) := by
-    have h_dual_boundary : LinearMap.rank (toricDualBoundary L) = LinearMap.rank (toricBoundary2 (L := L)) := by
-      have h_dual_boundary : (toricDualBoundary L).toMatrix' = (toricBoundary2 (L := L)).toMatrix'.transpose := by
+  have := LinearMap.finrank_range_add_finrank_ker ( toricDualBoundary L ) ;
+  simp_all +decide ;
+  have h_dual_boundary_range :
+      Module.finrank (ZMod 2) (LinearMap.range (toricDualBoundary L)) =
+        Module.finrank (ZMod 2) (LinearMap.range (toricBoundary2 (L := L))) := by
+    have h_dual_boundary :
+        LinearMap.rank (toricDualBoundary L) =
+          LinearMap.rank (toricBoundary2 (L := L)) := by
+      have h_dual_boundary :
+          (toricDualBoundary L).toMatrix' =
+            (toricBoundary2 (L := L)).toMatrix'.transpose := by
         ext ⟨x, y⟩ e; simp [LinearMap.toMatrix', toricDualBoundary, toricBoundary2];
         cases e <;> simp +decide [ Pi.single_apply ];
         · grind;
         · grind +splitImp
-      have h_dual_boundary : Matrix.rank (toricDualBoundary L).toMatrix' = Matrix.rank (toricBoundary2 (L := L)).toMatrix' := by
+      have h_dual_boundary :
+          Matrix.rank (toricDualBoundary L).toMatrix' =
+            Matrix.rank (toricBoundary2 (L := L)).toMatrix' := by
         rw [ h_dual_boundary, Matrix.rank_transpose ];
       convert h_dual_boundary using 1;
       simp +decide [ Matrix.rank, LinearMap.rank ];
@@ -259,7 +307,8 @@ Dimension of the dual boundary space.
 theorem toric_finrank_dualBoundaries :
     Module.finrank (ZMod 2) (toricDualBoundaries (L := L)) = L * L - 1 := by
   -- By definition of `toricDualBoundaries`, we know that it is the range of the vertex cut map.
-  have h_dualBoundaries_range : toricDualBoundaries L = LinearMap.range (toricVertexCutMap (L := L)) := by
+  have h_dualBoundaries_range :
+      toricDualBoundaries L = LinearMap.range (toricVertexCutMap (L := L)) := by
     exact rfl;
   rw [ h_dualBoundaries_range ];
   have := LinearMap.finrank_range_add_finrank_ker ( toricVertexCutMap ( L := L ) );
@@ -303,18 +352,30 @@ theorem phiDual_eq_phiDualLinearMap (x : toricDualH1 (L := L)) :
 theorem phiDual_injective :
     Function.Injective (phiDual (L := L)) := by
   have h_finrank : Module.finrank (ZMod 2) (toricDualH1 (L := L)) = 2 := by
-    have h_finrank : Module.finrank (ZMod 2) (toricDualCycles (L := L)) - Module.finrank (ZMod 2) (toricDualBoundaries (L := L)) = 2 := by
+    have h_finrank :
+        Module.finrank (ZMod 2) (toricDualCycles (L := L)) -
+          Module.finrank (ZMod 2) (toricDualBoundaries (L := L)) = 2 := by
       rw [ toric_finrank_dualCycles, toric_finrank_dualBoundaries ];
-      exact Nat.sub_eq_of_eq_add <| by linarith [ Nat.sub_add_cancel <| show 1 ≤ L * L from Nat.mul_pos ( Fact.out ) ( Fact.out ) ] ;
-    have := Submodule.finrank_quotient_add_finrank ( Submodule.comap ( toricDualCycles ( L := L ) ).subtype ( toricDualBoundaries ( L := L ) ) );
+      exact Nat.sub_eq_of_eq_add <| by
+        linarith [ Nat.sub_add_cancel <|
+          show 1 ≤ L * L from Nat.mul_pos ( Fact.out ) ( Fact.out ) ] ;
+    have := Submodule.finrank_quotient_add_finrank
+      ( Submodule.comap ( toricDualCycles ( L := L ) ).subtype
+        ( toricDualBoundaries ( L := L ) ) );
     rw [ Nat.sub_eq_iff_eq_add ] at h_finrank;
-    · rw [ ← LinearEquiv.finrank_eq ( Submodule.comapSubtypeEquivOfLe ( show toricDualBoundaries ( L := L ) ≤ toricDualCycles ( L := L ) from by exact? ) ) ] at * ; linarith!;
+    · rw [ ← LinearEquiv.finrank_eq
+        ( Submodule.comapSubtypeEquivOfLe
+          ( show toricDualBoundaries ( L := L ) ≤ toricDualCycles ( L := L )
+            from by exact? ) ) ] at * ;
+      linarith!;
     · exact le_of_lt ( Nat.lt_of_sub_eq_succ h_finrank );
   have := @phiDual_surjective L ‹_›;
-  have h_finrank : Module.finrank (ZMod 2) (↥(LinearMap.range (phiDualLinearMap (L := L)))) = 2 := by
+  have h_finrank :
+      Module.finrank (ZMod 2) (↥(LinearMap.range (phiDualLinearMap (L := L)))) = 2 := by
     rw [ LinearMap.range_eq_top.mpr ] <;> norm_num [ this ];
     convert this using 1;
-  have := LinearMap.finrank_range_add_finrank_ker ( phiDualLinearMap ( L := L ) ) ; simp_all +decide ;
+  have := LinearMap.finrank_range_add_finrank_ker ( phiDualLinearMap ( L := L ) ) ;
+  simp_all +decide ;
   convert LinearMap.ker_eq_bot.mp this using 1
 
 /-
@@ -322,7 +383,8 @@ theorem phiDual_injective :
 -/
 theorem phiDual_equiv :
     ∃ _ : toricDualH1 (L := L) ≃ₗ[ZMod 2] (ZMod 2 × ZMod 2), True := by
-  use (LinearEquiv.ofBijective (phiDualLinearMap (L := L)) ⟨phiDual_injective (L := L), phiDual_surjective (L := L)⟩)
+  use (LinearEquiv.ofBijective (phiDualLinearMap (L := L))
+    ⟨phiDual_injective (L := L), phiDual_surjective (L := L)⟩)
 
 end Lattice
 end Stabilizer

--- a/QEC/Stabilizer/Lattice/ToricLogicalCorrespondenceZ.lean
+++ b/QEC/Stabilizer/Lattice/ToricLogicalCorrespondenceZ.lean
@@ -644,7 +644,8 @@ private lemma zTypeOps_in_stabilizer_has_phase_zero
           cases hsi with
           | inl h => simp [PauliOperator.mulOp] at h
           | inr h => simp [PauliOperator.mulOp] at h
-    exact NQubitPauliGroupElement.ext x 1 hx_ty.1 (by ext i; simp [NQubitPauliOperator.identity, hx_ops_I i])
+    exact NQubitPauliGroupElement.ext x 1 hx_ty.1
+      (by ext i; simp [NQubitPauliOperator.identity, hx_ops_I i])
   rw [hzx, hx_id, mul_one]
   exact hz_ty
 


### PR DESCRIPTION
## Summary

PR 3 of 10 in the linter-cleanup plan.

Pure mechanical reflow: each long line is split at a natural break point (after a comma, between operands, before \`:= by\`) with continuation indented relative to the opener. No semantic changes.

| File | Lines wrapped |
|------|---:|
| \`QEC/Stabilizer/Lattice/ToricDualWrappingInvariants.lean\` | 34 |
| \`QEC/Stabilizer/Codes/ToricCodeNStabilizerCode.lean\` | 5 |
| \`QEC/Stabilizer/Lattice/ToricLogicalCorrespondenceZ.lean\` | 1 |

## Verification

- \`lake build\` succeeds.
- Warning count: **606 → 566** (drop of 40, exactly matching expected count).
- \`linter.style.longLine\` count: **40 → 0**.

## Test plan

- [x] \`lake build\` clean
- [x] \`grep -c "linter.style.longLine" build.log\` == 0
- [x] No new warning category introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)