### PR TITLE
refactor(toric): delegate toric correspondence and CSS bridge to generic HomologicalCode

### DIFF
--- a/QEC/Stabilizer/Codes/ToricCodeNDistance.lean
+++ b/QEC/Stabilizer/Codes/ToricCodeNDistance.lean
@@ -3,6 +3,8 @@ import QEC.Stabilizer.Codes.ToricCodeNDistanceX
 import QEC.Stabilizer.Codes.ToricCodeNDistanceZ
 import QEC.Stabilizer.Codes.ToricCodeNStabilizerCode
 import QEC.Stabilizer.Lattice.ToricLogicalCorrespondenceZ
+import QEC.Stabilizer.Lattice.ToricChainComplex
+import QEC.Stabilizer.Homological.Distance
 import QEC.Stabilizer.PauliGroup.NQubitElement
 import QEC.Stabilizer.Core.CodeDistance
 
@@ -419,7 +421,14 @@ private lemma weight_toricZOperatorOfChain_eq (L : ℕ) [Fact (0 < L)]
       have hspec := Classical.choose_spec hex
       exact Stabilizer.Lattice.edgeToQubitIdx_injective L hspec.1
 
-/-- For a nontrivial logical `g`, the X-chain and Z-chain cannot both be boundaries. -/
+/-- For a nontrivial logical `g`, the X-chain and Z-chain cannot both be boundaries.
+
+Delegates to the generic CSS bridge
+`Homological.HomologicalCode.not_both_boundary_of_nontrivial` on `toricHomologicalCode L`,
+via the subgroup bridge (`toricHomologicalCode_homologicalStabilizerGroup_toSubgroup_eq`)
+and the `dualBoundaries` bridge (`toricHomologicalCode_dualBoundaries_eq`).  The
+`xChainOf`/`zChainOf`-side bridges are `rfl` since both definitions share
+`edgeToQubitIdx` as their qubit-indexing equivalence. -/
 private lemma not_both_boundary_of_nontrivial (L : ℕ) [Fact (2 ≤ L)]
     (g : NQubitPauliGroupElement (numQubits L))
     (hg : IsNontrivialLogicalOperator g (stabilizerGroup L)) :
@@ -427,39 +436,27 @@ private lemma not_both_boundary_of_nontrivial (L : ℕ) [Fact (2 ≤ L)]
       zChainOf L g ∈ Stabilizer.Lattice.toricDualBoundaries (L := L)) := by
   have hL0 : 0 < L := Nat.lt_of_lt_of_le (by decide : 0 < 2) (Fact.out : 2 ≤ L)
   haveI : Fact (0 < L) := ⟨hL0⟩
+  -- Translate the lattice `IsNontrivialLogicalOperator` to the abstract one
+  -- via the subgroup bridge.
+  have h_sub_eq :
+      (stabilizerGroup L).toSubgroup =
+        (Stabilizer.Lattice.toricHomologicalCode L).homologicalStabilizerGroup.toSubgroup :=
+    (Stabilizer.Lattice.toricHomologicalCode_homologicalStabilizerGroup_toSubgroup_eq L).symm
+  have hg_abs :
+      IsNontrivialLogicalOperator g
+        (Stabilizer.Lattice.toricHomologicalCode L).homologicalStabilizerGroup :=
+    (IsNontrivialLogicalOperator_of_toSubgroup_eq g h_sub_eq).mp hg
+  -- Now invoke the generic `not_both_boundary_of_nontrivial`.
+  -- The toric `xChainOf` matches `(toricHomologicalCode L).xChainOf` by definition
+  -- (both use `edgeToQubitIdx L` via the `edgeEquiv` field).
+  -- Same for `zChainOf` and `toricBoundaries = (toricHomologicalCode L).boundaries` (rfl).
+  -- `toricDualBoundaries` matches via `toricHomologicalCode_dualBoundaries_eq`.
   rintro ⟨hxBnd, hzBnd⟩
-  -- Define X-only and Z-only encodings of g
-  set g_X := Stabilizer.Lattice.toricXOperatorOfChain L (xChainOf L g) with hg_X
-  set g_Z := Stabilizer.Lattice.toricZOperatorOfChain L (zChainOf L g) with hg_Z
-  -- Each is in the appropriate generator closure (hence in the stabilizer subgroup)
-  have hgX_mem : g_X ∈ (stabilizerGroup L).toSubgroup := by
-    rw [stabilizerGroup_toSubgroup_eq, subgroup]
-    have : g_X ∈ Subgroup.closure (XGenerators L) :=
-      (Stabilizer.Lattice.xIsPlaquetteProduct_iff_mem_toricBoundaries L (xChainOf L g)).mpr hxBnd
-    apply Subgroup.closure_mono _ this
-    intro x hx; right; exact hx
-  have hgZ_mem : g_Z ∈ (stabilizerGroup L).toSubgroup := by
-    rw [stabilizerGroup_toSubgroup_eq, subgroup]
-    have : g_Z ∈ Subgroup.closure (ZGenerators L) :=
-      (Stabilizer.Lattice.zIsStarProduct_iff_mem_toricDualBoundaries L (zChainOf L g)).mpr hzBnd
-    apply Subgroup.closure_mono _ this
-    intro x hx; left; exact hx
-  -- Their product is also in the stabilizer
-  have hprod_mem : g_X * g_Z ∈ (stabilizerGroup L).toSubgroup :=
-    (stabilizerGroup L).toSubgroup.mul_mem hgX_mem hgZ_mem
-  -- (g_X * g_Z).operators = g.operators (computed per-qubit)
-  have hops_eq : (g_X * g_Z).operators = g.operators := by
-    ext i
-    have hX_i := toricXOf_xChain_operators_eq L g i
-    have hZ_i := toricZOf_zChain_operators_eq L g i
-    change ((g_X.operators i).mulOp (g_Z.operators i)).operator = g.operators i
-    rw [hX_i, hZ_i]
-    cases hgi : g.operators i <;>
-      simp [PauliOperator.mulOp]
-  -- Apply the third condition of IsNontrivialLogicalOperator
-  rw [IsNontrivialLogicalOperator_iff] at hg
-  obtain ⟨_, _, h_no_phase_dup⟩ := hg
-  exact h_no_phase_dup (g_X * g_Z) hprod_mem hops_eq
+  apply (Stabilizer.Lattice.toricHomologicalCode L).not_both_boundary_of_nontrivial g hg_abs
+  refine ⟨?_, ?_⟩
+  · exact hxBnd
+  · rw [← Stabilizer.Lattice.toricHomologicalCode_dualBoundaries_eq L] at hzBnd
+    exact hzBnd
 
 /-- CSS bridge: full distance = min(dX, dZ). -/
 theorem toricCodeN_distance_eq_min_dX_dZ (L dX dZ : ℕ) [Fact (2 ≤ L)]

--- a/QEC/Stabilizer/Codes/ToricCodeNStabilizerCode.lean
+++ b/QEC/Stabilizer/Codes/ToricCodeNStabilizerCode.lean
@@ -6,6 +6,8 @@ import QEC.Stabilizer.Core.LogicalOperators
 import QEC.Stabilizer.Lattice.ToricH1Dimension
 import QEC.Stabilizer.Lattice.ToricLogicalCorrespondenceX
 import QEC.Stabilizer.Lattice.ToricLogicalCorrespondenceZ
+import QEC.Stabilizer.Lattice.ToricChainComplex
+import QEC.Stabilizer.Homological.StabGroup
 
 /-!
 # Toric code as `StabilizerCode (2L², 2)`
@@ -154,14 +156,25 @@ lemma listToSet_packaged_subset_full (L : ℕ) [Fact (0 < L)] :
   · exact Or.inl (listToSet_genListZTrimmed_subset L hZ)
   · exact Or.inr (listToSet_genListXTrimmed_subset L hX)
 
-/-- The packaged generators pairwise commute (subset of full generators which commute). -/
+/-- The packaged generators pairwise commute.
+
+Delegates to the generic `Homological.HomologicalCode.homologicalGenerators_commute`
+on `Stabilizer.Lattice.toricHomologicalCode L`, via the generator-set bridges. -/
 lemma generators_commute_packaged (L : ℕ) [Fact (2 ≤ L)] :
     ∀ g ∈ listToSet (generatorsListPackaged L),
     ∀ h ∈ listToSet (generatorsListPackaged L), g * h = h * g := by
   haveI : Fact (0 < L) := ⟨lt_of_lt_of_le (by decide : 0 < 2) Fact.out⟩
+  -- Bridge: `generators L = (toricHomologicalCode L).homologicalGenerators`.
+  have h_gens_eq : generators L =
+      (Stabilizer.Lattice.toricHomologicalCode L).homologicalGenerators := by
+    unfold generators Quantum.Stabilizer.Homological.HomologicalCode.homologicalGenerators
+    rw [Stabilizer.Lattice.toricHomologicalCode_ZGenerators_eq,
+        Stabilizer.Lattice.toricHomologicalCode_XGenerators_eq]
+    rfl
   intro g hg h hh
-  exact generators_commute L g (listToSet_packaged_subset_full L hg)
-    h (listToSet_packaged_subset_full L hh)
+  apply (Stabilizer.Lattice.toricHomologicalCode L).homologicalGenerators_commute
+  · rw [← h_gens_eq]; exact listToSet_packaged_subset_full L hg
+  · rw [← h_gens_eq]; exact listToSet_packaged_subset_full L hh
 
 -- ---------------------------------------------------------------------------
 -- Phase 1.3 / 1.4: Homological identities
@@ -513,12 +526,24 @@ lemma closure_packaged_eq_full (L : ℕ) [Fact (2 ≤ L)] :
         change (x, y) ∈ (List.finRange L).product (List.finRange L)
         simp
 
-/-- `-I` is not in the closure of the packaged generator list. -/
+/-- `-I` is not in the closure of the packaged generator list.
+
+Delegates to the generic `negIdentity_not_mem_closure_homologicalGenerators` on
+`Stabilizer.Lattice.toricHomologicalCode L`, via the generator-set bridges and the
+`closure_packaged_eq_full` identity. -/
 lemma negIdentity_not_mem_packaged (L : ℕ) [Fact (2 ≤ L)] :
     StabilizerGroup.negIdentity (numQubits L) ∉
       Subgroup.closure (listToSet (generatorsListPackaged L)) := by
+  have h_gens_eq : generators L =
+      (Stabilizer.Lattice.toricHomologicalCode L).homologicalGenerators := by
+    unfold generators Quantum.Stabilizer.Homological.HomologicalCode.homologicalGenerators
+    rw [Stabilizer.Lattice.toricHomologicalCode_ZGenerators_eq,
+        Stabilizer.Lattice.toricHomologicalCode_XGenerators_eq]
+    rfl
   rw [closure_packaged_eq_full L, stabilizerGroup_toSubgroup_eq]
-  exact negIdentity_not_mem L
+  change StabilizerGroup.negIdentity (numQubits L) ∉ Subgroup.closure (generators L)
+  rw [h_gens_eq]
+  exact (Stabilizer.Lattice.toricHomologicalCode L).negIdentity_not_mem_closure_homologicalGenerators
 
 -- ---------------------------------------------------------------------------
 -- Phase 2: Logical operators (with logical-qubit-ops construction)
@@ -1520,6 +1545,19 @@ theorem toricStabilizerCode_subgroup_eq (L : ℕ) [Fact (2 ≤ L)] :
     (toricStabilizerCode L).toStabilizerGroup.toSubgroup = (stabilizerGroup L).toSubgroup := by
   change Subgroup.closure (listToSet (generatorsListPackaged L)) = _
   exact closure_packaged_eq_full L
+
+/-- Chain bridge: the toric stabilizer code's subgroup matches the abstract
+`(toricHomologicalCode L).homologicalStabilizerGroup`'s subgroup.
+
+Useful for delegating `IsNontrivialLogicalOperator` and centralizer membership
+through the generic `HomologicalCode` API.  Chains `toricStabilizerCode_subgroup_eq`
+with `Stabilizer.Lattice.toricHomologicalCode_homologicalStabilizerGroup_toSubgroup_eq`. -/
+theorem toricStabilizerCode_toSubgroup_eq_homologicalStabilizerGroup
+    (L : ℕ) [Fact (2 ≤ L)] :
+    (toricStabilizerCode L).toStabilizerGroup.toSubgroup =
+      (Stabilizer.Lattice.toricHomologicalCode L).homologicalStabilizerGroup.toSubgroup := by
+  rw [toricStabilizerCode_subgroup_eq,
+      ← Stabilizer.Lattice.toricHomologicalCode_homologicalStabilizerGroup_toSubgroup_eq]
 
 end ToricCodeN
 end StabilizerGroup

--- a/QEC/Stabilizer/Homological/Code.lean
+++ b/QEC/Stabilizer/Homological/Code.lean
@@ -95,6 +95,16 @@ theorem boundaries_le_cycles : X.boundaries ≤ X.cycles := by
   rcases hc with ⟨f, rfl⟩
   exact X.boundary_comp_apply f
 
+/-- Cycle membership unfolds to `∂₁ c = 0`. -/
+@[simp] theorem mem_cycles_iff (c : X.C1 → ZMod 2) :
+    c ∈ X.cycles ↔ X.boundary1 c = 0 :=
+  LinearMap.mem_ker
+
+/-- Boundary membership unfolds to existence of a 2-chain witness. -/
+theorem mem_boundaries_iff (c : X.C1 → ZMod 2) :
+    c ∈ X.boundaries ↔ ∃ f : X.C2 → ZMod 2, X.boundary2 f = c :=
+  Iff.rfl
+
 /-- `B₁` viewed as a submodule of `Z₁`. -/
 abbrev boundarySubmoduleInCycles : Submodule (ZMod 2) X.cycles :=
   Submodule.comap X.cycles.subtype X.boundaries
@@ -178,6 +188,21 @@ noncomputable def cutMap : (X.C0 → ZMod 2) →ₗ[ZMod 2] (X.C1 → ZMod 2) wh
 @[simp] theorem cutMap_apply (s : X.C0 → ZMod 2) (e : X.C1) :
     X.cutMap s e = ∑ v : X.C0, s v * X.boundary1 (Pi.single e 1) v := rfl
 
+/-- Pointwise expansion of `∂₁` via the standard basis on `C₁`.
+
+`(∂₁ c) v = ∑ e, c e · (∂₁ δ_e) v` where `δ_e := Pi.single e 1`.  This lets
+downstream code reason about per-vertex boundary values without re-deriving
+the basis expansion.  Used in `boundary1_cutMap_transpose`, and in the toric
+bridge that identifies `(toricHomologicalCode L).cutMap` with the lattice-
+specific `toricVertexCutMap`. -/
+theorem boundary1_apply_eq_sum (c : X.C1 → ZMod 2) (v : X.C0) :
+    X.boundary1 c v = ∑ e : X.C1, c e * X.boundary1 (Pi.single e 1) v := by
+  have hc : c = ∑ e : X.C1, c e • (Pi.single e (1 : ZMod 2)) := by
+    ext e
+    simp [Finset.sum_apply, Pi.single_apply]
+  conv_lhs => rw [hc]
+  simp [map_sum, map_smul, Finset.sum_apply, Pi.smul_apply, smul_eq_mul]
+
 /-- Symmetric pairing form of the transpose property.
 
 `⟨∂₁ c, s⟩ = ⟨c, cutMap s⟩` over `𝔽₂` with the standard pairing
@@ -185,14 +210,12 @@ noncomputable def cutMap : (X.C0 → ZMod 2) →ₗ[ZMod 2] (X.C1 → ZMod 2) wh
 theorem boundary1_cutMap_transpose (c : X.C1 → ZMod 2) (s : X.C0 → ZMod 2) :
     ∑ v : X.C0, X.boundary1 c v * s v =
       ∑ e : X.C1, c e * X.cutMap s e := by
-  -- Expand `c = ∑ e, c e • Pi.single e 1` and push the sum through `boundary1`.
-  have hc : c = ∑ e : X.C1, c e • (Pi.single e (1 : ZMod 2)) := by
-    ext e
-    simp [Finset.sum_apply, Pi.single_apply]
-  conv_lhs => rw [hc]
-  simp only [map_sum, map_smul, Finset.sum_apply, Pi.smul_apply, smul_eq_mul,
-    Finset.sum_mul]
-  rw [Finset.sum_comm]
+  have hlhs :
+      ∑ v : X.C0, X.boundary1 c v * s v =
+        ∑ v : X.C0, ∑ e : X.C1, c e * X.boundary1 (Pi.single e 1) v * s v := by
+    refine Finset.sum_congr rfl fun v _ => ?_
+    rw [boundary1_apply_eq_sum, Finset.sum_mul]
+  rw [hlhs, Finset.sum_comm]
   refine Finset.sum_congr rfl fun e _ => ?_
   rw [cutMap_apply, Finset.mul_sum]
   refine Finset.sum_congr rfl fun v _ => ?_

--- a/QEC/Stabilizer/Lattice.lean
+++ b/QEC/Stabilizer/Lattice.lean
@@ -7,6 +7,7 @@ import QEC.Stabilizer.Lattice.ToricHomology
 import QEC.Stabilizer.Lattice.ToricH1Dimension
 import QEC.Stabilizer.Lattice.ToricWrappingInvariants
 import QEC.Stabilizer.Lattice.ToricOperatorChains
+import QEC.Stabilizer.Lattice.ToricChainOps
 import QEC.Stabilizer.Lattice.ToricLogicalCorrespondenceX
 import QEC.Stabilizer.Lattice.ToricLogicalCorrespondenceZ
 import QEC.Stabilizer.Lattice.ToricDualWrappingInvariants

--- a/QEC/Stabilizer/Lattice/ToricChainComplex.lean
+++ b/QEC/Stabilizer/Lattice/ToricChainComplex.lean
@@ -1,8 +1,7 @@
 import QEC.Stabilizer.Homological
 import QEC.Stabilizer.Lattice.ToricHomology
 import QEC.Stabilizer.Lattice.ToricH1Dimension
-import QEC.Stabilizer.Lattice.ToricOperatorChains
-import QEC.Stabilizer.Lattice.ToricLogicalCorrespondenceZ
+import QEC.Stabilizer.Lattice.ToricChainOps
 import QEC.Stabilizer.Codes.ToricCodeN
 
 /-!
@@ -100,30 +99,144 @@ theorem toricHomologicalCode_chainXOperator_eq (L : ℕ) [Fact (0 < L)] (c : C1 
 theorem toricHomologicalCode_chainZOperator_eq (L : ℕ) [Fact (0 < L)] (c : C1 L) :
     (toricHomologicalCode L).chainZOperator c = toricZOperatorOfChain L c := rfl
 
-/-! ## Notes on the further toric file slim
+/-! ## Generator-set bridges
 
-Remaining bridges still needed for slimming the existing toric files
-(`ToricLogicalCorrespondenceX/Z.lean`, `ToricCodeNDistance.lean`,
-`ToricCodeNStabilizerCode.lean`):
+The toric instance carries its own `vertexStab`, `faceStab`, `ZGenerators`,
+`XGenerators` definitions (in `Codes/ToricCodeN.lean`).  The bridges below
+identify each of these with the generic versions provided by the
+`HomologicalCode` abstraction.
 
-  * `(toricHomologicalCode L).cutMap = toricVertexCutMap`
-    Non-trivial: abstract `cutMap` is defined as `∑ v, s v * ∂₁(δ_e)(v)`
-    while toric is defined by explicit edge match. Equal pointwise but
-    requires expanding the sum and case-splitting on edge type.
-  * `(toricHomologicalCode L).faceStabOf (x, y) = faceStab L x y`
-    Follows from cutMap-eq + chainXOperator-eq + the existing toric
-    `toricXOperatorOfChain_boundary_singleFace`.
-  * `(toricHomologicalCode L).vertexStabOf (x, y) = vertexStab L x y`
-    Similar via `toricZOperatorOfChain_cutMap_singleVtx`.
-  * Set equalities `(toricHomologicalCode L).XGenerators = XGenerators L` etc.
-  * Stabilizer-group equality.
+These bridges are what makes the toric correspondence / distance proofs
+collapse to one-line applications of the generic theorems in
+`Homological/LogicalCorrespondence.lean` and `Homological/Distance.lean`. -/
 
-With these bridges, each toric file's end-of-file iff theorems become
-1-line applications of the generic `chainXOperator_*_iff_*` /
-`chainZOperator_*_iff_*` theorems, plus a `rw` against the bridge.
-The full §B.3 symplectic-LI lift is independent of these bridges and is
-its own follow-up.
--/
+section Bridges
+
+variable (L : ℕ) [Fact (0 < L)]
+
+/-- The abstract `cutMap` of `toricHomologicalCode L` is the explicit
+`toricVertexCutMap`.  Proof: both are the `𝔽₂`-transpose of `∂₁`, and
+`∂₁` agrees on both definitions, so the transpose pairing
+`∑ v, ∂₁(δ_e) v * s v = ∑ e', δ_e e' * cutMap s e'` isolates the value
+at edge `e` on both sides. -/
+theorem toricHomologicalCode_cutMap_eq :
+    (toricHomologicalCode L).cutMap = toricVertexCutMap (L := L) := by
+  classical
+  refine LinearMap.ext fun s => ?_
+  funext e
+  -- Use an explicit `if`-chain as the indicator of edge `e`; this is `Pi.single e 1`
+  -- propositionally but avoids the family-inference complications of `Pi.single`.
+  let δ : EdgeIdx L → ZMod 2 := fun e' => if e' = e then 1 else 0
+  -- The abstract and toric transpose pairings, applied to `δ`.
+  have h1 := (toricHomologicalCode L).boundary1_cutMap_transpose δ s
+  have h2 := toricBoundary1_cutMap_transpose L δ s
+  -- The δ-weighted sum over `f : EdgeIdx L → ZMod 2` is just `f e`.
+  have hpi : ∀ f : EdgeIdx L → ZMod 2, ∑ e' : EdgeIdx L, δ e' * f e' = f e := by
+    intro f
+    have hsum :
+        ∑ e' : EdgeIdx L, δ e' * f e' = δ e * f e := by
+      refine Finset.sum_eq_single e ?_ ?_
+      · intros e' _ hne
+        change (if e' = e then (1 : ZMod 2) else 0) * f e' = 0
+        rw [if_neg hne]; ring
+      · intro h; exact absurd (Finset.mem_univ e) h
+    rw [hsum]
+    change (if e = e then (1 : ZMod 2) else 0) * f e = f e
+    rw [if_pos rfl]; ring
+  -- The two RHS sums are equal because the LHS sums are equal (both pair `∂₁ δ` with `s`).
+  have hRHS :
+      ∑ e' : EdgeIdx L, δ e' * (toricHomologicalCode L).cutMap s e'
+      = ∑ e' : EdgeIdx L, δ e' * toricVertexCutMap (L := L) s e' := by
+    have hLHS_eq :
+        ∑ v : VtxIdx L, (toricHomologicalCode L).boundary1 δ v * s v
+        = ∑ v : VtxIdx L, toricBoundary1 (L := L) δ v * s v := rfl
+    exact h1.symm.trans (hLHS_eq.trans h2)
+  -- Specialize `hpi` to both maps and chain.
+  have hL := hpi ((toricHomologicalCode L).cutMap s)
+  have hR := hpi (toricVertexCutMap (L := L) s)
+  exact hL.symm.trans (hRHS.trans hR)
+
+/-- The lattice `singleVtx v` is the abstract `singleVtx v`. -/
+theorem toricHomologicalCode_singleVtx_eq (v : VtxIdx L) :
+    (toricHomologicalCode L).singleVtx v = Lattice.singleVtx v := by
+  change (Pi.single v 1 : VtxIdx L → ZMod 2) = fun u => if u = v then 1 else 0
+  funext u
+  simp [Pi.single_apply]
+
+/-- The lattice `singleFace f` is the abstract `singleFace f`. -/
+theorem toricHomologicalCode_singleFace_eq (f : FaceIdx L) :
+    (toricHomologicalCode L).singleFace f = Lattice.singleFace f := by
+  change (Pi.single f 1 : FaceIdx L → ZMod 2) = fun p => if p = f then 1 else 0
+  funext p
+  simp [Pi.single_apply]
+
+variable [Fact (2 ≤ L)]
+
+/-- Bridge: the abstract vertex stabilizer equals the lattice `vertexStab`. -/
+theorem toricHomologicalCode_vertexStabOf_eq (v : VtxIdx L) :
+    (toricHomologicalCode L).vertexStabOf v =
+      StabilizerGroup.ToricCodeN.vertexStab L v.1 v.2 := by
+  unfold Homological.HomologicalCode.vertexStabOf
+  rw [toricHomologicalCode_chainZOperator_eq, toricHomologicalCode_cutMap_eq,
+      toricHomologicalCode_singleVtx_eq]
+  exact toricZOperatorOfChain_cutMap_singleVtx L v.1 v.2
+
+/-- Bridge: the abstract face stabilizer equals the lattice `faceStab`.
+    Routed through `toricXOperatorOfChain_boundary_singleFace`. -/
+theorem toricHomologicalCode_faceStabOf_eq (f : FaceIdx L) :
+    (toricHomologicalCode L).faceStabOf f =
+      StabilizerGroup.ToricCodeN.faceStab L f.1 f.2 := by
+  unfold Homological.HomologicalCode.faceStabOf
+  rw [toricHomologicalCode_chainXOperator_eq, toricHomologicalCode_singleFace_eq]
+  exact toricXOperatorOfChain_boundary_singleFace L f.1 f.2
+
+/-- Bridge: the abstract Z-generator set equals the lattice `ZGenerators L`. -/
+theorem toricHomologicalCode_ZGenerators_eq :
+    (toricHomologicalCode L).ZGenerators = StabilizerGroup.ToricCodeN.ZGenerators L := by
+  ext g
+  refine ⟨?_, ?_⟩
+  · rintro ⟨v, rfl⟩
+    rw [toricHomologicalCode_vertexStabOf_eq]
+    exact ⟨(v.1, v.2), rfl⟩
+  · rintro ⟨⟨x, y⟩, rfl⟩
+    refine ⟨(x, y), ?_⟩
+    exact toricHomologicalCode_vertexStabOf_eq L (x, y)
+
+/-- Bridge: the abstract X-generator set equals the lattice `XGenerators L`. -/
+theorem toricHomologicalCode_XGenerators_eq :
+    (toricHomologicalCode L).XGenerators = StabilizerGroup.ToricCodeN.XGenerators L := by
+  ext g
+  refine ⟨?_, ?_⟩
+  · rintro ⟨f, rfl⟩
+    rw [toricHomologicalCode_faceStabOf_eq]
+    exact ⟨(f.1, f.2), rfl⟩
+  · rintro ⟨⟨x, y⟩, rfl⟩
+    refine ⟨(x, y), ?_⟩
+    exact toricHomologicalCode_faceStabOf_eq L (x, y)
+
+/-! Note: the `dual` bridges (`dualCycles_eq`, `dualBoundary_eq`,
+`dualBoundaries_eq`) live in `ToricLogicalCorrespondenceZ.lean` — they reference
+`toricDualBoundary`/`toricDualCycles`/`toricDualBoundaries`, which are defined
+there.  See the §E.2 (Z-side) refactor for those bridges and the delegated iffs. -/
+
+/-- Bridge: the lattice `StabilizerGroup.ToricCodeN.stabilizerGroup L` and the abstract
+`(toricHomologicalCode L).homologicalStabilizerGroup` have the same underlying subgroup.
+
+This is the key fact for delegating any `IsNontrivialLogicalOperator` /
+`Subgroup`-mem statements between the toric and the generic stabilizer groups —
+see `IsNontrivialLogicalOperator_of_toSubgroup_eq`. -/
+theorem toricHomologicalCode_homologicalStabilizerGroup_toSubgroup_eq :
+    (toricHomologicalCode L).homologicalStabilizerGroup.toSubgroup =
+      (StabilizerGroup.ToricCodeN.stabilizerGroup L).toSubgroup := by
+  rw [StabilizerGroup.ToricCodeN.stabilizerGroup_toSubgroup_eq]
+  change Subgroup.closure (toricHomologicalCode L).homologicalGenerators =
+    Subgroup.closure (StabilizerGroup.ToricCodeN.generators L)
+  unfold Homological.HomologicalCode.homologicalGenerators
+    StabilizerGroup.ToricCodeN.generators
+  rw [toricHomologicalCode_ZGenerators_eq, toricHomologicalCode_XGenerators_eq]
+  rfl
+
+end Bridges
 
 end Lattice
 end Stabilizer

--- a/QEC/Stabilizer/Lattice/ToricChainOps.lean
+++ b/QEC/Stabilizer/Lattice/ToricChainOps.lean
@@ -1,0 +1,367 @@
+import Mathlib.Tactic
+import QEC.Stabilizer.Lattice.ToricOperatorChains
+import QEC.Stabilizer.Lattice.ToricH1Dimension
+import QEC.Stabilizer.Codes.ToricCodeN
+
+/-!
+# Toric chain-operator machinery (below the iff layer)
+
+This file collects the lattice-specific chain ↔ Pauli-element bridges that
+the generic `HomologicalCode`-instance for the toric code needs.  Placing
+them here (between `ToricH1Dimension` / `ToricCodeN` and the X/Z logical
+correspondence iff files) avoids a circular import:
+
+  `ToricChainComplex` imports this file → defines `toricHomologicalCode`
+  and the generator-set bridges → `ToricLogicalCorrespondenceX/Z` import
+  `ToricChainComplex` and delegate their iff theorems to the generic
+  `HomologicalCode` correspondence.
+
+Specifically, this file contains:
+
+* `toricZOperatorOfChain` — Z-flavored mirror of `toricXOperatorOfChain`.
+* `chainOfZOperator` and the round-trip lemma `chainOfZOperator_*`.
+* `toricXOperatorOfChain_zero` / `_add` and Z analogues.
+* `toricXOperatorOfChain_boundary_singleFace` — identifies the encoded
+  chain `toricBoundary2 (singleFace (x, y))` with the lattice `faceStab L x y`.
+* `toricZOperatorOfChain_cutMap_singleVtx` — same for the vertex side.
+-/
+
+namespace Quantum
+namespace Stabilizer
+namespace Lattice
+
+open scoped BigOperators
+
+-- ---------------------------------------------------------------------------
+-- Z-operator encoding (mirror of `toricXOperatorOfChain`)
+-- ---------------------------------------------------------------------------
+
+/-- Build a Z-type Pauli element from a 1-chain (dual to `toricXOperatorOfChain`). -/
+def toricZOperatorOfChain (L : ℕ) (c : C1 L) :
+    NQubitPauliGroupElement (toricNumQubits L) :=
+  ⟨0, fun q =>
+    if ∃ e : EdgeIdx L, edgeToQubitIdx L e = q ∧ c e = 1
+    then PauliOperator.Z else PauliOperator.I⟩
+
+/-- Recover a 1-chain from a Z-type Pauli element. -/
+def chainOfZOperator (L : ℕ) (g : NQubitPauliGroupElement (toricNumQubits L)) : C1 L :=
+  fun e => if g.operators (edgeToQubitIdx L e) = PauliOperator.Z then 1 else 0
+
+/-- Roundtrip: chain → Z-operator → chain. -/
+theorem chainOfZOperator_toricZOperatorOfChain (L : ℕ) (c : C1 L) :
+    chainOfZOperator L (toricZOperatorOfChain L c) = c := by
+  by_cases hL : 0 < L
+  · letI : Fact (0 < L) := ⟨hL⟩
+    ext e
+    by_cases hce : c e = 1
+    · have hex : ∃ e' : EdgeIdx L, edgeToQubitIdx L e' = edgeToQubitIdx L e ∧ c e' = 1 :=
+        ⟨e, rfl, hce⟩
+      simp [chainOfZOperator, toricZOperatorOfChain, hex, hce]
+    · have hnot :
+          ¬ ∃ e' : EdgeIdx L, edgeToQubitIdx L e' = edgeToQubitIdx L e ∧ c e' = 1 := by
+        intro hx
+        rcases hx with ⟨e', heq, he1⟩
+        exact hce ((edgeToQubitIdx_injective (L := L) heq) ▸ he1)
+      have hce0 : c e = 0 := by
+        rcases Nat.le_one_iff_eq_zero_or_eq_one.mp
+            (Nat.le_of_lt_succ (c e).val_lt) with h0 | h1
+        · calc c e = ((c e).val : ZMod 2) := (ZMod.natCast_zmod_val (c e)).symm
+               _ = 0 := by simp [h0]
+        · exact absurd (by calc
+              c e = ((c e).val : ZMod 2) := (ZMod.natCast_zmod_val (c e)).symm
+              _ = 1 := by simp [h1]) hce
+      simp [chainOfZOperator, toricZOperatorOfChain, hnot, hce0]
+  · have hL0 : L = 0 := Nat.eq_zero_of_not_pos hL
+    subst hL0
+    ext e
+    cases e with
+    | h x y => exact (Fin.elim0 x)
+    | v x y => exact (Fin.elim0 x)
+
+/-- Support membership of `toricZOperatorOfChain` at an indexed edge qubit. -/
+lemma mem_support_toricZOperatorOfChain_edgeToQubitIdx_iff
+    (L : ℕ) [Fact (0 < L)] (c : C1 L) (e : EdgeIdx L) :
+    edgeToQubitIdx L e ∈ (toricZOperatorOfChain L c).operators.support ↔ c e = 1 := by
+  constructor
+  · intro hmem
+    by_contra hne
+    have hnot :
+        ¬ ∃ e' : EdgeIdx L, edgeToQubitIdx L e' = edgeToQubitIdx L e ∧ c e' = 1 := by
+      intro hex
+      rcases hex with ⟨e', heq, he1⟩
+      have he' : e' = e := edgeToQubitIdx_injective L heq
+      exact hne (he' ▸ he1)
+    have hI : (toricZOperatorOfChain L c).operators (edgeToQubitIdx L e) = PauliOperator.I := by
+      simp [toricZOperatorOfChain, hnot]
+    have hneqI : (toricZOperatorOfChain L c).operators (edgeToQubitIdx L e) ≠ PauliOperator.I := by
+      simpa [NQubitPauliOperator.support] using hmem
+    exact hneqI hI
+  · intro he1
+    have hex : ∃ e' : EdgeIdx L, edgeToQubitIdx L e' = edgeToQubitIdx L e ∧ c e' = 1 :=
+      ⟨e, rfl, he1⟩
+    have hZ : (toricZOperatorOfChain L c).operators (edgeToQubitIdx L e) = PauliOperator.Z := by
+      simp [toricZOperatorOfChain, hex]
+    simp [NQubitPauliOperator.support, hZ]
+
+/-- The Z-operator-of-chain at qubit `q` is `Z` if some edge mapping to `q` has `c e = 1`,
+else `I`. -/
+lemma toricZOperatorOfChain_op_at (L : ℕ) (c : C1 L) (q : Fin (toricNumQubits L)) :
+    (toricZOperatorOfChain L c).operators q =
+      if ∃ e, edgeToQubitIdx L e = q ∧ c e = 1
+        then PauliOperator.Z else PauliOperator.I := rfl
+
+-- ---------------------------------------------------------------------------
+-- Homomorphism lemmas: `_zero` and `_add` for both X and Z
+-- ---------------------------------------------------------------------------
+
+/-- `toricXOperatorOfChain` sends the zero chain to the identity element. -/
+lemma toricXOperatorOfChain_zero (L : ℕ) :
+    toricXOperatorOfChain L 0 = 1 := by
+  unfold toricXOperatorOfChain
+  aesop
+
+set_option maxHeartbeats 1000000 in
+-- This pointwise-to-global proof unfolds many dependent equalities and case splits.
+/-- `toricXOperatorOfChain` maps chain addition to Pauli multiplication. -/
+lemma toricXOperatorOfChain_add (L : ℕ) (c c' : C1 L) :
+    toricXOperatorOfChain L (c + c') =
+      toricXOperatorOfChain L c * toricXOperatorOfChain L c' := by
+  simp [toricXOperatorOfChain] at *
+  simp +decide [NQubitPauliGroupElement.mul, NQubitPauliGroupElement.mulOp]
+  constructor
+  · rw [Finset.sum_eq_zero]; aesop
+  · ext q
+    split_ifs <;> simp_all +decide [Fin.ext_iff, ZMod]
+    · rename_i h₁ h₂ h₃
+      obtain ⟨e₁, he₁, he₂⟩ := h₁
+      obtain ⟨e₂, he₃, he₄⟩ := h₂
+      obtain ⟨e₃, he₅, he₆⟩ := h₃
+      have h_eq : e₁ = e₂ ∧ e₂ = e₃ := by
+        have h_eq :
+            ∀ e₁ e₂ : EdgeIdx L, edgeToQubitIdx L e₁ = edgeToQubitIdx L e₂ → e₁ = e₂ := by
+          intros e₁ e₂ h_eq
+          have h_eq' : edgeToQubitIdx L e₁ = edgeToQubitIdx L e₂ := h_eq
+          simp [edgeToQubitIdx] at h_eq'
+          rcases e₁ with (_ | _) <;> rcases e₂ with (_ | _) <;> norm_num at h_eq' ⊢
+          · rename_i a b c d
+            have h_eq' : b = d := by
+              exact Fin.ext (by nlinarith [Fin.is_lt a, Fin.is_lt b, Fin.is_lt c, Fin.is_lt d])
+            aesop
+          · rename_i a b c d
+            exact absurd h_eq'
+              (by nlinarith only [Fin.is_lt a, Fin.is_lt b, Fin.is_lt c, Fin.is_lt d])
+          · rename_i a b c d
+            exact absurd h_eq'
+              (by nlinarith [Fin.is_lt a, Fin.is_lt b, Fin.is_lt c, Fin.is_lt d])
+          · rename_i a b c d
+            have h_eq' : b = d := by
+              exact Fin.ext (by nlinarith [Fin.is_lt a, Fin.is_lt b, Fin.is_lt c, Fin.is_lt d])
+            aesop
+        exact ⟨h_eq e₁ e₂ (Fin.ext <| by aesop), h_eq e₂ e₃ (Fin.ext <| by aesop)⟩
+      grind
+    · grind
+    · grind
+    · grind
+
+/-- `toricZOperatorOfChain` maps the zero chain to the identity element. -/
+lemma toricZOperatorOfChain_zero (L : ℕ) :
+    toricZOperatorOfChain L 0 = 1 := by
+  unfold toricZOperatorOfChain
+  aesop
+
+set_option maxHeartbeats 1000000 in
+-- maxHeartbeats bumped: chain → Pauli homomorphism unfolding produces a goal with
+-- per-qubit case splits over `PauliOperator.mulOp`.
+/-- `toricZOperatorOfChain` maps chain addition to Pauli multiplication. -/
+lemma toricZOperatorOfChain_add (L : ℕ) (c c' : C1 L) :
+    toricZOperatorOfChain L (c + c') =
+      toricZOperatorOfChain L c * toricZOperatorOfChain L c' := by
+  simp [toricZOperatorOfChain] at *
+  simp +decide [NQubitPauliGroupElement.mul, NQubitPauliGroupElement.mulOp]
+  constructor
+  · rw [Finset.sum_eq_zero]; aesop
+  · ext q
+    split_ifs <;> simp_all +decide [Fin.ext_iff, ZMod]
+    · rename_i h₁ h₂ h₃
+      obtain ⟨e₁, he₁, he₂⟩ := h₁
+      obtain ⟨e₂, he₃, he₄⟩ := h₂
+      obtain ⟨e₃, he₅, he₆⟩ := h₃
+      have h_eq : e₁ = e₂ ∧ e₂ = e₃ := by
+        have h_eq :
+            ∀ e₁ e₂ : EdgeIdx L, edgeToQubitIdx L e₁ = edgeToQubitIdx L e₂ → e₁ = e₂ := by
+          intros e₁ e₂ h_eq
+          have h_eq' : edgeToQubitIdx L e₁ = edgeToQubitIdx L e₂ := h_eq
+          simp [edgeToQubitIdx] at h_eq'
+          rcases e₁ with (_ | _) <;> rcases e₂ with (_ | _) <;> norm_num at h_eq' ⊢
+          · rename_i a b c d
+            have h_eq' : b = d := by
+              exact Fin.ext (by nlinarith [Fin.is_lt a, Fin.is_lt b, Fin.is_lt c, Fin.is_lt d])
+            aesop
+          · rename_i a b c d
+            exact absurd h_eq'
+              (by nlinarith only [Fin.is_lt a, Fin.is_lt b, Fin.is_lt c, Fin.is_lt d])
+          · rename_i a b c d
+            exact absurd h_eq'
+              (by nlinarith [Fin.is_lt a, Fin.is_lt b, Fin.is_lt c, Fin.is_lt d])
+          · rename_i a b c d
+            have h_eq' : b = d := by
+              exact Fin.ext (by nlinarith [Fin.is_lt a, Fin.is_lt b, Fin.is_lt c, Fin.is_lt d])
+            aesop
+        exact ⟨h_eq e₁ e₂ (Fin.ext <| by aesop), h_eq e₂ e₃ (Fin.ext <| by aesop)⟩
+      grind
+    · grind
+    · grind
+    · grind
+
+-- ---------------------------------------------------------------------------
+-- Generator bridges: face stab via X-chain on ∂₂(singleFace),
+-- vertex stab via Z-chain on cutMap(singleVtx).
+-- ---------------------------------------------------------------------------
+
+/-- `toricXOperatorOfChain` maps the boundary of a single face to the corresponding
+face stabilizer. -/
+lemma toricXOperatorOfChain_boundary_singleFace (L : ℕ) [Fact (2 ≤ L)] (x y : Fin L) :
+    toricXOperatorOfChain L (toricBoundary2 (L := L) (singleFace (x, y))) =
+      StabilizerGroup.ToricCodeN.faceStab L x y := by
+  unfold toricXOperatorOfChain StabilizerGroup.ToricCodeN.faceStab
+  congr with q
+  split_ifs <;> simp_all +decide [NQubitPauliOperator.set]
+  · rename_i h
+    obtain ⟨e, rfl, he⟩ := h
+    rcases e with (_ | _) <;> simp_all +decide [toricBoundary2, singleFace]
+    · unfold edgeToQubitIdx; split_ifs at he <;> simp_all +decide [Fin.ext_iff]
+    · split_ifs at he <;> simp_all +decide [Fin.ext_iff, StabilizerGroup.ToricCodeN.next]
+  · split_ifs <;> simp_all +decide [toricNumQubits]
+    · rename_i h₁ h₂
+      contrapose! h₁
+      use EdgeIdx.v (StabilizerGroup.ToricCodeN.next L x) y
+      unfold edgeToQubitIdx; simp +decide [StabilizerGroup.ToricCodeN.next]
+      constructor
+      · exact rfl
+      · exact next_ne_self L x
+    · rename_i h₁ h₂ h₃
+      contrapose! h₁
+      use EdgeIdx.v x y
+      unfold edgeToQubitIdx; simp +decide [StabilizerGroup.ToricCodeN.vEdge]
+      grind
+    · rename_i h₁ h₂ h₃ h₄
+      contrapose! h₁
+      use EdgeIdx.h x (StabilizerGroup.ToricCodeN.next L y); simp +decide [edgeToQubitIdx]
+      unfold StabilizerGroup.ToricCodeN.next; simp +decide [Fin.ext_iff]
+      by_cases hy : y.val = L - 1
+      · rcases L with (_ | _ | L) <;> simp_all +decide
+        exact absurd (Fact.out (p := 2 ≤ 0 + 1)) (by decide)
+      · rw [Nat.mod_eq_of_lt] <;> omega
+    · rename_i h₁ h₂ h₃ h₄ h₅
+      contrapose! h₁
+      use EdgeIdx.h x y
+      unfold toricBoundary2; simp +decide [singleFace]
+      exact
+        Decidable.not_imp_iff_and_not.mp fun a ↦
+          h₄ (congrArg (StabilizerGroup.ToricCodeN.hEdge L x) (a rfl))
+    · unfold NQubitPauliOperator.identity; aesop
+
+set_option maxHeartbeats 800000 in
+-- maxHeartbeats bumped: equality on n-qubit Pauli elements after unfolding the cut map
+-- and the singleVtx indicator across 2·L² edges.
+/-- `toricZOperatorOfChain` applied to `toricVertexCutMap (singleVtx (xv, yv))`
+    equals the vertex stabilizer at `(xv, yv)`. -/
+lemma toricZOperatorOfChain_cutMap_singleVtx (L : ℕ) [Fact (2 ≤ L)]
+    (xv yv : Fin L) :
+    toricZOperatorOfChain L (toricVertexCutMap (L := L) (singleVtx (xv, yv))) =
+      StabilizerGroup.ToricCodeN.vertexStab L xv yv := by
+  have hL0 : 0 < L := Nat.lt_of_lt_of_le (by decide : 0 < 2) (Fact.out : 2 ≤ L)
+  haveI : Fact (0 < L) := ⟨hL0⟩
+  unfold toricZOperatorOfChain StabilizerGroup.ToricCodeN.vertexStab
+  congr with q
+  split_ifs <;> simp_all +decide [NQubitPauliOperator.set]
+  · rename_i h
+    obtain ⟨e, rfl, he⟩ := h
+    rcases e with ⟨ex, ey⟩ | ⟨ex, ey⟩
+    · -- h-edge case
+      simp only [toricVertexCutMap] at he
+      have hxL : (xv : ℕ) < L := xv.isLt
+      have hyL : (yv : ℕ) < L := yv.isLt
+      have hexL : (ex : ℕ) < L := ex.isLt
+      have heyL : (ey : ℕ) < L := ey.isLt
+      by_cases h1 : (ex, ey) = (xv, yv)
+      · obtain ⟨hex, hey⟩ := Prod.mk_inj.mp h1
+        subst hex; subst hey
+        unfold edgeToQubitIdx
+        simp_all +decide [Fin.ext_iff, StabilizerGroup.ToricCodeN.hEdge,
+          StabilizerGroup.ToricCodeN.vEdge, StabilizerGroup.ToricCodeN.prev,
+          NQubitPauliOperator.identity]
+      · by_cases h2 : (StabilizerGroup.ToricCodeN.next L ex, ey) = (xv, yv)
+        · obtain ⟨hnex, hey⟩ := Prod.mk_inj.mp h2
+          subst hey
+          have hex_eq : ex = StabilizerGroup.ToricCodeN.prev L xv :=
+            (Stabilizer.Lattice.eq_prev_iff_next_eq L ex xv).mpr hnex
+          subst hex_eq
+          unfold edgeToQubitIdx
+          simp_all +decide [Fin.ext_iff, StabilizerGroup.ToricCodeN.hEdge,
+            StabilizerGroup.ToricCodeN.vEdge, StabilizerGroup.ToricCodeN.prev,
+            NQubitPauliOperator.identity]
+        · exfalso
+          simp [h1, h2] at he
+    · -- v-edge case
+      simp only [toricVertexCutMap] at he
+      have hxL : (xv : ℕ) < L := xv.isLt
+      have hyL : (yv : ℕ) < L := yv.isLt
+      have hexL : (ex : ℕ) < L := ex.isLt
+      have heyL : (ey : ℕ) < L := ey.isLt
+      by_cases h1 : (ex, ey) = (xv, yv)
+      · obtain ⟨hex, hey⟩ := Prod.mk_inj.mp h1
+        subst hex; subst hey
+        unfold edgeToQubitIdx
+        simp_all +decide [Fin.ext_iff, StabilizerGroup.ToricCodeN.hEdge,
+          StabilizerGroup.ToricCodeN.vEdge, StabilizerGroup.ToricCodeN.prev,
+          NQubitPauliOperator.identity]
+      · by_cases h2 : (ex, StabilizerGroup.ToricCodeN.next L ey) = (xv, yv)
+        · obtain ⟨hex, hney⟩ := Prod.mk_inj.mp h2
+          subst hex
+          have hey_eq : ey = StabilizerGroup.ToricCodeN.prev L yv :=
+            (Stabilizer.Lattice.eq_prev_iff_next_eq L ey yv).mpr hney
+          subst hey_eq
+          unfold edgeToQubitIdx
+          simp_all +decide [Fin.ext_iff, StabilizerGroup.ToricCodeN.hEdge,
+            StabilizerGroup.ToricCodeN.vEdge, StabilizerGroup.ToricCodeN.prev,
+            NQubitPauliOperator.identity]
+        · exfalso
+          simp [h1, h2] at he
+  · -- neg case: q not in support of cutMap(singleVtx), must show vertexStab q = I
+    split_ifs <;> simp_all +decide [toricNumQubits]
+    · rename_i h₁ h₂
+      contrapose! h₁
+      refine ⟨EdgeIdx.v xv (StabilizerGroup.ToricCodeN.prev L yv), ?_, ?_⟩
+      · rfl
+      · have hne : (StabilizerGroup.ToricCodeN.prev L yv) ≠ yv :=
+          Stabilizer.Lattice.prev_ne_self L yv
+        simp [toricVertexCutMap, singleVtx, StabilizerGroup.ToricCodeN.prev,
+          Stabilizer.Lattice.next_prev, hne]
+    · rename_i h₁ h₂ h₃
+      contrapose! h₁
+      refine ⟨EdgeIdx.v xv yv, ?_, ?_⟩
+      · rfl
+      · have hne : StabilizerGroup.ToricCodeN.next L yv ≠ yv :=
+          Stabilizer.Lattice.next_ne_self L yv
+        simp [toricVertexCutMap, singleVtx, hne]
+    · rename_i h₁ h₂ h₃ h₄
+      contrapose! h₁
+      refine ⟨EdgeIdx.h (StabilizerGroup.ToricCodeN.prev L xv) yv, ?_, ?_⟩
+      · rfl
+      · have hne : (StabilizerGroup.ToricCodeN.prev L xv) ≠ xv :=
+          Stabilizer.Lattice.prev_ne_self L xv
+        simp [toricVertexCutMap, singleVtx, StabilizerGroup.ToricCodeN.prev,
+          Stabilizer.Lattice.next_prev, hne]
+    · rename_i h₁ h₂ h₃ h₄ h₅
+      contrapose! h₁
+      refine ⟨EdgeIdx.h xv yv, ?_, ?_⟩
+      · rfl
+      · have hne : StabilizerGroup.ToricCodeN.next L xv ≠ xv :=
+          Stabilizer.Lattice.next_ne_self L xv
+        simp [toricVertexCutMap, singleVtx, hne]
+    · unfold NQubitPauliOperator.identity; aesop
+
+end Lattice
+end Stabilizer
+end Quantum

--- a/QEC/Stabilizer/Lattice/ToricLogicalCorrespondenceX.lean
+++ b/QEC/Stabilizer/Lattice/ToricLogicalCorrespondenceX.lean
@@ -1,7 +1,8 @@
 import Mathlib.Tactic
-import QEC.Stabilizer.Lattice.ToricOperatorChains
+import QEC.Stabilizer.Lattice.ToricChainOps
 import QEC.Stabilizer.Lattice.ToricHomology
-import QEC.Stabilizer.Codes.ToricCodeN
+import QEC.Stabilizer.Lattice.ToricChainComplex
+import QEC.Stabilizer.Homological.LogicalCorrespondence
 import QEC.Stabilizer.Core.LogicalOperators
 
 
@@ -329,109 +330,16 @@ theorem boundary1_pointwise_zero_iff_mem_toricCycles
   · intro h v
     exact congrArg (fun f => f v) h
 
-/-- Commutation criterion: X-chain commutes with all Z checks iff it is a cycle. -/
+/-- Commutation criterion: X-chain commutes with all Z checks iff it is a cycle.
+
+This delegates to the generic `chainXOperator_commutes_ZGenerators_iff_mem_cycles`
+via the toric `HomologicalCode` instance and the lattice/abstract generator-set bridge. -/
 theorem xCommutesWithZChecks_iff_mem_toricCycles (L : ℕ) [Fact (2 ≤ L)] (c : C1 L) :
     xCommutesWithZChecks L c ↔ c ∈ toricCycles (L := L) := by
-  exact
-    (xCommutesWithZChecks_iff_boundary1_pointwise_zero L c).trans
-      (boundary1_pointwise_zero_iff_mem_toricCycles L c)
-
-/-
-`toricXOperatorOfChain` maps the zero chain to the identity Pauli element.
--/
-lemma toricXOperatorOfChain_zero (L : ℕ) :
-    toricXOperatorOfChain L 0 = 1 := by
-  unfold toricXOperatorOfChain;
-  aesop
-
-/-
-`toricXOperatorOfChain` maps chain addition to Pauli multiplication (ZMod 2 ↔ X²=I).
--/
-set_option maxHeartbeats 1000000 in
--- This pointwise-to-global proof unfolds many dependent equalities and case splits.
-lemma toricXOperatorOfChain_add (L : ℕ) (c c' : C1 L) :
-    toricXOperatorOfChain L (c + c') =
-      toricXOperatorOfChain L c * toricXOperatorOfChain L c' := by
-  -- By definition of toricXOperatorOfChain, the operators are determined by input 1-entries.
-  simp [toricXOperatorOfChain] at *;
-  simp +decide [ NQubitPauliGroupElement.mul, NQubitPauliGroupElement.mulOp ];
-  constructor;
-  · rw [ Finset.sum_eq_zero ] ; aesop;
-  · ext q;
-    split_ifs <;> simp_all +decide [ Fin.ext_iff, ZMod ];
-    · rename_i h₁ h₂ h₃;
-      obtain ⟨ e₁, he₁, he₂ ⟩ := h₁
-      obtain ⟨ e₂, he₃, he₄ ⟩ := h₂
-      obtain ⟨ e₃, he₅, he₆ ⟩ := h₃
-      have h_eq : e₁ = e₂ ∧ e₂ = e₃ := by
-        have h_eq : ∀ e₁ e₂ : EdgeIdx L, edgeToQubitIdx L e₁ = edgeToQubitIdx L e₂ → e₁ = e₂ := by
-          intros e₁ e₂ h_eq
-          have h_eq' : edgeToQubitIdx L e₁ = edgeToQubitIdx L e₂ := h_eq
-          simp [edgeToQubitIdx] at h_eq';
-          rcases e₁ with ( _ | _ ) <;> rcases e₂ with ( _ | _ ) <;> norm_num at h_eq' ⊢;
-          · rename_i a b c d;
-            have h_eq' : b = d := by
-              exact Fin.ext ( by nlinarith [ Fin.is_lt a, Fin.is_lt b, Fin.is_lt c, Fin.is_lt d ] );
-            aesop;
-          · rename_i a b c d
-            exact absurd h_eq'
-              (by nlinarith only [Fin.is_lt a, Fin.is_lt b, Fin.is_lt c, Fin.is_lt d])
-          · rename_i a b c d
-            exact absurd h_eq'
-              (by nlinarith [Fin.is_lt a, Fin.is_lt b, Fin.is_lt c, Fin.is_lt d])
-          · rename_i a b c d;
-            have h_eq' : b = d := by
-              exact Fin.ext ( by nlinarith [ Fin.is_lt a, Fin.is_lt b, Fin.is_lt c, Fin.is_lt d ] );
-            aesop;
-        exact ⟨ h_eq e₁ e₂ ( Fin.ext <| by aesop ), h_eq e₂ e₃ ( Fin.ext <| by aesop ) ⟩;
-      grind;
-    · grind;
-    · grind;
-    · grind
-
-/-
-`toricXOperatorOfChain` maps the boundary of a single face to the corresponding face stabilizer.
--/
-lemma toricXOperatorOfChain_boundary_singleFace (L : ℕ) [Fact (2 ≤ L)] (x y : Fin L) :
-    toricXOperatorOfChain L (toricBoundary2 (L := L) (singleFace (x, y))) =
-      StabilizerGroup.ToricCodeN.faceStab L x y := by
-  unfold toricXOperatorOfChain StabilizerGroup.ToricCodeN.faceStab;
-  congr with q;
-  split_ifs <;> simp_all +decide [ NQubitPauliOperator.set ];
-  · rename_i h
-    obtain ⟨e, rfl, he⟩ := h
-    rcases e with (_ | _) <;> simp_all +decide [toricBoundary2, singleFace]
-    · unfold edgeToQubitIdx; split_ifs at he <;> simp_all +decide [ Fin.ext_iff ] ;
-    · split_ifs at he <;> simp_all +decide [ Fin.ext_iff, StabilizerGroup.ToricCodeN.next ];
-  · split_ifs <;> simp_all +decide [ toricNumQubits ];
-    · rename_i h₁ h₂;
-      contrapose! h₁;
-      use EdgeIdx.v (StabilizerGroup.ToricCodeN.next L x) y;
-      unfold edgeToQubitIdx; simp +decide [ StabilizerGroup.ToricCodeN.next ] ;
-      constructor;
-      · exact rfl
-      · exact next_ne_self L x
-    · rename_i h₁ h₂ h₃;
-      contrapose! h₁;
-      use EdgeIdx.v x y;
-      unfold edgeToQubitIdx; simp +decide [ StabilizerGroup.ToricCodeN.vEdge ] ;
-      grind;
-    · rename_i h₁ h₂ h₃ h₄;
-      contrapose! h₁;
-      use EdgeIdx.h x (StabilizerGroup.ToricCodeN.next L y); simp +decide [ edgeToQubitIdx ] ;
-      unfold StabilizerGroup.ToricCodeN.next; simp +decide [ Fin.ext_iff ] ;
-      by_cases hy : y.val = L - 1;
-      · rcases L with ( _ | _ | L ) <;> simp_all +decide;
-        exact absurd ( Fact.out ( p := 2 ≤ 0 + 1 ) ) ( by decide );
-      · rw [ Nat.mod_eq_of_lt ] <;> omega;
-    · rename_i h₁ h₂ h₃ h₄ h₅;
-      contrapose! h₁;
-      use EdgeIdx.h x y;
-      unfold toricBoundary2; simp +decide [ singleFace ] ;
-      exact
-        Decidable.not_imp_iff_and_not.mp fun a ↦
-          h₄ (congrArg (StabilizerGroup.ToricCodeN.hEdge L x) (a rfl));
-    · unfold NQubitPauliOperator.identity; aesop;
+  haveI : Fact (0 < L) := ⟨Nat.lt_of_lt_of_le (by decide : 0 < 2) Fact.out⟩
+  unfold xCommutesWithZChecks
+  rw [← toricHomologicalCode_ZGenerators_eq]
+  exact (toricHomologicalCode L).chainXOperator_commutes_ZGenerators_iff_mem_cycles c
 
 /-
 Every 2-chain is a sum of single-face indicators.
@@ -444,49 +352,16 @@ lemma c2_eq_sum_singleFace (L : ℕ) (f : C2 L) :
     split_ifs <;> simp_all (config := {decide := true}) <;>
     first | rfl | exact absurd rfl ‹_›
 
-/-
-Stabilizer criterion: X-chain is plaquette product iff it is a boundary.
--/
+/-- Stabilizer criterion: X-chain is plaquette product iff it is a boundary.
+
+Delegates to `chainXOperator_mem_XClosure_iff_mem_boundaries` on the toric
+`HomologicalCode` instance via the X-generator bridge. -/
 theorem xIsPlaquetteProduct_iff_mem_toricBoundaries (L : ℕ) [Fact (2 ≤ L)] (c : C1 L) :
     xIsPlaquetteProduct L c ↔ c ∈ toricBoundaries (L := L) := by
-  constructor <;> intro hc <;> simp_all +decide [ xIsPlaquetteProduct, toricBoundaries ];
-  · have h_closure :
-        ∀ g ∈ Subgroup.closure (StabilizerGroup.ToricCodeN.XGenerators L),
-          ∃ f : C2 L, toricXOperatorOfChain L (toricBoundary2 (L := L) f) = g := by
-      intro g hg
-      induction hg using Subgroup.closure_induction with
-      | mem g hg =>
-          rcases hg with ⟨⟨x, y⟩, rfl⟩
-          exact ⟨singleFace (x, y), toricXOperatorOfChain_boundary_singleFace L x y⟩
-      | one => use 0; simp [toricXOperatorOfChain_zero]
-      | mul x y hx hy ihx ihy =>
-          obtain ⟨f₁, hf₁⟩ := ihx
-          obtain ⟨f₂, hf₂⟩ := ihy
-          use f₁ + f₂
-          simp +decide [hf₁, hf₂, toricXOperatorOfChain_add]
-      | inv x hx ih =>
-          obtain ⟨f, hf⟩ := ih
-          use f
-          simp_all +decide [toricXOperatorOfChain]
-          rw [← hf]
-          ext <;> simp +decide [NQubitPauliGroupElement.inv]
-    have := @chainOfXOperator_toricXOperatorOfChain L;
-    grind +splitImp;
-  · obtain ⟨ f, rfl ⟩ := hc;
-    rw [ c2_eq_sum_singleFace L f ];
-    induction (Finset.univ.filter fun p : FaceIdx L => f p = 1) using Finset.induction with
-    | empty =>
-        simp_all +decide
-        rw [ toricXOperatorOfChain_zero ]
-        exact OneMemClass.one_mem _
-    | insert a s has ih =>
-        simp_all +decide [Finset.sum_insert]
-        rw [ toricXOperatorOfChain_add ]
-        exact Subgroup.mul_mem _
-          (by
-            rw [toricXOperatorOfChain_boundary_singleFace]
-            exact Subgroup.subset_closure <| Set.mem_range_self _)
-          ih
+  haveI : Fact (0 < L) := ⟨Nat.lt_of_lt_of_le (by decide : 0 < 2) Fact.out⟩
+  unfold xIsPlaquetteProduct
+  rw [← toricHomologicalCode_XGenerators_eq]
+  exact (toricHomologicalCode L).chainXOperator_mem_XClosure_iff_mem_boundaries c
 
 /-
 X-type operators commute with the toric X-type chain encoding.
@@ -675,45 +550,29 @@ lemma stabilizer_same_ops_implies_boundary
   rw [h_eq] at hxcl
   exact (xIsPlaquetteProduct_iff_mem_toricBoundaries L c).mp hxcl
 
-/-
-X nontrivial logical iff corresponding chain is cycle-not-boundary.
--/
-set_option maxHeartbeats 1000000 in
--- This theorem combines closure induction with nontrivial-coset conditions.
+/-- X nontrivial logical iff corresponding chain is cycle-not-boundary.
+
+Delegates to the generic `chainXOperator_isNontrivialLogical_iff` via the
+shared underlying subgroup of the toric and abstract stabilizer groups. -/
 theorem xNontrivialLogical_iff_cycle_not_boundary (L : ℕ) [Fact (2 ≤ L)] (c : C1 L) :
     StabilizerGroup.IsNontrivialLogicalOperator
         (toricXOperatorOfChain L c) (StabilizerGroup.ToricCodeN.stabilizerGroup L) ↔
       c ∈ toricCycles (L := L) ∧ c ∉ toricBoundaries (L := L) := by
-  constructor <;> intro h;
-  · constructor;
-    · exact toricXOperatorOfChain_mem_centralizer_iff_cycle L c |>.1 h.1;
-    · intro hc
-      have h_plaquette :
-          toricXOperatorOfChain L c ∈
-            Subgroup.closure (StabilizerGroup.ToricCodeN.XGenerators L) := by
-        exact xIsPlaquetteProduct_iff_mem_toricBoundaries L c |>.2 hc
-      have h_in_stabilizer :
-          toricXOperatorOfChain L c ∈
-            (StabilizerGroup.ToricCodeN.stabilizerGroup L).toSubgroup := by
-        refine Subgroup.closure_induction ( fun x hx => ?_ ) ?_ ?_ ?_ h_plaquette;
-        · exact Subgroup.subset_closure
-            (by
-              rw [StabilizerGroup.ToricCodeN.listToSet_generatorsList]
-              exact Set.mem_union_right _ hx)
-        · exact OneMemClass.one_mem _;
-        · exact fun x y hx hy hx' hy' => Subgroup.mul_mem _ hx' hy';
-        · exact fun x hx₁ hx₂ => Subgroup.inv_mem _ hx₂
-      exact h.2.1 h_in_stabilizer;
-  · constructor;
-    · exact toricXOperatorOfChain_mem_centralizer_iff_cycle L c |>.2 h.1;
-    · have h_1 := h.1
-      have h_2 := h.2
-      constructor;
-      · intro hg
-        exact h_2 (stabilizer_same_ops_implies_boundary L c
-          (toricXOperatorOfChain L c) hg rfl)
-      · intro s hs hEq
-        exact h_2 (stabilizer_same_ops_implies_boundary L c s hs hEq)
+  haveI : Fact (0 < L) := ⟨Nat.lt_of_lt_of_le (by decide : 0 < 2) Fact.out⟩
+  -- The toric and abstract stabilizer groups have the same underlying subgroup
+  -- once we translate the lattice generator sets via the §E bridges.
+  have h_subgroup_eq :
+      (StabilizerGroup.ToricCodeN.stabilizerGroup L).toSubgroup =
+        (toricHomologicalCode L).homologicalStabilizerGroup.toSubgroup := by
+    rw [StabilizerGroup.ToricCodeN.stabilizerGroup_toSubgroup_eq]
+    change Subgroup.closure (StabilizerGroup.ToricCodeN.generators L) =
+      Subgroup.closure (toricHomologicalCode L).homologicalGenerators
+    unfold StabilizerGroup.ToricCodeN.generators Homological.HomologicalCode.homologicalGenerators
+    rw [toricHomologicalCode_ZGenerators_eq, toricHomologicalCode_XGenerators_eq]
+    rfl
+  rw [StabilizerGroup.IsNontrivialLogicalOperator_of_toSubgroup_eq _ h_subgroup_eq]
+  -- The toric `chainXOperator c` is `toricXOperatorOfChain L c` by `rfl`-bridge.
+  exact (toricHomologicalCode L).chainXOperator_isNontrivialLogical_iff c
 
 
 end Lattice

--- a/QEC/Stabilizer/Lattice/ToricLogicalCorrespondenceZ.lean
+++ b/QEC/Stabilizer/Lattice/ToricLogicalCorrespondenceZ.lean
@@ -1,7 +1,8 @@
 import Mathlib.Tactic
-import QEC.Stabilizer.Lattice.ToricOperatorChains
+import QEC.Stabilizer.Lattice.ToricChainOps
 import QEC.Stabilizer.Lattice.ToricH1Dimension
-import QEC.Stabilizer.Codes.ToricCodeN
+import QEC.Stabilizer.Lattice.ToricChainComplex
+import QEC.Stabilizer.Homological.LogicalCorrespondence
 import QEC.Stabilizer.Core.LogicalOperators
 
 namespace Quantum
@@ -30,84 +31,8 @@ Dual boundaries = range(toricVertexCutMap) = Z-chains that are products of verte
 -/
 
 -- ---------------------------------------------------------------------------
--- 1.  Z-operator encoding
--- ---------------------------------------------------------------------------
-
-/-- Build a Z-type Pauli element from a 1-chain (dual to `toricXOperatorOfChain`). -/
-def toricZOperatorOfChain (L : ℕ) (c : C1 L) :
-    NQubitPauliGroupElement (toricNumQubits L) :=
-  ⟨0, fun q =>
-    if ∃ e : EdgeIdx L, edgeToQubitIdx L e = q ∧ c e = 1
-    then PauliOperator.Z else PauliOperator.I⟩
-
-/-- Recover a 1-chain from a Z-type Pauli element. -/
-def chainOfZOperator (L : ℕ) (g : NQubitPauliGroupElement (toricNumQubits L)) : C1 L :=
-  fun e => if g.operators (edgeToQubitIdx L e) = PauliOperator.Z then 1 else 0
-
-/-- Roundtrip: chain → Z-operator → chain. -/
-theorem chainOfZOperator_toricZOperatorOfChain (L : ℕ) (c : C1 L) :
-    chainOfZOperator L (toricZOperatorOfChain L c) = c := by
-  by_cases hL : 0 < L
-  · letI : Fact (0 < L) := ⟨hL⟩
-    ext e
-    by_cases hce : c e = 1
-    · have hex : ∃ e' : EdgeIdx L, edgeToQubitIdx L e' = edgeToQubitIdx L e ∧ c e' = 1 :=
-        ⟨e, rfl, hce⟩
-      simp [chainOfZOperator, toricZOperatorOfChain, hex, hce]
-    · have hnot :
-          ¬ ∃ e' : EdgeIdx L, edgeToQubitIdx L e' = edgeToQubitIdx L e ∧ c e' = 1 := by
-        intro hx
-        rcases hx with ⟨e', heq, he1⟩
-        exact hce ((edgeToQubitIdx_injective (L := L) heq) ▸ he1)
-      have hce0 : c e = 0 := by
-        rcases Nat.le_one_iff_eq_zero_or_eq_one.mp (Nat.le_of_lt_succ (c e).val_lt) with h0 | h1
-        · calc c e = ((c e).val : ZMod 2) := (ZMod.natCast_zmod_val (c e)).symm
-               _ = 0 := by simp [h0]
-        · exact absurd (by calc
-              c e = ((c e).val : ZMod 2) := (ZMod.natCast_zmod_val (c e)).symm
-              _ = 1 := by simp [h1]) hce
-      simp [chainOfZOperator, toricZOperatorOfChain, hnot, hce0]
-  · have hL0 : L = 0 := Nat.eq_zero_of_not_pos hL
-    subst hL0
-    ext e
-    cases e with
-    | h x y => exact (Fin.elim0 x)
-    | v x y => exact (Fin.elim0 x)
-
-/-- Support membership of `toricZOperatorOfChain` at an indexed edge qubit. -/
-lemma mem_support_toricZOperatorOfChain_edgeToQubitIdx_iff
-    (L : ℕ) [Fact (0 < L)] (c : C1 L) (e : EdgeIdx L) :
-    edgeToQubitIdx L e ∈ (toricZOperatorOfChain L c).operators.support ↔ c e = 1 := by
-  constructor
-  · intro hmem
-    by_contra hne
-    have hnot :
-        ¬ ∃ e' : EdgeIdx L, edgeToQubitIdx L e' = edgeToQubitIdx L e ∧ c e' = 1 := by
-      intro hex
-      rcases hex with ⟨e', heq, he1⟩
-      have he' : e' = e := edgeToQubitIdx_injective L heq
-      exact hne (he' ▸ he1)
-    have hI : (toricZOperatorOfChain L c).operators (edgeToQubitIdx L e) = PauliOperator.I := by
-      simp [toricZOperatorOfChain, hnot]
-    have hneqI : (toricZOperatorOfChain L c).operators (edgeToQubitIdx L e) ≠ PauliOperator.I := by
-      simpa [NQubitPauliOperator.support] using hmem
-    exact hneqI hI
-  · intro he1
-    have hex : ∃ e' : EdgeIdx L, edgeToQubitIdx L e' = edgeToQubitIdx L e ∧ c e' = 1 :=
-      ⟨e, rfl, he1⟩
-    have hZ : (toricZOperatorOfChain L c).operators (edgeToQubitIdx L e) = PauliOperator.Z := by
-      simp [toricZOperatorOfChain, hex]
-    simp [NQubitPauliOperator.support, hZ]
-
-/-- The Z-operator-of-chain at qubit `q` is `Z` if some edge mapping to `q` has `c e = 1`,
-else `I`. -/
-lemma toricZOperatorOfChain_op_at (L : ℕ) (c : C1 L) (q : Fin (toricNumQubits L)) :
-    (toricZOperatorOfChain L c).operators q =
-      if ∃ e, edgeToQubitIdx L e = q ∧ c e = 1
-        then PauliOperator.Z else PauliOperator.I := rfl
-
--- ---------------------------------------------------------------------------
--- 2.  Dual cycle map and submodules
+-- 1.  Dual cycle map and submodules (Z-operator encoding lives in
+--     `ToricChainOps.lean` so the bridges in `ToricChainComplex.lean` can use it).
 -- ---------------------------------------------------------------------------
 
 /-- `toricDualBoundary`: the transpose of ∂₂, checking commutation with face stabs.
@@ -138,6 +63,182 @@ theorem toricDualBoundaries_le_toricDualCycles (L : ℕ) [Fact (0 < L)] :
   -- Each edge-value appears twice in the sum; a + a = 0 in ZMod 2.
   simp [toricDualBoundary, toricVertexCutMap]
   grind
+
+/-! ## §E bridges: lattice ↔ abstract dual structures
+
+These bridges allow Z-side iff theorems to be delegated to the generic
+`Homological.LogicalCorrespondence` theorems.  The bridges live here (rather
+than in `ToricChainComplex.lean`) because `toricDualBoundary`,
+`toricDualCycles`, `toricDualBoundaries` are defined in this file. -/
+
+section DualBridges
+
+variable (L : ℕ) [Fact (0 < L)]
+
+/-- Bridge: the abstract `dualBoundaries` (range of `cutMap`) equals the lattice
+`toricDualBoundaries` (range of `toricVertexCutMap`).  Follows directly from
+`toricHomologicalCode_cutMap_eq`. -/
+theorem toricHomologicalCode_dualBoundaries_eq :
+    (toricHomologicalCode L).dualBoundaries = toricDualBoundaries (L := L) := by
+  unfold Homological.HomologicalCode.dualBoundaries toricDualBoundaries
+  rw [toricHomologicalCode_cutMap_eq]
+  rfl
+
+/-- Bridge: the abstract `dualBoundary` linear map equals the lattice
+`toricDualBoundary`.
+
+Both are the `𝔽₂`-transpose of `toricBoundary2`.  The abstract one is defined
+as `c ↦ λ p, ∑ e, c e * ∂₂(δ_p)(e)`; the toric one is the explicit 4-term sum
+`c (h x y) + c (h x (next y)) + c (v x y) + c (v (next x) y)`.  We prove the
+equality pointwise by splitting `EdgeIdx` into h-edges and v-edges and
+identifying the four nonzero `∂₂(Pi.single (x, y) 1)` contributions. -/
+theorem toricHomologicalCode_dualBoundary_eq :
+    (toricHomologicalCode L).dualBoundary = toricDualBoundary (L := L) := by
+  classical
+  refine LinearMap.ext fun c => ?_
+  funext ⟨x, y⟩
+  -- LHS = ∑ e, c e * toricBoundary2 (Pi.single (x, y) 1) e
+  -- RHS = c (h x y) + c (h x (next y)) + c (v x y) + c (v (next x) y)
+  -- Strategy: split EdgeIdx into h and v via `edgeIdxEquivSum`, expand
+  -- `toricBoundary2 (Pi.single (x, y) 1)` pointwise, and identify the 4 nonzero terms.
+  change ∑ e : EdgeIdx L,
+        c e * toricBoundary2 (L := L) (Pi.single (x, y) (1 : ZMod 2)) e
+    = c (EdgeIdx.h x y) + c (EdgeIdx.h x (StabilizerGroup.ToricCodeN.next L y))
+      + c (EdgeIdx.v x y) + c (EdgeIdx.v (StabilizerGroup.ToricCodeN.next L x) y)
+  -- Step 1: rewrite the EdgeIdx-sum as a `Sum`-sum via `edgeIdxEquivSum`.
+  rw [← Equiv.sum_comp (edgeIdxEquivSum L).symm
+        (fun e : EdgeIdx L =>
+          c e * toricBoundary2 (L := L) (Pi.single (x, y) (1 : ZMod 2)) e),
+      Fintype.sum_sum_type]
+  -- Step 2: reduce each VtxIdx-sum.
+  -- h-edges:
+  --   ∑ p, c (h p.1 p.2) * (Pi.single (x, y) 1 (p.1, p.2) +
+  --                          Pi.single (x, y) 1 (p.1, prev p.2))
+  --   = c (h x y) + c (h x (next y))   (by Pi.single isolates one term in each)
+  have h_eq_prev_iff : ∀ {a b : Fin L},
+      StabilizerGroup.ToricCodeN.prev L a = b
+        ↔ a = StabilizerGroup.ToricCodeN.next L b := by
+    intros a b
+    constructor
+    · intro h
+      subst h
+      exact (Stabilizer.Lattice.next_prev L a).symm
+    · intro h
+      subst h
+      exact Stabilizer.Lattice.prev_next L b
+  have hh :
+      ∑ p : VtxIdx L,
+          (fun e : EdgeIdx L =>
+              c e * toricBoundary2 (L := L) (Pi.single (x, y) (1 : ZMod 2)) e)
+            ((edgeIdxEquivSum L).symm (Sum.inl p))
+      = c (EdgeIdx.h x y) + c (EdgeIdx.h x (StabilizerGroup.ToricCodeN.next L y)) := by
+    -- Rewrite `(edgeIdxEquivSum L).symm (Sum.inl p) = h p.1 p.2`
+    simp only [show ∀ p : VtxIdx L,
+        (edgeIdxEquivSum L).symm (Sum.inl p) = EdgeIdx.h p.1 p.2 by
+      rintro ⟨_, _⟩; rfl]
+    -- Unfold `toricBoundary2 (Pi.single (x, y) 1) (h p.1 p.2)`.
+    have heval : ∀ p : VtxIdx L,
+        toricBoundary2 (L := L) (Pi.single (x, y) (1 : ZMod 2)) (EdgeIdx.h p.1 p.2)
+          = (if (p.1, p.2) = (x, y) then (1 : ZMod 2) else 0)
+            + (if (p.1, StabilizerGroup.ToricCodeN.prev L p.2) = (x, y)
+                then 1 else 0) := by
+      intro p; simp [toricBoundary2, Pi.single_apply]
+    simp_rw [heval, mul_add, Finset.sum_add_distrib]
+    -- Now we have two sums to evaluate.
+    -- First: ∑ p, c (h p.1 p.2) * [(p.1, p.2) = (x, y)] = c (h x y)
+    have h1 :
+        ∑ p : VtxIdx L,
+            c (EdgeIdx.h p.1 p.2) * (if (p.1, p.2) = (x, y) then (1 : ZMod 2) else 0)
+        = c (EdgeIdx.h x y) := by
+      rw [Finset.sum_eq_single ((x, y) : VtxIdx L)]
+      · simp
+      · intros p _ hne; rw [if_neg hne]; ring
+      · intro h; exact absurd (Finset.mem_univ _) h
+    -- Second: ∑ p, c (h p.1 p.2) * [(p.1, prev p.2) = (x, y)] = c (h x (next y))
+    have h2 :
+        ∑ p : VtxIdx L,
+            c (EdgeIdx.h p.1 p.2)
+              * (if (p.1, StabilizerGroup.ToricCodeN.prev L p.2) = (x, y)
+                  then (1 : ZMod 2) else 0)
+        = c (EdgeIdx.h x (StabilizerGroup.ToricCodeN.next L y)) := by
+      rw [Finset.sum_eq_single ((x, StabilizerGroup.ToricCodeN.next L y) : VtxIdx L)]
+      · -- The indicator at (x, next y) is 1 (since prev (next y) = y).
+        rw [if_pos]
+        · ring
+        · refine Prod.mk.injEq _ _ _ _ |>.mpr ⟨rfl, ?_⟩
+          exact Stabilizer.Lattice.prev_next L y
+      · intros p _ hne
+        rw [if_neg]
+        · ring
+        · intro hcontra
+          apply hne
+          have hp1 : p.1 = x := (Prod.mk.injEq _ _ _ _).mp hcontra |>.1
+          have hp2 : StabilizerGroup.ToricCodeN.prev L p.2 = y :=
+            (Prod.mk.injEq _ _ _ _).mp hcontra |>.2
+          refine Prod.mk.injEq _ _ _ _ |>.mpr ⟨hp1, ?_⟩
+          exact h_eq_prev_iff.mp hp2
+      · intro h; exact absurd (Finset.mem_univ _) h
+    rw [h1, h2]
+  -- v-edges: symmetric.
+  have hv :
+      ∑ p : VtxIdx L,
+          (fun e : EdgeIdx L =>
+              c e * toricBoundary2 (L := L) (Pi.single (x, y) (1 : ZMod 2)) e)
+            ((edgeIdxEquivSum L).symm (Sum.inr p))
+      = c (EdgeIdx.v x y) + c (EdgeIdx.v (StabilizerGroup.ToricCodeN.next L x) y) := by
+    simp only [show ∀ p : VtxIdx L,
+        (edgeIdxEquivSum L).symm (Sum.inr p) = EdgeIdx.v p.1 p.2 by
+      rintro ⟨_, _⟩; rfl]
+    have heval : ∀ p : VtxIdx L,
+        toricBoundary2 (L := L) (Pi.single (x, y) (1 : ZMod 2)) (EdgeIdx.v p.1 p.2)
+          = (if (p.1, p.2) = (x, y) then (1 : ZMod 2) else 0)
+            + (if (StabilizerGroup.ToricCodeN.prev L p.1, p.2) = (x, y)
+                then 1 else 0) := by
+      intro p; simp [toricBoundary2, Pi.single_apply]
+    simp_rw [heval, mul_add, Finset.sum_add_distrib]
+    have h1 :
+        ∑ p : VtxIdx L,
+            c (EdgeIdx.v p.1 p.2) * (if (p.1, p.2) = (x, y) then (1 : ZMod 2) else 0)
+        = c (EdgeIdx.v x y) := by
+      rw [Finset.sum_eq_single ((x, y) : VtxIdx L)]
+      · simp
+      · intros p _ hne; rw [if_neg hne]; ring
+      · intro h; exact absurd (Finset.mem_univ _) h
+    have h2 :
+        ∑ p : VtxIdx L,
+            c (EdgeIdx.v p.1 p.2)
+              * (if (StabilizerGroup.ToricCodeN.prev L p.1, p.2) = (x, y)
+                  then (1 : ZMod 2) else 0)
+        = c (EdgeIdx.v (StabilizerGroup.ToricCodeN.next L x) y) := by
+      rw [Finset.sum_eq_single ((StabilizerGroup.ToricCodeN.next L x, y) : VtxIdx L)]
+      · rw [if_pos]
+        · ring
+        · refine Prod.mk.injEq _ _ _ _ |>.mpr ⟨?_, rfl⟩
+          exact Stabilizer.Lattice.prev_next L x
+      · intros p _ hne
+        rw [if_neg]
+        · ring
+        · intro hcontra
+          apply hne
+          have hp1 : StabilizerGroup.ToricCodeN.prev L p.1 = x :=
+            (Prod.mk.injEq _ _ _ _).mp hcontra |>.1
+          have hp2 : p.2 = y := (Prod.mk.injEq _ _ _ _).mp hcontra |>.2
+          refine Prod.mk.injEq _ _ _ _ |>.mpr ⟨?_, hp2⟩
+          exact h_eq_prev_iff.mp hp1
+      · intro h; exact absurd (Finset.mem_univ _) h
+    rw [h1, h2]
+  rw [hh, hv]
+  ring
+
+/-- Bridge: the abstract `dualCycles` (kernel of abstract `dualBoundary`) equals
+the lattice `toricDualCycles` (kernel of `toricDualBoundary`). -/
+theorem toricHomologicalCode_dualCycles_eq :
+    (toricHomologicalCode L).dualCycles = toricDualCycles (L := L) := by
+  unfold Homological.HomologicalCode.dualCycles toricDualCycles
+  rw [toricHomologicalCode_dualBoundary_eq]
+  rfl
+
+end DualBridges
 
 -- ---------------------------------------------------------------------------
 -- 3.  Z-type predicates
@@ -330,65 +431,20 @@ theorem dualBoundary_pointwise_zero_iff_mem_toricDualCycles
   · intro h p
     exact congrArg (fun f => f p) h
 
-/-- Z-chain commutes with all face checks iff it is a dual cycle. -/
+/-- Z-chain commutes with all face checks iff it is a dual cycle.
+
+Delegates to the generic `chainZOperator_commutes_XGenerators_iff_mem_dualCycles`
+via the X-generator and dual-cycle bridges. -/
 theorem zCommutesWithXChecks_iff_mem_toricDualCycles (L : ℕ) [Fact (2 ≤ L)] (c : C1 L) :
-    zCommutesWithXChecks L c ↔ c ∈ toricDualCycles (L := L) :=
-  (zCommutesWithXChecks_iff_dualBoundary_pointwise_zero L c).trans
-    (dualBoundary_pointwise_zero_iff_mem_toricDualCycles L c)
+    zCommutesWithXChecks L c ↔ c ∈ toricDualCycles (L := L) := by
+  haveI : Fact (0 < L) := ⟨Nat.lt_of_lt_of_le (by decide : 0 < 2) Fact.out⟩
+  unfold zCommutesWithXChecks
+  rw [← toricHomologicalCode_XGenerators_eq, ← toricHomologicalCode_dualCycles_eq]
+  exact (toricHomologicalCode L).chainZOperator_commutes_XGenerators_iff_mem_dualCycles c
 
 -- ---------------------------------------------------------------------------
 -- 6.  Vertex-stabilizer criterion (star product ↔ dual boundary)
 -- ---------------------------------------------------------------------------
-
-/-- `toricZOperatorOfChain` maps the zero chain to the identity element. -/
-lemma toricZOperatorOfChain_zero (L : ℕ) :
-    toricZOperatorOfChain L 0 = 1 := by
-  unfold toricZOperatorOfChain
-  aesop
-
-set_option maxHeartbeats 1000000 in
--- maxHeartbeats bumped: chain → Pauli homomorphism unfolding produces a goal with
--- per-qubit case splits over `PauliOperator.mulOp`.
-/-- `toricZOperatorOfChain` maps chain addition to Pauli multiplication. -/
-lemma toricZOperatorOfChain_add (L : ℕ) (c c' : C1 L) :
-    toricZOperatorOfChain L (c + c') =
-      toricZOperatorOfChain L c * toricZOperatorOfChain L c' := by
-  simp [toricZOperatorOfChain] at *
-  simp +decide [NQubitPauliGroupElement.mul, NQubitPauliGroupElement.mulOp]
-  constructor
-  · rw [Finset.sum_eq_zero]; aesop
-  · ext q
-    split_ifs <;> simp_all +decide [Fin.ext_iff, ZMod]
-    · rename_i h₁ h₂ h₃
-      obtain ⟨e₁, he₁, he₂⟩ := h₁
-      obtain ⟨e₂, he₃, he₄⟩ := h₂
-      obtain ⟨e₃, he₅, he₆⟩ := h₃
-      have h_eq : e₁ = e₂ ∧ e₂ = e₃ := by
-        have h_eq : ∀ e₁ e₂ : EdgeIdx L,
-            edgeToQubitIdx L e₁ = edgeToQubitIdx L e₂ → e₁ = e₂ := by
-          intros e₁ e₂ h_eq
-          have h_eq' : edgeToQubitIdx L e₁ = edgeToQubitIdx L e₂ := h_eq
-          simp [edgeToQubitIdx] at h_eq'
-          rcases e₁ with (_ | _) <;> rcases e₂ with (_ | _) <;> norm_num at h_eq' ⊢
-          · rename_i a b c d
-            have h_eq' : b = d := by
-              exact Fin.ext (by nlinarith [Fin.is_lt a, Fin.is_lt b, Fin.is_lt c, Fin.is_lt d])
-            aesop
-          · rename_i a b c d
-            exact absurd h_eq'
-              (by nlinarith only [Fin.is_lt a, Fin.is_lt b, Fin.is_lt c, Fin.is_lt d])
-          · rename_i a b c d
-            exact absurd h_eq'
-              (by nlinarith [Fin.is_lt a, Fin.is_lt b, Fin.is_lt c, Fin.is_lt d])
-          · rename_i a b c d
-            have h_eq' : b = d := by
-              exact Fin.ext (by nlinarith [Fin.is_lt a, Fin.is_lt b, Fin.is_lt c, Fin.is_lt d])
-            aesop
-        exact ⟨h_eq e₁ e₂ (Fin.ext <| by aesop), h_eq e₂ e₃ (Fin.ext <| by aesop)⟩
-      grind
-    · grind
-    · grind
-    · grind
 
 /-- Helper: every 0-chain is a sum of single-vertex indicators. -/
 private lemma c0_eq_sum_singleVtx (L : ℕ) (s : C0 L) :
@@ -399,157 +455,16 @@ private lemma c0_eq_sum_singleVtx (L : ℕ) (s : C0 L) :
     split_ifs <;> simp_all (config := {decide := true}) <;>
     first | rfl | exact absurd rfl ‹_›
 
-set_option maxHeartbeats 800000 in
--- maxHeartbeats bumped: equality on n-qubit Pauli elements after unfolding the cut map
--- and the singleVtx indicator across 2·L² edges.
-/-- `toricZOperatorOfChain` applied to `toricVertexCutMap (singleVtx (xv, yv))`
-    equals the vertex stabilizer at `(xv, yv)`. -/
-lemma toricZOperatorOfChain_cutMap_singleVtx (L : ℕ) [Fact (2 ≤ L)]
-    (xv yv : Fin L) :
-    toricZOperatorOfChain L (toricVertexCutMap (L := L) (singleVtx (xv, yv))) =
-      StabilizerGroup.ToricCodeN.vertexStab L xv yv := by
-  have hL0 : 0 < L := Nat.lt_of_lt_of_le (by decide : 0 < 2) (Fact.out : 2 ≤ L)
-  haveI : Fact (0 < L) := ⟨hL0⟩
-  unfold toricZOperatorOfChain StabilizerGroup.ToricCodeN.vertexStab
-  congr with q
-  split_ifs <;> simp_all +decide [NQubitPauliOperator.set]
-  · rename_i h
-    obtain ⟨e, rfl, he⟩ := h
-    rcases e with ⟨ex, ey⟩ | ⟨ex, ey⟩
-    · -- h-edge case: cutMap (singleVtx (xv,yv)) at h(ex,ey) = 1 means
-      -- ((ex,ey) = (xv,yv)) XOR (next L ex = xv ∧ ey = yv)
-      simp only [toricVertexCutMap] at he
-      have hxL : (xv : ℕ) < L := xv.isLt
-      have hyL : (yv : ℕ) < L := yv.isLt
-      have hexL : (ex : ℕ) < L := ex.isLt
-      have heyL : (ey : ℕ) < L := ey.isLt
-      -- he is essentially Σ over the 2 disjuncts, but in ZMod 2.
-      -- Decompose into cases by `decide`.
-      by_cases h1 : (ex, ey) = (xv, yv)
-      · obtain ⟨hex, hey⟩ := Prod.mk_inj.mp h1
-        subst hex; subst hey
-        unfold edgeToQubitIdx
-        simp_all +decide [Fin.ext_iff, StabilizerGroup.ToricCodeN.hEdge,
-          StabilizerGroup.ToricCodeN.vEdge, StabilizerGroup.ToricCodeN.prev,
-          NQubitPauliOperator.identity]
-      · by_cases h2 : (StabilizerGroup.ToricCodeN.next L ex, ey) = (xv, yv)
-        · obtain ⟨hnex, hey⟩ := Prod.mk_inj.mp h2
-          subst hey
-          have hex_eq : ex = StabilizerGroup.ToricCodeN.prev L xv :=
-            (Stabilizer.Lattice.eq_prev_iff_next_eq L ex xv).mpr hnex
-          subst hex_eq
-          unfold edgeToQubitIdx
-          simp_all +decide [Fin.ext_iff, StabilizerGroup.ToricCodeN.hEdge,
-            StabilizerGroup.ToricCodeN.vEdge, StabilizerGroup.ToricCodeN.prev,
-            NQubitPauliOperator.identity]
-        · exfalso
-          simp [h1, h2] at he
-    · -- v-edge case: cutMap (singleVtx (xv,yv)) at v(ex,ey) = 1 means
-      -- ((ex,ey) = (xv,yv)) XOR (ex = xv ∧ next L ey = yv)
-      simp only [toricVertexCutMap] at he
-      have hxL : (xv : ℕ) < L := xv.isLt
-      have hyL : (yv : ℕ) < L := yv.isLt
-      have hexL : (ex : ℕ) < L := ex.isLt
-      have heyL : (ey : ℕ) < L := ey.isLt
-      by_cases h1 : (ex, ey) = (xv, yv)
-      · obtain ⟨hex, hey⟩ := Prod.mk_inj.mp h1
-        subst hex; subst hey
-        unfold edgeToQubitIdx
-        simp_all +decide [Fin.ext_iff, StabilizerGroup.ToricCodeN.hEdge,
-          StabilizerGroup.ToricCodeN.vEdge, StabilizerGroup.ToricCodeN.prev,
-          NQubitPauliOperator.identity]
-      · by_cases h2 : (ex, StabilizerGroup.ToricCodeN.next L ey) = (xv, yv)
-        · obtain ⟨hex, hney⟩ := Prod.mk_inj.mp h2
-          subst hex
-          have hey_eq : ey = StabilizerGroup.ToricCodeN.prev L yv :=
-            (Stabilizer.Lattice.eq_prev_iff_next_eq L ey yv).mpr hney
-          subst hey_eq
-          unfold edgeToQubitIdx
-          simp_all +decide [Fin.ext_iff, StabilizerGroup.ToricCodeN.hEdge,
-            StabilizerGroup.ToricCodeN.vEdge, StabilizerGroup.ToricCodeN.prev,
-            NQubitPauliOperator.identity]
-        · exfalso
-          simp [h1, h2] at he
-  · -- neg case: q not in support of cutMap(singleVtx), must show vertexStab q = I
-    split_ifs <;> simp_all +decide [toricNumQubits]
-    · rename_i h₁ h₂
-      contrapose! h₁
-      refine ⟨EdgeIdx.v xv (StabilizerGroup.ToricCodeN.prev L yv), ?_, ?_⟩
-      · rfl
-      · have hne : (StabilizerGroup.ToricCodeN.prev L yv) ≠ yv :=
-          Stabilizer.Lattice.prev_ne_self L yv
-        simp [toricVertexCutMap, singleVtx, StabilizerGroup.ToricCodeN.prev,
-          Stabilizer.Lattice.next_prev, hne]
-    · rename_i h₁ h₂ h₃
-      contrapose! h₁
-      refine ⟨EdgeIdx.v xv yv, ?_, ?_⟩
-      · rfl
-      · have hne : StabilizerGroup.ToricCodeN.next L yv ≠ yv :=
-          Stabilizer.Lattice.next_ne_self L yv
-        simp [toricVertexCutMap, singleVtx, hne]
-    · rename_i h₁ h₂ h₃ h₄
-      contrapose! h₁
-      refine ⟨EdgeIdx.h (StabilizerGroup.ToricCodeN.prev L xv) yv, ?_, ?_⟩
-      · rfl
-      · have hne : (StabilizerGroup.ToricCodeN.prev L xv) ≠ xv :=
-          Stabilizer.Lattice.prev_ne_self L xv
-        simp [toricVertexCutMap, singleVtx, StabilizerGroup.ToricCodeN.prev,
-          Stabilizer.Lattice.next_prev, hne]
-    · rename_i h₁ h₂ h₃ h₄ h₅
-      contrapose! h₁
-      refine ⟨EdgeIdx.h xv yv, ?_, ?_⟩
-      · rfl
-      · have hne : StabilizerGroup.ToricCodeN.next L xv ≠ xv :=
-          Stabilizer.Lattice.next_ne_self L xv
-        simp [toricVertexCutMap, singleVtx, hne]
-    · unfold NQubitPauliOperator.identity; aesop
+/-- Z-chain is a star product iff the chain is a dual boundary.
 
-/-- Z-chain is a star product iff the chain is a dual boundary. -/
+Delegates to the generic `chainZOperator_mem_ZClosure_iff_mem_dualBoundaries`
+via the Z-generator and dual-boundary bridges. -/
 theorem zIsStarProduct_iff_mem_toricDualBoundaries (L : ℕ) [Fact (2 ≤ L)] (c : C1 L) :
     zIsStarProduct L c ↔ c ∈ toricDualBoundaries (L := L) := by
-  constructor <;> intro hc <;>
-    simp_all +decide [zIsStarProduct, toricDualBoundaries]
-  · -- → direction: from closure(ZGen) to range(cutMap)
-    have h_closure :
-        ∀ g ∈ Subgroup.closure (StabilizerGroup.ToricCodeN.ZGenerators L),
-          ∃ s : C0 L, toricZOperatorOfChain L (toricVertexCutMap (L := L) s) = g := by
-      intro g hg
-      induction hg using Subgroup.closure_induction with
-      | mem g hg =>
-          rcases hg with ⟨⟨xv, yv⟩, rfl⟩
-          exact ⟨singleVtx (xv, yv), toricZOperatorOfChain_cutMap_singleVtx L xv yv⟩
-      | one =>
-          use 0
-          simp only [map_zero, toricZOperatorOfChain_zero]
-      | mul x y hx hy ihx ihy =>
-          obtain ⟨s₁, hs₁⟩ := ihx
-          obtain ⟨s₂, hs₂⟩ := ihy
-          use s₁ + s₂
-          simp only [map_add]
-          simp +decide [hs₁, hs₂, toricZOperatorOfChain_add]
-      | inv x hx ih =>
-          obtain ⟨s, hs⟩ := ih
-          use s
-          simp_all +decide [toricZOperatorOfChain]
-          rw [← hs]
-          ext <;> simp +decide [NQubitPauliGroupElement.inv]
-    have hroundtrip := @chainOfZOperator_toricZOperatorOfChain L
-    grind +splitImp
-  · -- ← direction: from range(cutMap) to closure(ZGen)
-    obtain ⟨s, rfl⟩ := hc
-    rw [c0_eq_sum_singleVtx L s]
-    simp only [map_sum]
-    induction (Finset.univ.filter fun v : VtxIdx L => s v = 1) using Finset.induction with
-    | empty =>
-        simp only [Finset.sum_empty, toricZOperatorOfChain_zero]
-        exact OneMemClass.one_mem _
-    | insert a fs ha ih =>
-        simp only [Finset.sum_insert ha, toricZOperatorOfChain_add]
-        exact Subgroup.mul_mem _
-          (by rcases a with ⟨xv, yv⟩
-              rw [toricZOperatorOfChain_cutMap_singleVtx]
-              exact Subgroup.subset_closure ⟨(xv, yv), rfl⟩)
-          ih
+  haveI : Fact (0 < L) := ⟨Nat.lt_of_lt_of_le (by decide : 0 < 2) Fact.out⟩
+  unfold zIsStarProduct
+  rw [← toricHomologicalCode_ZGenerators_eq, ← toricHomologicalCode_dualBoundaries_eq]
+  exact (toricHomologicalCode L).chainZOperator_mem_ZClosure_iff_mem_dualBoundaries c
 
 -- ---------------------------------------------------------------------------
 -- 7.  Centralizer membership
@@ -736,45 +651,26 @@ lemma stabilizer_same_ops_implies_dualBoundary
 -- 9.  Nontrivial logical ↔ dual cycle but not dual boundary
 -- ---------------------------------------------------------------------------
 
-set_option maxHeartbeats 1000000 in
--- maxHeartbeats bumped: chains both directions of the iff through several
--- `IsNontrivialLogicalOperator` unfoldings.
-/-- Z nontrivial logical iff corresponding chain is a dual-cycle-not-dual-boundary. -/
+/-- Z nontrivial logical iff corresponding chain is a dual-cycle-not-dual-boundary.
+
+Delegates to the generic `chainZOperator_isNontrivialLogical_iff` via the
+stabilizer-subgroup bridge and the dual cycle/boundary bridges. -/
 theorem zNontrivialLogical_iff_dualCycle_not_dualBoundary
     (L : ℕ) [Fact (2 ≤ L)] (c : C1 L) :
     StabilizerGroup.IsNontrivialLogicalOperator
         (toricZOperatorOfChain L c) (StabilizerGroup.ToricCodeN.stabilizerGroup L) ↔
       c ∈ toricDualCycles (L := L) ∧ c ∉ toricDualBoundaries (L := L) := by
-  constructor <;> intro h
-  · -- mp: nontrivial logical → dual cycle not dual boundary
-    rw [StabilizerGroup.IsNontrivialLogicalOperator_iff] at h
-    constructor
-    · exact toricZOperatorOfChain_mem_centralizer_iff_dualCycle L c |>.1 h.1
-    · intro hc
-      have h_star :
-          toricZOperatorOfChain L c ∈
-            Subgroup.closure (StabilizerGroup.ToricCodeN.ZGenerators L) :=
-        (zIsStarProduct_iff_mem_toricDualBoundaries L c).2 hc
-      have h_in_stab :
-          toricZOperatorOfChain L c ∈
-            (StabilizerGroup.ToricCodeN.stabilizerGroup L).toSubgroup := by
-        refine Subgroup.closure_induction (fun x hx => ?_) ?_ ?_ ?_ h_star
-        · exact Subgroup.subset_closure
-            (by rw [StabilizerGroup.ToricCodeN.listToSet_generatorsList]
-                exact Set.mem_union_left _ hx)
-        · exact OneMemClass.one_mem _
-        · exact fun x y _ _ hx hy => Subgroup.mul_mem _ hx hy
-        · exact fun x _ hx => Subgroup.inv_mem _ hx
-      exact h.2.1 h_in_stab
-  · -- mpr: dual cycle not dual boundary → nontrivial logical
-    rw [StabilizerGroup.IsNontrivialLogicalOperator_iff]
-    refine ⟨?_, ?_, ?_⟩
-    · exact toricZOperatorOfChain_mem_centralizer_iff_dualCycle L c |>.2 h.1
-    · intro hg
-      exact h.2 (stabilizer_same_ops_implies_dualBoundary L c
-        (toricZOperatorOfChain L c) hg rfl)
-    · intro s hs hEq
-      exact h.2 (stabilizer_same_ops_implies_dualBoundary L c s hs hEq)
+  haveI : Fact (0 < L) := ⟨Nat.lt_of_lt_of_le (by decide : 0 < 2) Fact.out⟩
+  -- Translate the lattice `IsNontrivialLogicalOperator` to the abstract one
+  -- via the subgroup bridge.
+  have h_sub_eq :
+      (StabilizerGroup.ToricCodeN.stabilizerGroup L).toSubgroup =
+        (toricHomologicalCode L).homologicalStabilizerGroup.toSubgroup :=
+    (toricHomologicalCode_homologicalStabilizerGroup_toSubgroup_eq L).symm
+  rw [StabilizerGroup.IsNontrivialLogicalOperator_of_toSubgroup_eq _ h_sub_eq,
+      ← toricHomologicalCode_dualCycles_eq, ← toricHomologicalCode_dualBoundaries_eq]
+  -- `toricZOperatorOfChain L c = (toricHomologicalCode L).chainZOperator c` by `rfl`.
+  exact (toricHomologicalCode L).chainZOperator_isNontrivialLogical_iff c
 
 end Lattice
 end Stabilizer


### PR DESCRIPTION
## Summary

Wires the toric code's correspondence iffs, CSS distance bridge, and `StabilizerCode` packaging through the generic `Homological.HomologicalCode` infrastructure via `toricHomologicalCode L` plus seven lattice/abstract bridge lemmas. Implements Phase 2 (§A + §E) of the plan in `~/.claude/plans/i-was-also-planning-sunny-nova.md`.

### What now goes through the generic

Nine public toric results now delegate to `Homological/`:

| Toric theorem | Generic it calls |
|---|---|
| `xCommutesWithZChecks_iff_mem_toricCycles` | `chainXOperator_commutes_ZGenerators_iff_mem_cycles` |
| `xIsPlaquetteProduct_iff_mem_toricBoundaries` | `chainXOperator_mem_XClosure_iff_mem_boundaries` |
| `xNontrivialLogical_iff_cycle_not_boundary` | `chainXOperator_isNontrivialLogical_iff` |
| `zCommutesWithXChecks_iff_mem_toricDualCycles` | `chainZOperator_commutes_XGenerators_iff_mem_dualCycles` |
| `zIsStarProduct_iff_mem_toricDualBoundaries` | `chainZOperator_mem_ZClosure_iff_mem_dualBoundaries` |
| `zNontrivialLogical_iff_dualCycle_not_dualBoundary` | `chainZOperator_isNontrivialLogical_iff` |
| `generators_commute_packaged` | `homologicalGenerators_commute` |
| `negIdentity_not_mem_packaged` | `negIdentity_not_mem_closure_homologicalGenerators` |
| `not_both_boundary_of_nontrivial` (distance) | `Distance.not_both_boundary_of_nontrivial` |

### Bridges added (in `Stabilizer.Lattice` namespace)

- `toricHomologicalCode_cutMap_eq`
- `toricHomologicalCode_singleVtx_eq` / `_singleFace_eq`
- `toricHomologicalCode_vertexStabOf_eq` / `_faceStabOf_eq`
- `toricHomologicalCode_ZGenerators_eq` / `_XGenerators_eq`
- `toricHomologicalCode_homologicalStabilizerGroup_toSubgroup_eq`
- `toricHomologicalCode_dualBoundaries_eq` / `_dualBoundary_eq` / `_dualCycles_eq`
- New chained: `toricStabilizerCode_toSubgroup_eq_homologicalStabilizerGroup`

### §A prep lemmas (Homological/Code.lean)

- `mem_cycles_iff`
- `mem_boundaries_iff`
- `boundary1_apply_eq_sum` (pointwise basis-expansion of ∂₁)

### Architecture change

New file `Lattice/ToricChainOps.lean` (367 lines) consolidates chain-operator helpers (`toricZOperatorOfChain`, `_zero`, `_add`, `_cutMap_singleVtx`, `toricXOperatorOfChain_zero/_add/_boundary_singleFace`) previously split across X/Z iff files. This flips the import order so X/Z can import `ToricChainComplex` and consume the bridges. Symplectic-LI, logical-operator basis, and concrete distance witnesses remain toric-specific per the §B.3 / §D design choices in the plan.

### Stats

- 495 insertions, 568 deletions across 7 modified files
- New file `ToricChainOps.lean`: 367 lines (most moved from X/Z, not new content)
- Zero `sorry` introduced
- Full `lake build` passes (3396 jobs)

## Test plan

- [ ] `lake build` passes cleanly (verified locally — 3396 jobs)
- [ ] No new `sorry` markers introduced
- [ ] Theorem signatures unchanged on the refactored public surface (only proof bodies change); downstream consumers still compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)