### PR TITLE
chore(lint): clear 5 miscellaneous one-off warnings

### DIFF
--- a/QEC/Foundations/Tensor.lean
+++ b/QEC/Foundations/Tensor.lean
@@ -33,11 +33,8 @@ open Kronecker
 @[simp]
 theorem star_kron
   {α β : Type*}
-  [DecidableEq α] [Fintype α]
-  [DecidableEq β] [Fintype β]
   (a : Matrix α α ℂ) (b : Matrix β β ℂ) :
   star (a ⊗ₖ b) = (star a) ⊗ₖ (star b) := by
-  classical
   ext i j
   simp
 

--- a/QEC/Stabilizer/Codes/RotatedSurfaceCode3.lean
+++ b/QEC/Stabilizer/Codes/RotatedSurfaceCode3.lean
@@ -494,11 +494,13 @@ theorem no_weight_1_logical (g : NQubitPauliGroupElement 9)
   have h_cent := (IsNontrivialLogicalOperator_iff g stabilizerGroup).mp h_nontrivial |>.1
   exact weight_1_not_centralizer g hg h_cent
 
--- native_decide checks all (i,j,pi,pj) combinations: 9×8×3×3 = 648 cases,
--- each checking commutation with generators and existence of span coefficients.
+set_option linter.style.nativeDecide false in
 set_option maxRecDepth 16384 in
 set_option maxHeartbeats 4000000 in
--- The finite exhaustive search over weight-2 cases requires a large heartbeat budget.
+-- native_decide checks all (i,j,pi,pj) combinations: 9×8×3×3 = 648 cases,
+-- each checking commutation with generators and existence of span coefficients.
+-- We accept the compiler trust assumption here: this is a finite exhaustive check
+-- whose `decide` form would not terminate within any reasonable heartbeat budget.
 private lemma weight_2_pairs_span_coeffs :
     ∀ (i j : Fin 9), i ≠ j → ∀ (pi pj : PauliOperator), pi ≠ .I → pj ≠ .I →
     let op : NQubitPauliOperator 9 := fun k => if k = i then pi else if k = j then pj else .I

--- a/QEC/Stabilizer/Lattice/ToricDualWrappingInvariants.lean
+++ b/QEC/Stabilizer/Lattice/ToricDualWrappingInvariants.lean
@@ -54,11 +54,13 @@ variable [Fact (0 < L)]
 -- 2.  Independence on dual cycles
 -- ---------------------------------------------------------------------------
 
+omit [Fact (0 < L)] in
 /-- `hRowAt` is linear in the chain. -/
 theorem hRowAt_linear (y0 : Fin L) :
     ∀ c d : C1 L, hRowAt (L := L) y0 (c + d) = hRowAt (L := L) y0 c + hRowAt (L := L) y0 d := by
   intro c d; simp [hRowAt, Finset.sum_add_distrib]
 
+omit [Fact (0 < L)] in
 /-- `vColAt` is linear in the chain. -/
 theorem vColAt_linear (x0 : Fin L) :
     ∀ c d : C1 L, vColAt (L := L) x0 (c + d) = vColAt (L := L) x0 c + vColAt (L := L) x0 d := by


### PR DESCRIPTION
## Summary

PR 6 of 10 in the linter-cleanup plan. Four distinct linters that each fire once or twice.

| Site | Linter | Fix |
|------|--------|-----|
| \`Tensor.lean:33\` \`star_kron\` | \`unusedDecidableInType\` | Drop \`[DecidableEq α]\`, \`[DecidableEq β]\` (unused in type) |
| \`Tensor.lean:33\` \`star_kron\` | \`unusedFintypeInType\` | Drop \`[Fintype α]\`, \`[Fintype β]\` (unused in type) |
| \`ToricDualWrappingInvariants.lean:58\` \`hRowAt_linear\` | \`unusedSectionVars\` | \`omit [Fact (0 < L)] in\` |
| \`ToricDualWrappingInvariants.lean:63\` \`vColAt_linear\` | \`unusedSectionVars\` | \`omit [Fact (0 < L)] in\` |
| \`RotatedSurfaceCode3.lean:508\` \`weight_2_pairs_span_coeffs\` | \`style.nativeDecide\` | Locally suppress with \`set_option linter.style.nativeDecide false in\` and comment explaining why \`decide\` is non-viable for the 648-case finite check |

## Verification

- \`lake build\` succeeds.
- Warning count: **563 → 558** (drop of 5, exactly matching expected count).
- All four targeted linters reach 0.

## Test plan

- [x] \`lake build\` clean
- [x] No new warning category introduced
- [x] \`star_kron\` proof still goes through without the dropped instances

🤖 Generated with [Claude Code](https://claude.com/claude-code)