### PR TITLE
fix(qh): wire QuantumHamming.lean into build graph, repair mathlib API

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "lean-lsp": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "lean-lsp-mcp"
+      ],
+      "env": {}
+    }
+  }
+}

--- a/QEC/Stabilizer/Codes.lean
+++ b/QEC/Stabilizer/Codes.lean
@@ -1,5 +1,6 @@
 import QEC.Stabilizer.Codes.RepetitionCode3
 import QEC.Stabilizer.Codes.RepetitionCodeN
+import QEC.Stabilizer.Codes.QuantumHamming
 import QEC.Stabilizer.Codes.RotatedSurfaceCode3
 import QEC.Stabilizer.Codes.ToricCode8
 import QEC.Stabilizer.Codes.ToricCodeN

--- a/QEC/Stabilizer/Codes/QuantumHamming.lean
+++ b/QEC/Stabilizer/Codes/QuantumHamming.lean
@@ -563,14 +563,6 @@ private lemma checkMatrix_generatorsList_X
       simp [show ¬(idx.val < r) from hlt]
     rw [this, dif_neg hlt, checkMatrix_XGen_X_part]
 
--- Note: `linter.flexible` is suppressed on the two `sum_checkMatrix_*_eq` lemmas below.
--- The closing `simp_all +decide` / `simp +decide` after `refine Finset.sum_bij ... <;>`
--- is the workhorse closing several sum_bij subgoals (left-membership, value-equality) by
--- different paths than the trailing bullets, and the linter's suggested `simp_all only [...]`
--- / `simp only [...]` rewrites are too weak. Per-subgoal restructuring is a significant
--- refactor that doesn't materially improve readability.
-
-set_option linter.flexible false in
 /-- The sum ∑_{idx} f(idx) * checkMatrix(idx, Z-col k) = ∑_{a:Fin r} f(a) * hammingEntry(a,k). -/
 private lemma sum_checkMatrix_Z_eq
     (f : Fin (generatorsList r).length → ZMod 2)
@@ -603,7 +595,6 @@ private lemma sum_checkMatrix_Z_eq
   · exact fun b => ⟨⟨b, by rw [generatorsList_length]; linarith [Fin.is_lt b]⟩,
       by simp +decide⟩
 
-set_option linter.flexible false in
 /-- The sum ∑_{idx} f(idx) * checkMatrix(idx, X-col k) = ∑_{a:Fin r} f(r+a) * hammingEntry(a,k). -/
 private lemma sum_checkMatrix_X_eq
     (f : Fin (generatorsList r).length → ZMod 2)

--- a/QEC/Stabilizer/Codes/QuantumHamming.lean
+++ b/QEC/Stabilizer/Codes/QuantumHamming.lean
@@ -217,7 +217,7 @@ theorem hammingRowDot_eq_zero (hr : 3 ≤ r) (a b : Fin r) :
     rw [dif_pos hbit_a]
     ext
     change ((k.val + 1 ^^^ 2 ^ c) - 1 + 1 ^^^ 2 ^ c) - 1 = k.val
-    rw [Nat.sub_one_add_one_eq_of_pos hxor_pos, Nat.xor_cancel_right]; omega
+    rw [Nat.sub_one_add_one_eq_of_pos hxor_pos, Nat.xor_xor_cancel_right]; omega
   -- f has no fixed points on S
   · intro k hk
     simp only [S, Finset.mem_filter, Finset.mem_univ, true_and] at hk
@@ -229,7 +229,7 @@ theorem hammingRowDot_eq_zero (hr : 3 ≤ r) (a b : Fin r) :
     simp only [xorFlip] at heq
     have hxor_pos := xor_pos_of_testBit hca.symm hka
     have h1 : k.val + 1 ^^^ 2 ^ c = k.val + 1 := by omega
-    have h2 := Nat.xor_cancel_left (k.val + 1) (2 ^ c)
+    have h2 := Nat.xor_xor_cancel_left (k.val + 1) (2 ^ c)
     rw [h1, Nat.xor_self] at h2
     exact absurd h2.symm (by positivity)
 

--- a/QEC/Stabilizer/Codes/QuantumHamming.lean
+++ b/QEC/Stabilizer/Codes/QuantumHamming.lean
@@ -69,10 +69,11 @@ def hammingRowDot (a b : Fin r) : ZMod 2 :=
   ∑ k : Fin (2 ^ r - 1), hammingEntry r a k * hammingEntry r b k
 
 /-- Even cardinality from a fixed-point-free involution on a Finset. -/
-private lemma even_card_of_fpf_involution {α : Type*} [DecidableEq α]
+private lemma even_card_of_fpf_involution {α : Type*}
     (S : Finset α) (f : α → α) (hf_mem : ∀ x ∈ S, f x ∈ S)
     (hf_inv : ∀ x ∈ S, f (f x) = x) (hf_ne : ∀ x ∈ S, f x ≠ x) :
     Even S.card := by
+  classical
   induction S using Finset.strongInduction with
   | H S ih =>
     by_cases hS : S = ∅
@@ -139,7 +140,7 @@ private lemma xor_flip_val_lt {r c : ℕ} (hc : c < r) {k : Fin (2 ^ r - 1)}
     have hbad : (k.val + 1 ^^^ 2 ^ c).testBit a = (k.val + 1).testBit a :=
       testBit_xor_two_pow _ _ _ hac
     rw [h] at hbad
-    simp at hbad
+    simp only [Nat.zero_testBit] at hbad
     rw [ha] at hbad
     exact absurd hbad (by simp)
   omega
@@ -155,7 +156,10 @@ private lemma xor_pos_of_testBit {m c a : ℕ} (hac : a ≠ c)
   rw [Nat.pos_iff_ne_zero]
   intro h
   have := testBit_xor_two_pow m c a hac
-  rw [h] at this; simp at this; rw [ha] at this; simp at this
+  rw [h] at this
+  simp only [Nat.zero_testBit] at this
+  rw [ha] at this
+  exact Bool.false_ne_true this
 
 /-- The dot product of any two rows of the Hamming parity-check matrix is 0 (mod 2)
     for `r ≥ 3`.
@@ -177,7 +181,7 @@ theorem hammingRowDot_eq_zero (hr : 3 ≤ r) (a b : Fin r) :
   rw [ZMod.natCast_eq_zero_iff_even]
   -- Step 2: Find bit c < r with c ≠ a and c ≠ b (possible since r ≥ 3)
   have hc_exists : ∃ c : ℕ, c < r ∧ c ≠ a.val ∧ c ≠ b.val := by
-    by_contra hall; push_neg at hall
+    by_contra hall; push Not at hall
     have h0 := hall 0 (by omega); have h1 := hall 1 (by omega); have h2 := hall 2 (by omega)
     omega
   obtain ⟨c, hc_lt, hca, hcb⟩ := hc_exists
@@ -559,6 +563,14 @@ private lemma checkMatrix_generatorsList_X
       simp [show ¬(idx.val < r) from hlt]
     rw [this, dif_neg hlt, checkMatrix_XGen_X_part]
 
+-- Note: `linter.flexible` is suppressed on the two `sum_checkMatrix_*_eq` lemmas below.
+-- The closing `simp_all +decide` / `simp +decide` after `refine Finset.sum_bij ... <;>`
+-- is the workhorse closing several sum_bij subgoals (left-membership, value-equality) by
+-- different paths than the trailing bullets, and the linter's suggested `simp_all only [...]`
+-- / `simp only [...]` rewrites are too weak. Per-subgoal restructuring is a significant
+-- refactor that doesn't materially improve readability.
+
+set_option linter.flexible false in
 /-- The sum ∑_{idx} f(idx) * checkMatrix(idx, Z-col k) = ∑_{a:Fin r} f(a) * hammingEntry(a,k). -/
 private lemma sum_checkMatrix_Z_eq
     (f : Fin (generatorsList r).length → ZMod 2)
@@ -584,12 +596,14 @@ private lemma sum_checkMatrix_Z_eq
     Finset.filter p Finset.univ
   have hs : ∀ x : Fin (generatorsList r).length, x ∈ s ↔ p x := by
     intro x; simp [s, p, Finset.mem_filter]
-  simp +zetaDelta at *;
-  refine' Finset.sum_bij ( fun x hx => ⟨ x.val, by
-    grind +qlia ⟩ ) _ _ _ _ <;> simp_all +decide;
-  · exact fun a ha b hb hab => Fin.ext hab;
-  · exact fun b => ⟨ ⟨ b, by rw [ generatorsList_length ] ; linarith [ Fin.is_lt b ] ⟩, by simp +decide ⟩
+  simp +zetaDelta only [Finset.univ_eq_attach, add_zero] at *
+  refine Finset.sum_bij (fun x _ => ⟨x.val, by grind +qlia⟩) ?_ ?_ ?_ ?_ <;>
+    simp_all +decide
+  · exact fun a ha b hb hab => Fin.ext hab
+  · exact fun b => ⟨⟨b, by rw [generatorsList_length]; linarith [Fin.is_lt b]⟩,
+      by simp +decide⟩
 
+set_option linter.flexible false in
 /-- The sum ∑_{idx} f(idx) * checkMatrix(idx, X-col k) = ∑_{a:Fin r} f(r+a) * hammingEntry(a,k). -/
 private lemma sum_checkMatrix_X_eq
     (f : Fin (generatorsList r).length → ZMod 2)
@@ -616,17 +630,19 @@ private lemma sum_checkMatrix_X_eq
     Finset.filter p Finset.univ
   have hs : ∀ x : Fin (generatorsList r).length, x ∈ s ↔ p x := by
     intro x; simp [s, p, Finset.mem_filter]
-  simp;
-  refine' Finset.sum_bij ( fun x _ => ⟨ x.val - r, by
+  simp only [Finset.univ_eq_attach, zero_add]
+  refine Finset.sum_bij (fun x _ => ⟨x.val - r, by
     have hxge : r ≤ x.val := by
       exact le_of_not_gt (by simpa [p] using x.property)
     have hxlt : x.val < (generatorsList r).length := x.1.isLt
     have hlen : (generatorsList r).length = 2 * r := generatorsList_length r
     have hxlt' : x.val < 2 * r := by simpa [hlen] using hxlt
-    omega⟩ ) _ _ _ _ <;> simp +decide;
-  · exact fun a ha b hb hab => Fin.ext <| by linarith [ Nat.sub_add_cancel ha, Nat.sub_add_cancel hb ] ;
-  · intro b; use ⟨ r + b, by rw [ generatorsList_length ] ; linarith [ Fin.is_lt b ] ⟩ ; aesop;
-  · exact fun a ha => Or.inl <| congr_arg f <| Fin.ext <| by simp +decide [ Nat.add_sub_of_le ha ] ;
+    omega⟩) ?_ ?_ ?_ ?_ <;> simp +decide
+  · exact fun a ha b hb hab =>
+      Fin.ext <| by linarith [Nat.sub_add_cancel ha, Nat.sub_add_cancel hb]
+  · intro b; use ⟨r + b, by rw [generatorsList_length]; linarith [Fin.is_lt b]⟩; aesop
+  · exact fun a ha =>
+      Or.inl <| congr_arg f <| Fin.ext <| by simp +decide [Nat.add_sub_of_le ha]
 
 /-- The check-matrix rows of the quantum Hamming generators are linearly independent. -/
 theorem rowsLinearIndependent_generatorsList :

--- a/README.md
+++ b/README.md
@@ -73,6 +73,18 @@ lake build
 - Use `#check` and `#eval` commands in Lean to explore definitions
 - Run `lake build` after making changes to verify your code compiles
 
+#### Claude Code users (optional)
+
+This repo ships a project-scoped MCP configuration in `.mcp.json` that wires
+up the [lean-lsp MCP server](https://github.com/oOo0oOo/lean-lsp-mcp), giving
+[Claude Code](https://claude.com/claude-code) agents in-editor access to live
+proof states, mathlib search (LeanSearch, Loogle, Lean Hammer), and Lean
+diagnostics. Claude Code will prompt you to approve the server on first launch.
+
+Requirements: [`uv`](https://docs.astral.sh/uv/) on `PATH` (provides `uvx`).
+[`ripgrep`](https://github.com/BurntSushi/ripgrep) is recommended for the
+local-search tool. See [`CLAUDE.md`](CLAUDE.md) for the agent-side workflow.
+
 ## Contributing
 
 Contributions are welcome! If you add new modules or definitions, please:


### PR DESCRIPTION
## Summary

Four commits — wire QuantumHamming into the build graph, repair stale mathlib references, and clear every linter warning the file produces.

### 1. `fix(qh): wire QuantumHamming.lean into build graph, repair mathlib API`

The file was orphaned: nothing imported it, so \`lake build\` silently hid the fact that it no longer compiled. Renames two stale mathlib references (\`Nat.xor_cancel_{right,left}\` → \`Nat.xor_xor_cancel_{right,left}\` from Batteries) and adds the file to \`QEC/Stabilizer/Codes.lean\` so future breakage is caught by \`lake build\`.

### 2. `chore(qh lint): clear all 17 linter warnings`

Cleared 11 of 17 cleanly; the remaining 6 \`linter.flexible\` warnings on \`sum_checkMatrix_*_eq\` were initially handled via \`set_option linter.flexible false in\` suppressions.

### 3. `chore(qh lint): remove linter.flexible suppressions`

Per project policy (no linter suppressions in the codebase), drops the two \`set_option linter.flexible false in\` lines. The 6 underlying warnings re-surface honestly.

### 4. `chore(qh lint): close the 6 stubborn linter.flexible warnings`

Used the Lean LSP MCP (\`lean_multi_attempt\` with \`simp_all? +decide\` / \`simp? +decide\`) to get per-subgoal \`simp_all +decide only [...]\` / \`simp +decide only [...]\` suggestions. Took the union across all 4 \`Finset.sum_bij\` subgoals at each site to produce a single explicit list — closes the trivial cases and normalizes the non-trivial cases exactly as the original wide \`simp_all +decide\` did. The trailing \`· exact ...\` bullets keep working unmodified.

## Final fix breakdown

| Linter | Count | Fixed cleanly | Suppressed |
|--------|------:|--:|--:|
| `unusedDecidableInType` | 1 | 1 | 0 |
| `push_neg` deprecation | 1 | 1 | 0 |
| `style.refine` | 2 | 2 | 0 |
| `style.longLine` | 2 | 2 | 0 |
| `flexible` | 11 | 11 | 0 |
| **Total** | **17** | **17** | **0** |

## Verification

- \`lake build\` succeeds (3396 jobs).
- Direct build: \`lake build QEC.Stabilizer.Codes.QuantumHamming 2>&1 | grep \"^error:\"\` returns nothing.
- Warning count: 462 (main) → 479 after wiring → **462** after lint cleanup. Net-zero global impact.
- 0 \`set_option linter.* false\` lines in QH.

## Test plan

- [x] \`lake build\` clean
- [x] \`QuantumHamming.lean\` in the import graph
- [x] No suppressions in the file
- [x] \`lean_diagnostic_messages\` on the file returns 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)