### PR TITLE
chore(lint): retire refine' at 14 sites

### DIFF
--- a/QEC/Stabilizer/Lattice/ToricDualWrappingInvariants.lean
+++ b/QEC/Stabilizer/Lattice/ToricDualWrappingInvariants.lean
@@ -246,9 +246,9 @@ theorem phiDual_surjective :
     obtain ⟨c, hc⟩ : ∃ c : C1 L,
         (∑ x : Fin L, c (EdgeIdx.h x (zeroCoord L))) = a ∧
           (∑ y : Fin L, c (EdgeIdx.v (zeroCoord L) y)) = b := by
-      refine' ⟨ fun e =>
+      refine ⟨ fun e =>
         if e = EdgeIdx.h ( zeroCoord L ) ( zeroCoord L ) then a
-        else if e = EdgeIdx.v ( zeroCoord L ) ( zeroCoord L ) then b else 0, _, _ ⟩ <;>
+        else if e = EdgeIdx.v ( zeroCoord L ) ( zeroCoord L ) then b else 0, ?_, ?_ ⟩ <;>
         simp +decide
     generalize_proofs at *; (
     -- Define the chain $c'$ such that it has $a$ horizontal edges and $b$ vertical edges.
@@ -256,9 +256,9 @@ theorem phiDual_surjective :
         (∀ x y, c' (EdgeIdx.h x y) = c (EdgeIdx.h x (zeroCoord L))) ∧
           (∀ x y, c' (EdgeIdx.v x y) = c (EdgeIdx.v (zeroCoord L) y)) ∧
             (∀ p : FaceIdx L, toricDualBoundary L c' p = 0) := by
-      refine' ⟨ fun e => match e with
+      refine ⟨ fun e => match e with
         | EdgeIdx.h x y => c ( EdgeIdx.h x ( zeroCoord L ) )
-        | EdgeIdx.v x y => c ( EdgeIdx.v ( zeroCoord L ) y ), _, _, _ ⟩ <;>
+        | EdgeIdx.v x y => c ( EdgeIdx.v ( zeroCoord L ) y ), ?_, ?_, ?_ ⟩ <;>
         simp +decide [ toricDualBoundary ];
       grind +ring
     generalize_proofs at *; (
@@ -315,7 +315,7 @@ theorem toric_finrank_dualBoundaries :
   rw [ h_dualBoundaries_range ];
   have := LinearMap.finrank_range_add_finrank_ker ( toricVertexCutMap ( L := L ) );
   rw [ show Module.finrank ( ZMod 2 ) ( C0 L ) = L * L from ?_ ] at this;
-  · refine' eq_tsub_of_add_eq _;
+  · refine eq_tsub_of_add_eq ?_;
     convert this;
     exact?;
   · simp +decide [ C0, Module.finrank ]

--- a/QEC/Stabilizer/Lattice/ToricH1Dimension.lean
+++ b/QEC/Stabilizer/Lattice/ToricH1Dimension.lean
@@ -158,10 +158,10 @@ theorem toric_rank_boundary1_eq_rank_cutMap :
   rw [ ← LinearMap.finrank_range_dualMap_eq_finrank_range ];
   fapply LinearEquiv.finrank_eq;
   symm;
-  refine' ( LinearEquiv.ofBijective _ ⟨ _, _ ⟩ );
-  refine' { .. };
-  refine' fun x => ⟨ _, _ ⟩;
-  refine' { toFun := fun c => ∑ e : EdgeIdx L, c e * x.val e, map_add' := _, map_smul' := _ };
+  refine LinearEquiv.ofBijective ?_ ⟨?_, ?_⟩;
+  refine { toFun := ?_, map_add' := ?_, map_smul' := ?_ };
+  refine fun x => ⟨?_, ?_⟩;
+  refine { toFun := fun c => ∑ e : EdgeIdx L, c e * x.val e, map_add' := ?_, map_smul' := ?_ };
   all_goals
     norm_num
       [funext_iff, Finset.sum_add_distrib, mul_add, add_mul, mul_assoc, mul_left_comm,
@@ -169,7 +169,7 @@ theorem toric_rank_boundary1_eq_rank_cutMap :
   any_goals intros; ext; simp +decide [ Finset.mul_sum _ _ _ ];
   all_goals norm_num [ Function.Injective, Function.Surjective ];
   · obtain ⟨ y, hy ⟩ := x.2;
-    refine' ⟨ _, _ ⟩;
+    refine ⟨?_, ?_⟩;
     exact ∑ v : VtxIdx L, y v • ( LinearMap.proj v );
     ext c; simp +decide [ ← hy ] ;
     convert toricBoundary1_cutMap_transpose L ( Pi.single c 1 ) y using 1;
@@ -179,8 +179,7 @@ theorem toric_rank_boundary1_eq_rank_cutMap :
     replace h := congr_fun h (fun y => if y = x then 1 else 0)
     aesop
   · intro a;
-    refine' ⟨ _, ⟨ _, rfl ⟩, _ ⟩;
-    exact fun v => a ( fun u => if u = v then 1 else 0 );
+    refine ⟨_, ⟨fun v => a (fun u => if u = v then 1 else 0), rfl⟩, ?_⟩;
     ext c; simp +decide ;
     convert (toricBoundary1_cutMap_transpose L (Pi.single c 1)
       (fun v => a (fun u => if u = v then 1 else 0))).symm using 1;

--- a/QEC/Stabilizer/Lattice/ToricLogicalCorrespondenceX.lean
+++ b/QEC/Stabilizer/Lattice/ToricLogicalCorrespondenceX.lean
@@ -222,7 +222,7 @@ theorem four_filter_card_eq_indicator_sum
       incidentQubitIdx2 L xv yv ≠ incidentQubitIdx3 L xv yv ∧
       incidentQubitIdx2 L xv yv ≠ incidentQubitIdx4 L xv yv ∧
       incidentQubitIdx3 L xv yv ≠ incidentQubitIdx4 L xv yv := by
-    refine' ⟨_, _, _, _, _, _⟩
+    refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩
       <;> intro h
       <;> simp_all +decide
         [Fin.ext_iff, StabilizerGroup.ToricCodeN.hEdge, StabilizerGroup.ToricCodeN.vEdge]
@@ -534,7 +534,7 @@ lemma toricXOperatorOfChain_mem_centralizer_iff_cycle
         fun h => by
           rw [StabilizerGroup.ToricCodeN.stabilizerGroup_toSubgroup_eq] at h
           exact h
-    refine' Subgroup.closure_induction ( fun x hx => _ ) _ _ _ h_closure;
+    refine Subgroup.closure_induction ( fun x hx => ?_ ) ?_ ?_ ?_ h_closure;
     · cases hx with
       | inl hx => exact h_comm x hx
       | inr hx =>
@@ -689,7 +689,7 @@ theorem xNontrivialLogical_iff_cycle_not_boundary (L : ℕ) [Fact (2 ≤ L)] (c 
       have h_in_stabilizer :
           toricXOperatorOfChain L c ∈
             (StabilizerGroup.ToricCodeN.stabilizerGroup L).toSubgroup := by
-        refine' Subgroup.closure_induction ( fun x hx => _ ) _ _ _ h_plaquette;
+        refine Subgroup.closure_induction ( fun x hx => ?_ ) ?_ ?_ ?_ h_plaquette;
         · exact Subgroup.subset_closure
             (by
               rw [StabilizerGroup.ToricCodeN.listToSet_generatorsList]

--- a/QEC/Stabilizer/Lattice/ToricLogicalCorrespondenceZ.lean
+++ b/QEC/Stabilizer/Lattice/ToricLogicalCorrespondenceZ.lean
@@ -589,7 +589,7 @@ lemma toricZOperatorOfChain_mem_centralizer_iff_dualCycle
         g ∈ Subgroup.closure (StabilizerGroup.ToricCodeN.generators L) := by
       rw [StabilizerGroup.ToricCodeN.stabilizerGroup_toSubgroup_eq] at hg
       exact hg
-    refine' Subgroup.closure_induction (fun x hx => _) _ _ _ h_closure
+    refine Subgroup.closure_induction (fun x hx => ?_) ?_ ?_ ?_ h_closure
     · cases hx with
       | inl hx =>
           obtain ⟨⟨xv, yv⟩, rfl⟩ := hx
@@ -754,7 +754,7 @@ theorem zNontrivialLogical_iff_dualCycle_not_dualBoundary
       have h_in_stab :
           toricZOperatorOfChain L c ∈
             (StabilizerGroup.ToricCodeN.stabilizerGroup L).toSubgroup := by
-        refine' Subgroup.closure_induction (fun x hx => _) _ _ _ h_star
+        refine Subgroup.closure_induction (fun x hx => ?_) ?_ ?_ ?_ h_star
         · exact Subgroup.subset_closure
             (by rw [StabilizerGroup.ToricCodeN.listToSet_generatorsList]
                 exact Set.mem_union_left _ hx)


### PR DESCRIPTION
## Summary

PR 8 of 10 in the linter-cleanup plan.

`refine'` is discouraged by `linter.style.refine`. This PR converts all **14** sites — no suppressions.

| File | Sites |
|------|---:|
| `QEC/Stabilizer/Lattice/ToricLogicalCorrespondenceX.lean` | 3 |
| `QEC/Stabilizer/Lattice/ToricLogicalCorrespondenceZ.lean` | 2 |
| `QEC/Stabilizer/Lattice/ToricDualWrappingInvariants.lean` | 3 |
| `QEC/Stabilizer/Lattice/ToricH1Dimension.lean` | 6 |

Most sites are a mechanical `_` → `?_` swap. The 6 sites inside `toric_rank_boundary1_eq_rank_cutMap` needed two small proof adjustments:

1. **`refine' { .. }` → explicit fields.** The record-builder shorthand becomes `refine { toFun := ?_, map_add' := ?_, map_smul' := ?_ }`, matching the pattern already used by `toricVertexCutMap` earlier in the same file.

2. **Surjectivity witness inlined.** The original `refine' ⟨ _, ⟨ _, rfl ⟩, _ ⟩; exact fun v => a (...)` relied on `refine'`'s lazy elaboration to thread the `_` slots so `rfl` could unify them after the fact. Under strict `refine` elaboration the `rfl` fires before the surrounding slots are filled, so the witness is inlined: `refine ⟨_, ⟨fun v => a (...), rfl⟩, ?_⟩`. The outer slot is then determined by unification through the inner `rfl`, and only the equation goal remains.

## Verification

- `lake build` clean.
- `linter.style.refine` count: **14 → 0**.
- No `set_option linter.style.refine false` anywhere in the tree.

## Test plan

- [x] `lake build` clean
- [x] `grep -c "linter.style.refine" build.log` == 0
- [x] No new warning category introduced
- [x] No localized suppression of the linter

🤖 Generated with [Claude Code](https://claude.com/claude-code)