### PR TITLE
chore(lint): convert all 12 induction' to modern induction with

### DIFF
--- a/QEC/Stabilizer/Lattice/ToricDualWrappingInvariants.lean
+++ b/QEC/Stabilizer/Lattice/ToricDualWrappingInvariants.lean
@@ -95,9 +95,13 @@ theorem hRowAt_independent_on_dualCycles (c : toricDualCycles (L := L)) (y0 y1 :
   have h_induction : ∀ k : ℕ, ∀ y : Fin L,
       hRowAt L y c.1 =
         hRowAt L (Fin.mk ((y.val + k) % L) (Nat.mod_lt _ (Fact.out))) c.1 := by
-    intro k y; induction' k with k ih <;> simp_all +decide [ ← add_assoc, Nat.mod_eq_of_lt ] ;
-    specialize h_row_eq ⟨ ( y + k ) % L, Nat.mod_lt _ ( Fact.out ) ⟩ ;
-    simp_all +decide [ ← eq_sub_iff_add_eq', next ] ;
+    intro k y
+    induction k with
+    | zero => simp_all +decide [ Nat.mod_eq_of_lt ]
+    | succ k ih =>
+        simp_all +decide [ ← add_assoc ]
+        specialize h_row_eq ⟨ ( y + k ) % L, Nat.mod_lt _ ( Fact.out ) ⟩
+        simp_all +decide [ ← eq_sub_iff_add_eq', next ]
   convert h_induction ( y1.val + L - y0.val ) y0 using 1;
   simp +decide [ add_tsub_cancel_of_le
     ( show ( y0 : ℕ ) ≤ y1 + L from by linarith [ Fin.is_lt y0, Fin.is_lt y1 ] ),

--- a/QEC/Stabilizer/Lattice/ToricH1Dimension.lean
+++ b/QEC/Stabilizer/Lattice/ToricH1Dimension.lean
@@ -224,15 +224,16 @@ theorem mem_ker_cutMap_iff (s : C0 L) :
               s (⟨0, by linarith [Fact.out (p := 0 < L)]⟩,
                 ⟨0, by linarith [Fact.out (p := 0 < L)]⟩) := by
         intro y
-        induction' y with y ih;
-        induction' y with y ih;
-        · rfl;
-        · specialize h_const
-            ⟨0, by linarith [Fact.out (p := 0 < L)]⟩
-            ⟨y, by linarith [Fact.out (p := 0 < L)]⟩
-          simp_all +decide [ next ];
-          simp_all +decide [ Nat.mod_eq_of_lt ( by linarith : y + 1 < L ) ];
-          grind
+        obtain ⟨y, ih⟩ := y
+        induction y with
+        | zero => rfl
+        | succ y ih_step =>
+            specialize h_const
+              ⟨0, by linarith [Fact.out (p := 0 < L)]⟩
+              ⟨y, by linarith [Fact.out (p := 0 < L)]⟩
+            simp_all +decide [ next ]
+            simp_all +decide [ Nat.mod_eq_of_lt ( by linarith : y + 1 < L ) ]
+            grind
       exact h_const_x x ▸ h_const_y y ▸ rfl
     obtain ⟨c, hc⟩ := h_const_val
     exact ⟨c, funext fun p => by simp [hc]⟩
@@ -310,13 +311,15 @@ theorem mem_ker_boundary2_iff (f : C2 L) :
             rw [← two_smul (ZMod 2) _]
             simp +decide)]
     have h_ind : ∀ x y, f (x, y) = f (x, ⟨0, by linarith [Fact.out (p := 0 < L)]⟩) := by
-      intro x y; induction' y with y ih;
-      induction' y with y ih;
-      · rfl;
-      · convert h_const x ⟨ y, by linarith ⟩ using 1;
-        · congr;
-          norm_num [ Fin.val_add, Nat.mod_eq_of_lt ih ];
-        · exact Eq.symm ( by solve_by_elim [ Nat.lt_of_succ_lt ] );
+      intro x y
+      obtain ⟨y, ih⟩ := y
+      induction y with
+      | zero => rfl
+      | succ y ih_step =>
+          convert h_const x ⟨ y, by linarith ⟩ using 1
+          · congr
+            norm_num [ Fin.val_add, Nat.mod_eq_of_lt ih ]
+          · exact Eq.symm ( by solve_by_elim [ Nat.lt_of_succ_lt ] )
     have h_const_x :
         ∀ x, f (next L x, ⟨0, by linarith [Fact.out (p := 0 < L)]⟩) =
           f (x, ⟨0, by linarith [Fact.out (p := 0 < L)]⟩) := by
@@ -340,12 +343,13 @@ theorem mem_ker_boundary2_iff (f : C2 L) :
           f (⟨0, by linarith [Fact.out (p := 0 < L)]⟩,
             ⟨0, by linarith [Fact.out (p := 0 < L)]⟩) := by
       intro x
-      induction' x with x ih;
-      induction' x with x ih;
-      · rfl;
-      · convert h_const_x ⟨ x, by linarith ⟩ using 1;
-        · exact Fin.ext ( by simp +decide [ next, Nat.mod_eq_of_lt ih ] );
-        · exact Eq.symm ( by solve_by_elim [ Nat.lt_of_succ_lt ] );
+      obtain ⟨x, ih⟩ := x
+      induction x with
+      | zero => rfl
+      | succ x ih_step =>
+          convert h_const_x ⟨ x, by linarith ⟩ using 1
+          · exact Fin.ext ( by simp +decide [ next, Nat.mod_eq_of_lt ih ] )
+          · exact Eq.symm ( by solve_by_elim [ Nat.lt_of_succ_lt ] )
     exact
       ⟨f (⟨0, by linarith [Fact.out (p := 0 < L)]⟩, ⟨0, by linarith [Fact.out (p := 0 < L)]⟩),
         funext fun x => by aesop⟩

--- a/QEC/Stabilizer/Lattice/ToricLogicalCorrespondenceX.lean
+++ b/QEC/Stabilizer/Lattice/ToricLogicalCorrespondenceX.lean
@@ -454,33 +454,39 @@ theorem xIsPlaquetteProduct_iff_mem_toricBoundaries (L : ℕ) [Fact (2 ≤ L)] (
         ∀ g ∈ Subgroup.closure (StabilizerGroup.ToricCodeN.XGenerators L),
           ∃ f : C2 L, toricXOperatorOfChain L (toricBoundary2 (L := L) f) = g := by
       intro g hg
-      induction' hg using Subgroup.closure_induction with g hg ih;
-      · rcases hg with ⟨⟨x, y⟩, rfl⟩
-        exact ⟨singleFace (x, y), toricXOperatorOfChain_boundary_singleFace L x y⟩
-      · use 0; simp [toricXOperatorOfChain_zero];
-      · rename_i h₁ h₂ h₃ h₄
-        obtain ⟨f₁, hf₁⟩ := h₃
-        obtain ⟨f₂, hf₂⟩ := h₄
-        use f₁ + f₂
-        simp +decide [hf₁, hf₂, toricXOperatorOfChain_add]
-      · obtain ⟨f, hf⟩ := ‹_›
-        use f
-        simp_all +decide [toricXOperatorOfChain]
-        rw [← hf]
-        ext <;> simp +decide [NQubitPauliGroupElement.inv]
+      induction hg using Subgroup.closure_induction with
+      | mem g hg =>
+          rcases hg with ⟨⟨x, y⟩, rfl⟩
+          exact ⟨singleFace (x, y), toricXOperatorOfChain_boundary_singleFace L x y⟩
+      | one => use 0; simp [toricXOperatorOfChain_zero]
+      | mul x y hx hy ihx ihy =>
+          obtain ⟨f₁, hf₁⟩ := ihx
+          obtain ⟨f₂, hf₂⟩ := ihy
+          use f₁ + f₂
+          simp +decide [hf₁, hf₂, toricXOperatorOfChain_add]
+      | inv x hx ih =>
+          obtain ⟨f, hf⟩ := ih
+          use f
+          simp_all +decide [toricXOperatorOfChain]
+          rw [← hf]
+          ext <;> simp +decide [NQubitPauliGroupElement.inv]
     have := @chainOfXOperator_toricXOperatorOfChain L;
     grind +splitImp;
   · obtain ⟨ f, rfl ⟩ := hc;
     rw [ c2_eq_sum_singleFace L f ];
-    induction' (Finset.univ.filter fun p : FaceIdx L => f p = 1) using Finset.induction <;>
-      simp_all +decide [Finset.sum_insert]
-    · rw [ toricXOperatorOfChain_zero ] ; exact OneMemClass.one_mem _;
-    · rw [ toricXOperatorOfChain_add ];
-      exact Subgroup.mul_mem _
-        (by
-          rw [toricXOperatorOfChain_boundary_singleFace]
-          exact Subgroup.subset_closure <| Set.mem_range_self _)
-        ‹_›
+    induction (Finset.univ.filter fun p : FaceIdx L => f p = 1) using Finset.induction with
+    | empty =>
+        simp_all +decide
+        rw [ toricXOperatorOfChain_zero ]
+        exact OneMemClass.one_mem _
+    | insert a s has ih =>
+        simp_all +decide [Finset.sum_insert]
+        rw [ toricXOperatorOfChain_add ]
+        exact Subgroup.mul_mem _
+          (by
+            rw [toricXOperatorOfChain_boundary_singleFace]
+            exact Subgroup.subset_closure <| Set.mem_range_self _)
+          ih
 
 /-
 X-type operators commute with the toric X-type chain encoding.

--- a/QEC/Stabilizer/Lattice/ToricLogicalCorrespondenceZ.lean
+++ b/QEC/Stabilizer/Lattice/ToricLogicalCorrespondenceZ.lean
@@ -514,38 +514,42 @@ theorem zIsStarProduct_iff_mem_toricDualBoundaries (L : ℕ) [Fact (2 ≤ L)] (c
         ∀ g ∈ Subgroup.closure (StabilizerGroup.ToricCodeN.ZGenerators L),
           ∃ s : C0 L, toricZOperatorOfChain L (toricVertexCutMap (L := L) s) = g := by
       intro g hg
-      induction' hg using Subgroup.closure_induction with g hg ih
-      · rcases hg with ⟨⟨xv, yv⟩, rfl⟩
-        exact ⟨singleVtx (xv, yv), toricZOperatorOfChain_cutMap_singleVtx L xv yv⟩
-      · use 0
-        simp only [map_zero, toricZOperatorOfChain_zero]
-      · rename_i h₁ h₂ h₃ h₄
-        obtain ⟨s₁, hs₁⟩ := h₃
-        obtain ⟨s₂, hs₂⟩ := h₄
-        use s₁ + s₂
-        simp only [map_add]
-        simp +decide [hs₁, hs₂, toricZOperatorOfChain_add]
-      · obtain ⟨s, hs⟩ := ‹_›
-        use s
-        simp_all +decide [toricZOperatorOfChain]
-        rw [← hs]
-        ext <;> simp +decide [NQubitPauliGroupElement.inv]
+      induction hg using Subgroup.closure_induction with
+      | mem g hg =>
+          rcases hg with ⟨⟨xv, yv⟩, rfl⟩
+          exact ⟨singleVtx (xv, yv), toricZOperatorOfChain_cutMap_singleVtx L xv yv⟩
+      | one =>
+          use 0
+          simp only [map_zero, toricZOperatorOfChain_zero]
+      | mul x y hx hy ihx ihy =>
+          obtain ⟨s₁, hs₁⟩ := ihx
+          obtain ⟨s₂, hs₂⟩ := ihy
+          use s₁ + s₂
+          simp only [map_add]
+          simp +decide [hs₁, hs₂, toricZOperatorOfChain_add]
+      | inv x hx ih =>
+          obtain ⟨s, hs⟩ := ih
+          use s
+          simp_all +decide [toricZOperatorOfChain]
+          rw [← hs]
+          ext <;> simp +decide [NQubitPauliGroupElement.inv]
     have hroundtrip := @chainOfZOperator_toricZOperatorOfChain L
     grind +splitImp
   · -- ← direction: from range(cutMap) to closure(ZGen)
     obtain ⟨s, rfl⟩ := hc
     rw [c0_eq_sum_singleVtx L s]
     simp only [map_sum]
-    induction' (Finset.univ.filter fun v : VtxIdx L => s v = 1) using Finset.induction
-      with a fs ha ih
-    · simp only [Finset.sum_empty, toricZOperatorOfChain_zero]
-      exact OneMemClass.one_mem _
-    · simp only [Finset.sum_insert ha, toricZOperatorOfChain_add]
-      exact Subgroup.mul_mem _
-        (by rcases a with ⟨xv, yv⟩
-            rw [toricZOperatorOfChain_cutMap_singleVtx]
-            exact Subgroup.subset_closure ⟨(xv, yv), rfl⟩)
-        ih
+    induction (Finset.univ.filter fun v : VtxIdx L => s v = 1) using Finset.induction with
+    | empty =>
+        simp only [Finset.sum_empty, toricZOperatorOfChain_zero]
+        exact OneMemClass.one_mem _
+    | insert a fs ha ih =>
+        simp only [Finset.sum_insert ha, toricZOperatorOfChain_add]
+        exact Subgroup.mul_mem _
+          (by rcases a with ⟨xv, yv⟩
+              rw [toricZOperatorOfChain_cutMap_singleVtx]
+              exact Subgroup.subset_closure ⟨(xv, yv), rfl⟩)
+          ih
 
 -- ---------------------------------------------------------------------------
 -- 7.  Centralizer membership

--- a/QEC/Stabilizer/Lattice/ToricWrappingInvariants.lean
+++ b/QEC/Stabilizer/Lattice/ToricWrappingInvariants.lean
@@ -146,11 +146,14 @@ theorem vAt_independent_on_cycles (c : toricCycles (L := L)) (y0 y1 : Fin L) :
       vAt (L := L) y (c.1) =
         vAt (L := L) (Fin.mk ((y.val + k) % L) (Nat.mod_lt _ (Fact.out : 0 < L))) (c.1) := by
     intro k y
-    induction' k with k ih <;> simp +decide [Nat.add_mod, Nat.mod_eq_of_lt]
-    simp +decide [ih]
-    convert h_B1_gen _ |> Eq.symm using 2
-    norm_num [add_assoc, Nat.mod_eq_of_lt]
-    norm_num [← add_assoc, next]
+    induction k with
+    | zero => simp +decide [Nat.mod_eq_of_lt]
+    | succ k ih =>
+        simp +decide [Nat.add_mod, Nat.mod_eq_of_lt]
+        simp +decide [ih]
+        convert h_B1_gen _ |> Eq.symm using 2
+        norm_num [add_assoc, Nat.mod_eq_of_lt]
+        norm_num [← add_assoc, next]
   convert h_ind ( y1.val + L - y0.val ) y0 using 1;
   simp +decide [add_tsub_cancel_of_le
     (show (y0 : ℕ) ≤ y1 + L from by linarith [Fin.is_lt y0, Fin.is_lt y1]), Nat.mod_eq_of_lt]


### PR DESCRIPTION
## Summary

PR 9 of 10. Retires every \`induction'\` site flagged by \`linter.style.induction\` by rewriting to the modern \`induction ... with | case => ...\` syntax. **No suppressions** — each conversion uses the actual case names of the induction principle in use.

| File | Sites | Pattern |
|------|---:|---|
| \`ToricH1Dimension.lean\` | 6 (3 paired) | Nested two-step \`induction'\`: \`obtain ⟨y, ih⟩ := y; induction y with | zero => ... | succ y ih_step => ...\` |
| \`ToricLogicalCorrespondenceX.lean\` | 2 | \`induction hg using Subgroup.closure_induction with | mem ... | one | mul ... | inv ...\` and \`induction ... using Finset.induction with | empty | insert a s has ih\` |
| \`ToricLogicalCorrespondenceZ.lean\` | 2 | Z-side mirror of the X cases |
| \`ToricWrappingInvariants.lean\` | 1 | Nat induction with closing \`<;>\` chain split into \`| zero | succ k ih\` |
| \`ToricDualWrappingInvariants.lean\` | 1 | Same Nat-induction shape |

## Tricky conversion: the nested two-step \`induction'\`

The original used:
\`\`\`lean
induction' y with y ih;
induction' y with y ih;
\`\`\`
on \`y : Fin L\`, which destructured the Fin into \`y : ℕ\` + \`ih : y < L\`, then did Nat induction reusing the name \`ih\` for the Fin bound at each step.

Modern equivalent:
\`\`\`lean
obtain ⟨y, ih⟩ := y
induction y with
| zero => rfl
| succ y ih_step => ...  -- ih_step is the Nat IH; ih : y + 1 < L still in scope
\`\`\`

\`induction\` preserves outer hypotheses by substitution, so \`ih\` ends up as \`y + 1 < L\` in the succ case — and references like \`Nat.mod_eq_of_lt ih\` continue to work unchanged. The Nat IH gets a separate name (\`ih_step\`).

## Bonus: trimmed redundant simp args

Converting \`induction' k with k ih <;> simp +decide [a, b]\` into explicit per-case bodies often makes one of the lemmas redundant in the zero branch and the other redundant in the succ branch (the \`<;>\`-applied set was the union). The linter flagged 4 such args; this PR trims them at the same time.

## Verification

- \`lake build\` succeeds.
- Warning count: **453 → 441** (drop of exactly 12, all \`linter.style.induction\` eliminated, no new categories introduced).
- \`linter.style.induction\` count: **12 → 0**.
- No \`set_option linter.* false\` lines in the touched code.

## Test plan

- [x] \`lake build\` clean
- [x] \`grep -c "linter.style.induction" build.log\` == 0
- [x] No suppressions added

🤖 Generated with [Claude Code](https://claude.com/claude-code)