### PR TITLE
chore(lint): remove 14 empty lines inside commands

### DIFF
--- a/QEC/Foundations/Gates.lean
+++ b/QEC/Foundations/Gates.lean
@@ -268,7 +268,6 @@ macro_rules
 
 open Lean.Parser.Tactic in
 open Lean in
-
 /--
 `vec_expand`:
 - turns equality between vectors (functions) into pointwise goals with `ext`,

--- a/QEC/RepetitionCode/EncodeDecode.lean
+++ b/QEC/RepetitionCode/EncodeDecode.lean
@@ -124,16 +124,13 @@ lemma encodeVec_norm (v : QubitVec) :
               simp [Finset.sum_add_distrib]
         _ = ‖v 0‖ ^ 2 + ‖v 1‖ ^ 2 := by
               simp
-
     -- Now compute the RHS sum (over `Fin 2`).
     have hR :
         (∑ q : QubitBasis, ‖v q‖ ^ 2) = (‖v 0‖ ^ 2 + ‖v 1‖ ^ 2) := by
       -- `QubitBasis` is `Fin 2`.
       simp [QubitBasis, Fin.sum_univ_two]
-
     -- Combine.
     linarith [hL, hR]
-
   -- Finish by unfolding `norm` and rewriting the sum under the square root.
   simp [norm, hsum]
 

--- a/QEC/RepetitionCode/LogicalX.lean
+++ b/QEC/RepetitionCode/LogicalX.lean
@@ -103,7 +103,6 @@ lemma F_correct (v : QubitVec) :
   -- expand `v` in the {ket0, ket1} basis
   have hv : v = (v 0) • ket0.val + (v 1) • ket1.val := by
     simpa using qubitVec_eq_lincomb_kets (v := v)
-
   calc
     F v
         = F ((v 0) • ket0.val + (v 1) • ket1.val) := by

--- a/QEC/RepetitionCode/Recovery.lean
+++ b/QEC/RepetitionCode/Recovery.lean
@@ -241,18 +241,14 @@ lemma recoverVec_X_q1_3_encodeVec (v : QubitVec) :
   have henc : encodeVec v =
       (v 0) • basisVec (0,0,0) + (v 1) • basisVec (1,1,1) := by
     simpa using encodeVec_eq_lincomb (v := v)
-
   -- Define the linear operator G := recoverVec ∘ (X_q1_3.mulVec)
   let G : ThreeQubitVec → ThreeQubitVec :=
     fun w => recoverVec ((X_q1_3.val).mulVec w)
-
   -- Linearity of G (comes from linearity of mulVec and recoverVec)
   have G_add (w₁ w₂ : ThreeQubitVec) : G (w₁ + w₂) = G w₁ + G w₂ := by
     simp [G, Matrix.mulVec_add]
-
   have G_smul (a : ℂ) (w : ThreeQubitVec) : G (a • w) = a • G w := by
     simp [G, Matrix.mulVec_smul]
-
   -- Basis facts: G fixes |000⟩ and |111⟩ (these are the only generators we need)
   have G_basis_000 : G (basisVec (0,0,0)) = basisVec (0,0,0) := by
     -- X sends |000⟩ to |100⟩, then recoverVec sends |100⟩ back to |000⟩
@@ -262,7 +258,6 @@ lemma recoverVec_X_q1_3_encodeVec (v : QubitVec) :
     · by_cases h1 : ijk = (1,1,1)
       · simp [G, h1, maj1_amp]
       · simp [G, recoverVec, h0, h1]
-
   have G_basis_111 : G (basisVec (1,1,1)) = basisVec (1,1,1) := by
     -- X sends |111⟩ to |011⟩, then recoverVec sends |011⟩ back to |111⟩
     ext ijk
@@ -271,7 +266,6 @@ lemma recoverVec_X_q1_3_encodeVec (v : QubitVec) :
     · by_cases h1 : ijk = (1,1,1)
       · simp [G, h1, maj1_amp]
       · simp [G, recoverVec, h0, h1]
-
   -- Now finish by linearity: reduce to the two basis cases
   calc
     recoverVec ((X_q1_3.val).mulVec (encodeVec v))

--- a/QEC/Stabilizer/Codes/ToricCodeNDistanceX.lean
+++ b/QEC/Stabilizer/Codes/ToricCodeNDistanceX.lean
@@ -110,7 +110,6 @@ theorem horizontalLoopChain_edgeWeight_eq_L (L : ℕ) [Fact (2 ≤ L)] :
     _ = L := hcard
 
 /-- Section-8 upper-bound witness packaged as a nontrivial X logical of weight `L`. -/
-
 theorem exists_nontrivial_x_logical_weight_eq_L (L : ℕ) [Fact (2 ≤ L)] :
     ∃ g : NQubitPauliGroupElement (numQubits L),
       NQubitPauliGroupElement.IsXTypeElement g ∧

--- a/QEC/Stabilizer/PauliGroupSingle/Element.lean
+++ b/QEC/Stabilizer/PauliGroupSingle/Element.lean
@@ -76,7 +76,6 @@ theorem mul_assoc (p q r : PauliGroupElement) : (p * q) * r = p * (q * r) := by
   have h_op : ((p.operator.mulOp q.operator).operator.mulOp r.operator).operator =
               (p.operator.mulOp (q.operator.mulOp r.operator).operator).operator :=
     PauliOperator.mul_assoc_op p.operator q.operator r.operator
-
   have h_phase : ((p.phasePower + q.phasePower + (p.operator.mulOp q.operator).phasePower) +
                   r.phasePower +
                   ((p.operator.mulOp q.operator).operator.mulOp r.operator).phasePower) =
@@ -85,7 +84,6 @@ theorem mul_assoc (p q r : PauliGroupElement) : (p * q) * r = p * (q * r) := by
                   (p.operator.mulOp (q.operator.mulOp r.operator).operator).phasePower) := by
     simp [add_assoc, add_comm, add_left_comm]
     cases p.operator <;> cases q.operator <;> cases r.operator <;> simp
-
   apply PauliGroupElement.ext
   · exact h_phase
   · exact h_op


### PR DESCRIPTION
## Summary

PR 4 of 10 in the linter-cleanup plan.

Pure formatting: delete blank lines the linter flags as inside tactic blocks and command sequences. Comments remain intact, code semantics unchanged.

| File | Sites |
|------|---:|
| \`QEC/RepetitionCode/Recovery.lean\` | 6 |
| \`QEC/RepetitionCode/EncodeDecode.lean\` | 3 |
| \`QEC/Stabilizer/PauliGroupSingle/Element.lean\` | 2 |
| \`QEC/Foundations/Gates.lean\` | 1 |
| \`QEC/RepetitionCode/LogicalX.lean\` | 1 |
| \`QEC/Stabilizer/Codes/ToricCodeNDistanceX.lean\` | 1 |

## Verification

- \`lake build\` succeeds.
- Warning count: **606 → 592** (drop of 14, exactly matching expected count).
- \`linter.style.emptyLine\` count: **14 → 0**.

## Test plan

- [x] \`lake build\` clean
- [x] \`grep -c "do not place empty lines" build.log\` == 0
- [x] No new warning category introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)