### PR TITLE
feat(rsc): parametric rotated surface code on L × L lattice

### DIFF
--- a/QEC/Stabilizer/Codes.lean
+++ b/QEC/Stabilizer/Codes.lean
@@ -4,6 +4,7 @@ import QEC.Stabilizer.Codes.QuantumHamming
 import QEC.Stabilizer.Codes.RotatedSurfaceCode3
 import QEC.Stabilizer.Codes.RotatedSurfaceCodeN
 import QEC.Stabilizer.Codes.RotatedSurfaceCodeNStabilizerCode
+import QEC.Stabilizer.Codes.RotatedSurfaceCodeNDistanceX
 import QEC.Stabilizer.Codes.ToricCodeN
 import QEC.Stabilizer.Codes.ToricCodeNDistanceX
 import QEC.Stabilizer.Codes.ToricCodeNDistanceZ

--- a/QEC/Stabilizer/Codes.lean
+++ b/QEC/Stabilizer/Codes.lean
@@ -2,6 +2,8 @@ import QEC.Stabilizer.Codes.RepetitionCode3
 import QEC.Stabilizer.Codes.RepetitionCodeN
 import QEC.Stabilizer.Codes.QuantumHamming
 import QEC.Stabilizer.Codes.RotatedSurfaceCode3
+import QEC.Stabilizer.Codes.RotatedSurfaceCodeN
+import QEC.Stabilizer.Codes.RotatedSurfaceCodeNStabilizerCode
 import QEC.Stabilizer.Codes.ToricCodeN
 import QEC.Stabilizer.Codes.ToricCodeNDistanceX
 import QEC.Stabilizer.Codes.ToricCodeNDistanceZ

--- a/QEC/Stabilizer/Codes.lean
+++ b/QEC/Stabilizer/Codes.lean
@@ -6,6 +6,7 @@ import QEC.Stabilizer.Codes.RotatedSurfaceCodeN
 import QEC.Stabilizer.Codes.RotatedSurfaceCodeNStabilizerCode
 import QEC.Stabilizer.Codes.RotatedSurfaceCodeNDistanceX
 import QEC.Stabilizer.Codes.RotatedSurfaceCodeNDistanceZ
+import QEC.Stabilizer.Codes.RotatedSurfaceCodeNDistance
 import QEC.Stabilizer.Codes.ToricCodeN
 import QEC.Stabilizer.Codes.ToricCodeNDistanceX
 import QEC.Stabilizer.Codes.ToricCodeNDistanceZ

--- a/QEC/Stabilizer/Codes.lean
+++ b/QEC/Stabilizer/Codes.lean
@@ -5,6 +5,7 @@ import QEC.Stabilizer.Codes.RotatedSurfaceCode3
 import QEC.Stabilizer.Codes.RotatedSurfaceCodeN
 import QEC.Stabilizer.Codes.RotatedSurfaceCodeNStabilizerCode
 import QEC.Stabilizer.Codes.RotatedSurfaceCodeNDistanceX
+import QEC.Stabilizer.Codes.RotatedSurfaceCodeNDistanceZ
 import QEC.Stabilizer.Codes.ToricCodeN
 import QEC.Stabilizer.Codes.ToricCodeNDistanceX
 import QEC.Stabilizer.Codes.ToricCodeNDistanceZ

--- a/QEC/Stabilizer/Codes/RotatedSurfaceCodeN.lean
+++ b/QEC/Stabilizer/Codes/RotatedSurfaceCodeN.lean
@@ -1,0 +1,259 @@
+import QEC.Stabilizer.Lattice.RotatedSurfaceChainComplex
+import QEC.Stabilizer.Lattice.RotatedSurfaceH1Dimension
+import QEC.Stabilizer.Core.StabilizerGroup
+import QEC.Stabilizer.Core.CSSCommutationLemmas
+import QEC.Stabilizer.Homological.StabGroup
+import QEC.Stabilizer.Homological.LogicalCorrespondence
+
+/-!
+# Parametric rotated surface code on an `L × L` lattice (`L` odd, `L ≥ 3`)
+
+This file defines the lattice-side stabilizer generators for the rotated
+surface code, delegating commutation and the no-`-I` property to the generic
+`HomologicalCode` abstraction on `rotatedSurfaceHomologicalCode L`.
+
+The full `StabilizerCode (L*L) 1` packaging is built in
+[RotatedSurfaceCodeNStabilizerCode.lean](RotatedSurfaceCodeNStabilizerCode.lean).
+
+## Design
+
+The Z-stabilizer at a Z-face `zf : ZFaceIdx L` and the X-stabilizer at an
+X-face `xf : XFaceIdx L` are defined directly as the corresponding
+`HomologicalCode.vertexStabOf` / `faceStabOf`.  This pins every concrete
+generator to its abstract counterpart by definition, so the generator-set
+bridges below are all `rfl`.
+
+Since the rotated surface code has no redundant generators (we proved
+`rscBoundary2_injective` and `rscZCutMap_injective` in Stage 3), the
+full generator list has length
+
+  `|ZFaceIdx L| + |XFaceIdx L| = L² − 1 = numQubits L − 1`,
+
+which matches `StabilizerCode (L*L) 1`'s `generators_length` requirement
+*without trimming*.  Contrast the toric code, where the analogous list
+needs trimming by two (one redundancy on each side).
+-/
+
+namespace Quantum
+namespace StabilizerGroup
+namespace RotatedSurfaceCodeN
+
+open scoped BigOperators
+open NQubitPauliGroupElement
+open Stabilizer.Lattice.RotatedSurface
+
+/-- Physical qubit count: `L × L`. -/
+abbrev numQubits (L : ℕ) : ℕ := L * L
+
+variable (L : ℕ) [Fact (Odd L)] [Fact (3 ≤ L)]
+
+/-! ## Qubit indexing -/
+
+/-- Data-qubit index: row-major `(x, y) ↦ y * L + x`, matching `rscQubitEquiv`. -/
+noncomputable def dataQubitIdx (v : VtxIdx L) : Fin (numQubits L) :=
+  rscQubitEquiv L v
+
+/-! ## Stabilizer generators
+
+`zStab zf` and `xStab xf` are defined as the abstract `vertexStabOf` /
+`faceStabOf` on `rotatedSurfaceHomologicalCode L`.  This pins each
+generator to its homological counterpart, so the bridges below are all
+`rfl`.
+-/
+
+/-- Z-stabilizer at face `zf`. -/
+noncomputable def zStab (zf : ZFaceIdx L) : NQubitPauliGroupElement (numQubits L) :=
+  (rotatedSurfaceHomologicalCode L).vertexStabOf zf
+
+/-- X-stabilizer at face `xf`. -/
+noncomputable def xStab (xf : XFaceIdx L) : NQubitPauliGroupElement (numQubits L) :=
+  (rotatedSurfaceHomologicalCode L).faceStabOf xf
+
+@[simp] lemma zStab_eq_vertexStabOf (zf : ZFaceIdx L) :
+    zStab L zf = (rotatedSurfaceHomologicalCode L).vertexStabOf zf := rfl
+
+@[simp] lemma xStab_eq_faceStabOf (xf : XFaceIdx L) :
+    xStab L xf = (rotatedSurfaceHomologicalCode L).faceStabOf xf := rfl
+
+/-- Z-type generator set: all `zStab zf` for `zf : ZFaceIdx L`. -/
+noncomputable def ZGenerators : Set (NQubitPauliGroupElement (numQubits L)) :=
+  Set.range (zStab L)
+
+/-- X-type generator set: all `xStab xf` for `xf : XFaceIdx L`. -/
+noncomputable def XGenerators : Set (NQubitPauliGroupElement (numQubits L)) :=
+  Set.range (xStab L)
+
+/-- The full CSS generator set. -/
+noncomputable def generators : Set (NQubitPauliGroupElement (numQubits L)) :=
+  ZGenerators L ∪ XGenerators L
+
+/-- Bridge: the lattice-side Z-generators coincide with the abstract version. -/
+lemma ZGenerators_eq_homologicalZGenerators :
+    ZGenerators L = (rotatedSurfaceHomologicalCode L).ZGenerators := rfl
+
+/-- Bridge: the lattice-side X-generators coincide with the abstract version. -/
+lemma XGenerators_eq_homologicalXGenerators :
+    XGenerators L = (rotatedSurfaceHomologicalCode L).XGenerators := rfl
+
+/-- Bridge: the full generator set coincides with the abstract union. -/
+lemma generators_eq_homologicalGenerators :
+    generators L = (rotatedSurfaceHomologicalCode L).homologicalGenerators := rfl
+
+/-! ## Generator lists
+
+We enumerate the Z- and X-stabs via `Finset.univ.toList`.  This gives lists
+whose `listToSet` equals the corresponding generator set, and whose lengths
+are exactly `Fintype.card (ZFaceIdx L)` and `Fintype.card (XFaceIdx L)`.
+-/
+
+/-- Canonical list of all Z-stabs (length `(L²−1)/2`). -/
+noncomputable def generatorsListZ : List (NQubitPauliGroupElement (numQubits L)) :=
+  (Finset.univ : Finset (ZFaceIdx L)).toList.map (zStab L)
+
+/-- Canonical list of all X-stabs (length `(L²−1)/2`). -/
+noncomputable def generatorsListX : List (NQubitPauliGroupElement (numQubits L)) :=
+  (Finset.univ : Finset (XFaceIdx L)).toList.map (xStab L)
+
+/-- Canonical list of all generators (Z stabs then X stabs, length `L² − 1`). -/
+noncomputable def generatorsList : List (NQubitPauliGroupElement (numQubits L)) :=
+  generatorsListZ L ++ generatorsListX L
+
+/-! ### Length facts -/
+
+private lemma length_finset_univ_toList {α : Type*} [Fintype α] :
+    (Finset.univ : Finset α).toList.length = Fintype.card α := by
+  rw [Finset.length_toList, Finset.card_univ]
+
+lemma generatorsListZ_length :
+    (generatorsListZ L).length = Fintype.card (ZFaceIdx L) := by
+  simp [generatorsListZ]
+
+lemma generatorsListX_length :
+    (generatorsListX L).length = Fintype.card (XFaceIdx L) := by
+  simp [generatorsListX]
+
+lemma generatorsList_length :
+    (generatorsList L).length = numQubits L - 1 := by
+  unfold generatorsList numQubits
+  rw [List.length_append, generatorsListZ_length, generatorsListX_length]
+  exact card_ZFaceIdx_add_card_XFaceIdx (L := L)
+
+/-! ### `listToSet` for each list -/
+
+private lemma listToSet_map_finsetUnivToList {α : Type*} [Fintype α]
+    {n : ℕ} (f : α → NQubitPauliGroupElement n) :
+    listToSet ((Finset.univ : Finset α).toList.map f) = Set.range f := by
+  ext g
+  simp only [listToSet, Set.mem_setOf, Set.mem_range, List.mem_map,
+    Finset.mem_toList, Finset.mem_univ, true_and]
+
+lemma listToSet_generatorsListZ :
+    listToSet (generatorsListZ L) = ZGenerators L := by
+  unfold generatorsListZ ZGenerators
+  exact listToSet_map_finsetUnivToList _
+
+lemma listToSet_generatorsListX :
+    listToSet (generatorsListX L) = XGenerators L := by
+  unfold generatorsListX XGenerators
+  exact listToSet_map_finsetUnivToList _
+
+lemma listToSet_generatorsList :
+    listToSet (generatorsList L) = generators L := by
+  ext g
+  have hZ : g ∈ listToSet (generatorsListZ L) ↔ g ∈ ZGenerators L :=
+    Set.ext_iff.mp (listToSet_generatorsListZ L) g
+  have hX : g ∈ listToSet (generatorsListX L) ↔ g ∈ XGenerators L :=
+    Set.ext_iff.mp (listToSet_generatorsListX L) g
+  constructor
+  · intro hg
+    -- `hg : g ∈ listToSet (generatorsListZ L ++ generatorsListX L)` unfolds to a list-mem.
+    have hg' : g ∈ generatorsListZ L ++ generatorsListX L := hg
+    rcases List.mem_append.mp hg' with hgZ | hgX
+    · exact Or.inl (hZ.mp hgZ)
+    · exact Or.inr (hX.mp hgX)
+  · intro hg
+    change g ∈ generatorsListZ L ++ generatorsListX L
+    rcases hg with hgZ | hgX
+    · exact List.mem_append_left _ (hZ.mpr hgZ)
+    · exact List.mem_append_right _ (hX.mpr hgX)
+
+/-! ### Phase-zero -/
+
+lemma allPhaseZero_generatorsListZ : AllPhaseZero (generatorsListZ L) := by
+  intro g hg
+  rcases List.mem_map.mp hg with ⟨zf, _, rfl⟩
+  rfl
+
+lemma allPhaseZero_generatorsListX : AllPhaseZero (generatorsListX L) := by
+  intro g hg
+  rcases List.mem_map.mp hg with ⟨xf, _, rfl⟩
+  rfl
+
+lemma allPhaseZero_generatorsList : AllPhaseZero (generatorsList L) := by
+  intro g hg
+  rcases List.mem_append.mp hg with hZ | hX
+  · exact allPhaseZero_generatorsListZ L g hZ
+  · exact allPhaseZero_generatorsListX L g hX
+
+/-! ## Commutation, no `-I`, and the canonical stabilizer group
+
+All three properties are delegated to the generic `HomologicalCode`
+infrastructure on `rotatedSurfaceHomologicalCode L`.
+-/
+
+/-- Every Z-stab is Z-type. -/
+lemma zStab_is_ZType (zf : ZFaceIdx L) :
+    NQubitPauliGroupElement.IsZTypeElement (zStab L zf) :=
+  (rotatedSurfaceHomologicalCode L).vertexStabOf_isZType zf
+
+/-- Every X-stab is X-type. -/
+lemma xStab_is_XType (xf : XFaceIdx L) :
+    NQubitPauliGroupElement.IsXTypeElement (xStab L xf) :=
+  (rotatedSurfaceHomologicalCode L).faceStabOf_isXType xf
+
+/-- Generators pairwise commute (delegated to the generic CSS argument). -/
+lemma generators_commute :
+    ∀ g ∈ generators L, ∀ h ∈ generators L, g * h = h * g := by
+  intro g hg h hh
+  exact (rotatedSurfaceHomologicalCode L).homologicalGenerators_commute g hg h hh
+
+/-- `-I` is not in the closure of the lattice generators. -/
+lemma negIdentity_not_mem :
+    StabilizerGroup.negIdentity (numQubits L) ∉ Subgroup.closure (generators L) :=
+  (rotatedSurfaceHomologicalCode L).negIdentity_not_mem_closure_homologicalGenerators
+
+/-- The canonical rotated-surface stabilizer subgroup.
+
+  Equal by definition to
+  `(rotatedSurfaceHomologicalCode L).homologicalStabilizerGroup.toSubgroup`. -/
+noncomputable def subgroup : Subgroup (NQubitPauliGroupElement (numQubits L)) :=
+  Subgroup.closure (generators L)
+
+lemma subgroup_eq_homologicalStabilizerGroup :
+    subgroup L = (rotatedSurfaceHomologicalCode L).homologicalStabilizerGroup.toSubgroup := rfl
+
+/-- The full lattice-side stabilizer group. -/
+noncomputable def stabilizerGroup : StabilizerGroup (numQubits L) :=
+  StabilizerGroup.mkStabilizerFromGenerators (numQubits L) (generatorsList L)
+    (by rw [listToSet_generatorsList]; exact generators_commute L)
+    (by rw [listToSet_generatorsList]; exact negIdentity_not_mem L)
+
+lemma stabilizerGroup_toSubgroup_eq :
+    (stabilizerGroup L).toSubgroup = subgroup L := by
+  simp only [stabilizerGroup, StabilizerGroup.mkStabilizerFromGenerators, subgroup]
+  rw [listToSet_generatorsList]
+
+/-- The canonical stabilizer group has the same underlying subgroup as the
+generic `homologicalStabilizerGroup` from `rotatedSurfaceHomologicalCode L`.
+
+This is the key bridge that lets distance / centralizer / logical-operator
+proofs run against either group interchangeably (via
+`IsNontrivialLogicalOperator_of_toSubgroup_eq`). -/
+lemma stabilizerGroup_toSubgroup_eq_homologicalStabilizerGroup :
+    (stabilizerGroup L).toSubgroup =
+      (rotatedSurfaceHomologicalCode L).homologicalStabilizerGroup.toSubgroup := by
+  rw [stabilizerGroup_toSubgroup_eq, subgroup_eq_homologicalStabilizerGroup]
+
+end RotatedSurfaceCodeN
+end StabilizerGroup
+end Quantum

--- a/QEC/Stabilizer/Codes/RotatedSurfaceCodeNDistance.lean
+++ b/QEC/Stabilizer/Codes/RotatedSurfaceCodeNDistance.lean
@@ -1,0 +1,467 @@
+import Mathlib.Tactic
+import QEC.Stabilizer.Codes.RotatedSurfaceCodeNDistanceX
+import QEC.Stabilizer.Codes.RotatedSurfaceCodeNDistanceZ
+import QEC.Stabilizer.Codes.RotatedSurfaceCodeNStabilizerCode
+import QEC.Stabilizer.Homological.Distance
+import QEC.Stabilizer.Core.CodeDistance
+
+/-!
+# Stage 7 — Combined rotated-surface-code distance = `L`
+
+Combines the X-distance ≥ L (`RotatedSurfaceCodeNDistanceX`) and the
+Z-distance ≥ L (`RotatedSurfaceCodeNDistanceZ`) via the CSS bridge
+`HomologicalCode.not_both_boundary_of_nontrivial` to obtain
+`HasCodeDistance (rotatedSurfaceStabilizerCode L) L`.
+
+The argument mirrors `ToricCodeNDistance`:
+
+* For a non-trivial logical `g`, its X-chain `xChainOf g` is always a
+  cycle and its Z-chain `zChainOf g` is always a dual cycle (because `g`
+  commutes with every stabilizer generator).
+* The CSS bridge guarantees that the two chains cannot **both** be
+  boundaries.
+* Whichever side is *not* a boundary gives a non-trivial X-type
+  (resp. Z-type) logical via `chainXOperator` (resp. `chainZOperator`),
+  whose weight is ≥ L by Stage 5 (resp. Stage 6).
+* The qubit-wise inclusion `weight g ≥ chainWeight (xChainOf g)`
+  (`HomologicalCode.weight_ge_chainWeight_xChainOf`) then transfers the
+  bound to `weight g`.
+-/
+
+namespace Quantum
+namespace StabilizerGroup
+namespace RotatedSurfaceCodeN
+
+open scoped BigOperators
+open NQubitPauliGroupElement Stabilizer.Lattice.RotatedSurface
+  Quantum.Stabilizer.Homological.HomologicalCode
+
+variable (L : ℕ) [Fact (Odd L)] [Fact (3 ≤ L)]
+
+/-! ### Qubit-wise anticommutation bridges
+
+For any qubit `i`, the anticommutation pattern of `g` against a
+Z-type (resp. X-type) stabilizer generator depends only on `g`'s
+X-content (resp. Z-content) at `i`.  These are the rotated-surface
+analogues of `ToricCodeNDistance.anticommutesAt_vertexStab_g_iff_xChain`
+/ `anticommutesAt_faceStab_g_iff_zChain`. -/
+
+/-- Against the Z-type vertex stabilizer, qubit-wise anticommutation of
+`g` matches that of `chainXOperator (xChainOf g)` (the "X-only encoding"
+of `g`). -/
+private lemma anticommutesAt_vertexStabOf_iff_xChainOf
+    (g : NQubitPauliGroupElement (rotatedSurfaceHomologicalCode L).numQubits)
+    (v : (rotatedSurfaceHomologicalCode L).C0)
+    (i : Fin (rotatedSurfaceHomologicalCode L).numQubits) :
+    NQubitPauliGroupElement.anticommutesAt
+        ((rotatedSurfaceHomologicalCode L).vertexStabOf v).operators
+        g.operators i ↔
+      NQubitPauliGroupElement.anticommutesAt
+        ((rotatedSurfaceHomologicalCode L).vertexStabOf v).operators
+        ((rotatedSurfaceHomologicalCode L).chainXOperator
+          ((rotatedSurfaceHomologicalCode L).xChainOf g)).operators i := by
+  have hZ :
+      ((rotatedSurfaceHomologicalCode L).vertexStabOf v).operators i =
+        PauliOperator.I ∨
+      ((rotatedSurfaceHomologicalCode L).vertexStabOf v).operators i =
+        PauliOperator.Z :=
+    (Quantum.Stabilizer.Homological.HomologicalCode.vertexStabOf_isZType
+      (X := rotatedSurfaceHomologicalCode L) v).2 i
+  have heq :=
+    Quantum.Stabilizer.Homological.HomologicalCode.chainXOperator_xChainOf_op_at
+      (X := rotatedSurfaceHomologicalCode L) g i
+  rcases hZ with hI | hZ
+  · simp only [NQubitPauliGroupElement.anticommutesAt, hI]
+    cases hgi : g.operators i <;>
+      cases hxi :
+        ((rotatedSurfaceHomologicalCode L).chainXOperator
+          ((rotatedSurfaceHomologicalCode L).xChainOf g)).operators i <;>
+      simp [PauliOperator.mulOp]
+  · simp only [NQubitPauliGroupElement.anticommutesAt, hZ, heq]
+    cases hgi : g.operators i <;>
+      simp [PauliOperator.mulOp]
+
+/-- Against the X-type face stabilizer, qubit-wise anticommutation of `g`
+matches that of `chainZOperator (zChainOf g)` (the "Z-only encoding"
+of `g`). -/
+private lemma anticommutesAt_faceStabOf_iff_zChainOf
+    (g : NQubitPauliGroupElement (rotatedSurfaceHomologicalCode L).numQubits)
+    (f : (rotatedSurfaceHomologicalCode L).C2)
+    (i : Fin (rotatedSurfaceHomologicalCode L).numQubits) :
+    NQubitPauliGroupElement.anticommutesAt
+        ((rotatedSurfaceHomologicalCode L).faceStabOf f).operators
+        g.operators i ↔
+      NQubitPauliGroupElement.anticommutesAt
+        ((rotatedSurfaceHomologicalCode L).faceStabOf f).operators
+        ((rotatedSurfaceHomologicalCode L).chainZOperator
+          ((rotatedSurfaceHomologicalCode L).zChainOf g)).operators i := by
+  have hX :
+      ((rotatedSurfaceHomologicalCode L).faceStabOf f).operators i =
+        PauliOperator.I ∨
+      ((rotatedSurfaceHomologicalCode L).faceStabOf f).operators i =
+        PauliOperator.X :=
+    (Quantum.Stabilizer.Homological.HomologicalCode.faceStabOf_isXType
+      (X := rotatedSurfaceHomologicalCode L) f).2 i
+  have heq :=
+    Quantum.Stabilizer.Homological.HomologicalCode.chainZOperator_zChainOf_op_at
+      (X := rotatedSurfaceHomologicalCode L) g i
+  rcases hX with hI | hX
+  · simp only [NQubitPauliGroupElement.anticommutesAt, hI]
+    cases hgi : g.operators i <;>
+      cases hzi :
+        ((rotatedSurfaceHomologicalCode L).chainZOperator
+          ((rotatedSurfaceHomologicalCode L).zChainOf g)).operators i <;>
+      simp [PauliOperator.mulOp]
+  · simp only [NQubitPauliGroupElement.anticommutesAt, hX, heq]
+    cases hgi : g.operators i <;>
+      simp [PauliOperator.mulOp]
+
+/-! ### Centralizer → cycle bridges -/
+
+/-- For `g ∈ centralizer`, `xChainOf g` is a 1-cycle. -/
+private lemma xChainOf_mem_cycles_of_centralizer
+    (g : NQubitPauliGroupElement (rotatedSurfaceHomologicalCode L).numQubits)
+    (hg : g ∈ StabilizerGroup.centralizer
+            (rotatedSurfaceHomologicalCode L).homologicalStabilizerGroup) :
+    (rotatedSurfaceHomologicalCode L).xChainOf g ∈
+      (rotatedSurfaceHomologicalCode L).cycles := by
+  apply (chainXOperator_mem_centralizer_iff_mem_cycles
+      (X := rotatedSurfaceHomologicalCode L)
+      ((rotatedSurfaceHomologicalCode L).xChainOf g)).mp
+  intro s hs
+  refine Subgroup.closure_induction
+    (p := fun y _ => y *
+        (rotatedSurfaceHomologicalCode L).chainXOperator
+          ((rotatedSurfaceHomologicalCode L).xChainOf g) =
+      (rotatedSurfaceHomologicalCode L).chainXOperator
+        ((rotatedSurfaceHomologicalCode L).xChainOf g) * y) ?_ ?_ ?_ ?_ hs
+  · rintro y (⟨v, rfl⟩ | ⟨f, rfl⟩)
+    · -- y = vertexStabOf v (Z-type generator)
+      have hmem : (rotatedSurfaceHomologicalCode L).vertexStabOf v ∈
+          (rotatedSurfaceHomologicalCode L).homologicalStabilizerGroup.toSubgroup :=
+        Subgroup.subset_closure (Or.inl ⟨v, rfl⟩)
+      have hcomm_g :
+          (rotatedSurfaceHomologicalCode L).vertexStabOf v * g =
+            g * (rotatedSurfaceHomologicalCode L).vertexStabOf v :=
+        (Quantum.StabilizerGroup.mem_centralizer_iff g _).mp hg _ hmem
+      rw [NQubitPauliGroupElement.commutes_iff_even_anticommutes] at hcomm_g ⊢
+      classical
+      have hfilter_eq :
+          Finset.univ.filter (NQubitPauliGroupElement.anticommutesAt
+              ((rotatedSurfaceHomologicalCode L).vertexStabOf v).operators
+              ((rotatedSurfaceHomologicalCode L).chainXOperator
+                ((rotatedSurfaceHomologicalCode L).xChainOf g)).operators) =
+            Finset.univ.filter (NQubitPauliGroupElement.anticommutesAt
+              ((rotatedSurfaceHomologicalCode L).vertexStabOf v).operators
+              g.operators) := by
+        ext i
+        simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+        exact (anticommutesAt_vertexStabOf_iff_xChainOf L g v i).symm
+      rw [hfilter_eq]
+      exact hcomm_g
+    · -- y = faceStabOf f (X-type generator) — X-type / X-type commute trivially
+      exact Quantum.Stabilizer.Homological.HomologicalCode.chainXOperator_commutes_faceStabOf
+        (X := rotatedSurfaceHomologicalCode L)
+        ((rotatedSurfaceHomologicalCode L).xChainOf g) f
+  · -- one
+    change (1 : NQubitPauliGroupElement (rotatedSurfaceHomologicalCode L).numQubits) *
+        (rotatedSurfaceHomologicalCode L).chainXOperator
+          ((rotatedSurfaceHomologicalCode L).xChainOf g) =
+        (rotatedSurfaceHomologicalCode L).chainXOperator
+          ((rotatedSurfaceHomologicalCode L).xChainOf g) * 1
+    rw [_root_.one_mul, _root_.mul_one]
+  · -- mul
+    intros y₁ y₂ _ _ hy₁ hy₂
+    calc (y₁ * y₂) *
+            (rotatedSurfaceHomologicalCode L).chainXOperator
+              ((rotatedSurfaceHomologicalCode L).xChainOf g)
+        = y₁ * (y₂ *
+            (rotatedSurfaceHomologicalCode L).chainXOperator
+              ((rotatedSurfaceHomologicalCode L).xChainOf g)) := _root_.mul_assoc _ _ _
+      _ = y₁ * ((rotatedSurfaceHomologicalCode L).chainXOperator
+              ((rotatedSurfaceHomologicalCode L).xChainOf g) * y₂) := by rw [hy₂]
+      _ = (y₁ * (rotatedSurfaceHomologicalCode L).chainXOperator
+              ((rotatedSurfaceHomologicalCode L).xChainOf g)) * y₂ :=
+        (_root_.mul_assoc _ _ _).symm
+      _ = ((rotatedSurfaceHomologicalCode L).chainXOperator
+              ((rotatedSurfaceHomologicalCode L).xChainOf g) * y₁) * y₂ := by rw [hy₁]
+      _ = (rotatedSurfaceHomologicalCode L).chainXOperator
+              ((rotatedSurfaceHomologicalCode L).xChainOf g) * (y₁ * y₂) :=
+        _root_.mul_assoc _ _ _
+  · -- inv
+    intros y _ hy
+    exact (show Commute y _ from hy).inv_left.eq
+
+/-- For `g ∈ centralizer`, `zChainOf g` is a dual cycle. -/
+private lemma zChainOf_mem_dualCycles_of_centralizer
+    (g : NQubitPauliGroupElement (rotatedSurfaceHomologicalCode L).numQubits)
+    (hg : g ∈ StabilizerGroup.centralizer
+            (rotatedSurfaceHomologicalCode L).homologicalStabilizerGroup) :
+    (rotatedSurfaceHomologicalCode L).zChainOf g ∈
+      (rotatedSurfaceHomologicalCode L).dualCycles := by
+  apply (chainZOperator_mem_centralizer_iff_mem_dualCycles
+      (X := rotatedSurfaceHomologicalCode L)
+      ((rotatedSurfaceHomologicalCode L).zChainOf g)).mp
+  intro s hs
+  refine Subgroup.closure_induction
+    (p := fun y _ => y *
+        (rotatedSurfaceHomologicalCode L).chainZOperator
+          ((rotatedSurfaceHomologicalCode L).zChainOf g) =
+      (rotatedSurfaceHomologicalCode L).chainZOperator
+        ((rotatedSurfaceHomologicalCode L).zChainOf g) * y) ?_ ?_ ?_ ?_ hs
+  · rintro y (⟨v, rfl⟩ | ⟨f, rfl⟩)
+    · -- y = vertexStabOf v (Z-type generator) — Z-type / Z-type commute trivially
+      exact Quantum.Stabilizer.Homological.HomologicalCode.chainZOperator_commutes_vertexStabOf
+        (X := rotatedSurfaceHomologicalCode L)
+        ((rotatedSurfaceHomologicalCode L).zChainOf g) v
+    · -- y = faceStabOf f (X-type generator)
+      have hmem : (rotatedSurfaceHomologicalCode L).faceStabOf f ∈
+          (rotatedSurfaceHomologicalCode L).homologicalStabilizerGroup.toSubgroup :=
+        Subgroup.subset_closure (Or.inr ⟨f, rfl⟩)
+      have hcomm_g :
+          (rotatedSurfaceHomologicalCode L).faceStabOf f * g =
+            g * (rotatedSurfaceHomologicalCode L).faceStabOf f :=
+        (Quantum.StabilizerGroup.mem_centralizer_iff g _).mp hg _ hmem
+      rw [NQubitPauliGroupElement.commutes_iff_even_anticommutes] at hcomm_g ⊢
+      classical
+      have hfilter_eq :
+          Finset.univ.filter (NQubitPauliGroupElement.anticommutesAt
+              ((rotatedSurfaceHomologicalCode L).faceStabOf f).operators
+              ((rotatedSurfaceHomologicalCode L).chainZOperator
+                ((rotatedSurfaceHomologicalCode L).zChainOf g)).operators) =
+            Finset.univ.filter (NQubitPauliGroupElement.anticommutesAt
+              ((rotatedSurfaceHomologicalCode L).faceStabOf f).operators
+              g.operators) := by
+        ext i
+        simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+        exact (anticommutesAt_faceStabOf_iff_zChainOf L g f i).symm
+      rw [hfilter_eq]
+      exact hcomm_g
+  · -- one
+    change (1 : NQubitPauliGroupElement (rotatedSurfaceHomologicalCode L).numQubits) *
+        (rotatedSurfaceHomologicalCode L).chainZOperator
+          ((rotatedSurfaceHomologicalCode L).zChainOf g) =
+        (rotatedSurfaceHomologicalCode L).chainZOperator
+          ((rotatedSurfaceHomologicalCode L).zChainOf g) * 1
+    rw [_root_.one_mul, _root_.mul_one]
+  · -- mul
+    intros y₁ y₂ _ _ hy₁ hy₂
+    calc (y₁ * y₂) *
+            (rotatedSurfaceHomologicalCode L).chainZOperator
+              ((rotatedSurfaceHomologicalCode L).zChainOf g)
+        = y₁ * (y₂ *
+            (rotatedSurfaceHomologicalCode L).chainZOperator
+              ((rotatedSurfaceHomologicalCode L).zChainOf g)) := _root_.mul_assoc _ _ _
+      _ = y₁ * ((rotatedSurfaceHomologicalCode L).chainZOperator
+              ((rotatedSurfaceHomologicalCode L).zChainOf g) * y₂) := by rw [hy₂]
+      _ = (y₁ * (rotatedSurfaceHomologicalCode L).chainZOperator
+              ((rotatedSurfaceHomologicalCode L).zChainOf g)) * y₂ :=
+        (_root_.mul_assoc _ _ _).symm
+      _ = ((rotatedSurfaceHomologicalCode L).chainZOperator
+              ((rotatedSurfaceHomologicalCode L).zChainOf g) * y₁) * y₂ := by rw [hy₁]
+      _ = (rotatedSurfaceHomologicalCode L).chainZOperator
+              ((rotatedSurfaceHomologicalCode L).zChainOf g) * (y₁ * y₂) :=
+        _root_.mul_assoc _ _ _
+  · -- inv
+    intros y _ hy
+    exact (show Commute y _ from hy).inv_left.eq
+
+/-! ### Weight bridge: `weight (chain*Operator c) = chainWeight c`
+
+Local versions of the equalities `weight (chainXOperator c) = chainWeight c`
+and `weight (chainZOperator c) = chainWeight c`, proved via the same
+`rscQubitEquiv` bijection used in
+`RotatedSurfaceCodeNDistanceX.weight_chainXOperator_eq_chainSupport_card`. -/
+
+private lemma weight_chainXOperator_eq_chainWeight
+    (c : (rotatedSurfaceHomologicalCode L).C1 → ZMod 2) :
+    NQubitPauliGroupElement.weight
+        ((rotatedSurfaceHomologicalCode L).chainXOperator c) =
+      (rotatedSurfaceHomologicalCode L).chainWeight c := by
+  classical
+  unfold NQubitPauliGroupElement.weight NQubitPauliOperator.weight
+    Quantum.Stabilizer.Homological.HomologicalCode.chainWeight
+    Quantum.Stabilizer.Homological.HomologicalCode.chainSupport
+  symm
+  apply Finset.card_bij
+    (fun v _ => (rotatedSurfaceHomologicalCode L).edgeEquiv v)
+  · intro v hv
+    rw [Finset.mem_filter] at hv
+    have h_ne : c v ≠ 0 := hv.2
+    have h1 : c v = 1 := by
+      rcases Fin.exists_fin_two.mp ⟨c v, rfl⟩ with h0 | h1
+      · exact absurd h0 h_ne
+      · exact h1
+    exact (Quantum.Stabilizer.Homological.HomologicalCode.mem_support_chainXOperator_iff
+      (X := rotatedSurfaceHomologicalCode L) c v).mpr h1
+  · intros v₁ _ v₂ _ heq
+    exact (rotatedSurfaceHomologicalCode L).edgeEquiv.injective heq
+  · intros q hq
+    set v := (rotatedSurfaceHomologicalCode L).edgeEquiv.symm q with hv_def
+    have h_q : (rotatedSurfaceHomologicalCode L).edgeEquiv v = q :=
+      Equiv.apply_symm_apply _ _
+    refine ⟨v, ?_, h_q⟩
+    rw [Finset.mem_filter]
+    refine ⟨Finset.mem_univ _, ?_⟩
+    have h_iff :=
+      Quantum.Stabilizer.Homological.HomologicalCode.mem_support_chainXOperator_iff
+        (X := rotatedSurfaceHomologicalCode L) c v
+    rw [h_q] at h_iff
+    have hcv : c v = 1 := h_iff.mp hq
+    rw [hcv]; decide
+
+private lemma weight_chainZOperator_eq_chainWeight
+    (c : (rotatedSurfaceHomologicalCode L).C1 → ZMod 2) :
+    NQubitPauliGroupElement.weight
+        ((rotatedSurfaceHomologicalCode L).chainZOperator c) =
+      (rotatedSurfaceHomologicalCode L).chainWeight c := by
+  classical
+  unfold NQubitPauliGroupElement.weight NQubitPauliOperator.weight
+    Quantum.Stabilizer.Homological.HomologicalCode.chainWeight
+    Quantum.Stabilizer.Homological.HomologicalCode.chainSupport
+  symm
+  apply Finset.card_bij
+    (fun v _ => (rotatedSurfaceHomologicalCode L).edgeEquiv v)
+  · intro v hv
+    rw [Finset.mem_filter] at hv
+    have h_ne : c v ≠ 0 := hv.2
+    have h1 : c v = 1 := by
+      rcases Fin.exists_fin_two.mp ⟨c v, rfl⟩ with h0 | h1
+      · exact absurd h0 h_ne
+      · exact h1
+    exact (Quantum.Stabilizer.Homological.HomologicalCode.mem_support_chainZOperator_iff
+      (X := rotatedSurfaceHomologicalCode L) c v).mpr h1
+  · intros v₁ _ v₂ _ heq
+    exact (rotatedSurfaceHomologicalCode L).edgeEquiv.injective heq
+  · intros q hq
+    set v := (rotatedSurfaceHomologicalCode L).edgeEquiv.symm q with hv_def
+    have h_q : (rotatedSurfaceHomologicalCode L).edgeEquiv v = q :=
+      Equiv.apply_symm_apply _ _
+    refine ⟨v, ?_, h_q⟩
+    rw [Finset.mem_filter]
+    refine ⟨Finset.mem_univ _, ?_⟩
+    have h_iff :=
+      Quantum.Stabilizer.Homological.HomologicalCode.mem_support_chainZOperator_iff
+        (X := rotatedSurfaceHomologicalCode L) c v
+    rw [h_q] at h_iff
+    have hcv : c v = 1 := h_iff.mp hq
+    rw [hcv]; decide
+
+/-! ### Main theorem -/
+
+/-- **Stage 7 endpoint.**  The rotated surface code on an `L × L` lattice
+has code distance exactly `L`. -/
+theorem rotatedSurfaceCodeN_distance_eq_L :
+    HasCodeDistance (rotatedSurfaceStabilizerCode L) L := by
+  have hL_pos : 0 < L := by have h3 : 3 ≤ L := Fact.out; omega
+  -- Bridge: the StabilizerCode subgroup equals the homological one.
+  have h_sub_eq := rotatedSurfaceStabilizerCode_subgroup_eq_homological L
+  -- Bridge `IsNontrivialLogicalOperator` between the two groups.
+  have h_iff_NL : ∀ g,
+      Quantum.StabilizerGroup.IsNontrivialLogicalOperator g
+          (rotatedSurfaceStabilizerCode L).toStabilizerGroup ↔
+        Quantum.StabilizerGroup.IsNontrivialLogicalOperator g
+          (rotatedSurfaceHomologicalCode L).homologicalStabilizerGroup :=
+    fun g => Quantum.StabilizerGroup.IsNontrivialLogicalOperator_of_toSubgroup_eq g h_sub_eq
+  refine ⟨hL_pos, ?_, ?_⟩
+  · -- Lower bound: every non-trivial logical has weight ≥ L.
+    intro g hgLogical _hgwpos
+    have hg_hom := (h_iff_NL g).mp hgLogical
+    have hg_cent_hom :
+        g ∈ Quantum.StabilizerGroup.centralizer
+          (rotatedSurfaceHomologicalCode L).homologicalStabilizerGroup :=
+      ((Quantum.StabilizerGroup.IsNontrivialLogicalOperator_iff g _).mp hg_hom).1
+    -- Apply the abstract CSS bridge: not both boundary.
+    have h_not_both :=
+      Quantum.Stabilizer.Homological.HomologicalCode.not_both_boundary_of_nontrivial
+        (X := rotatedSurfaceHomologicalCode L) g hg_hom
+    -- xChainOf g ∈ cycles, zChainOf g ∈ dualCycles
+    have hxCyc := xChainOf_mem_cycles_of_centralizer L g hg_cent_hom
+    have hzCyc := zChainOf_mem_dualCycles_of_centralizer L g hg_cent_hom
+    -- Case on whether xChainOf g is a boundary.
+    by_cases hxBnd : (rotatedSurfaceHomologicalCode L).xChainOf g ∈
+        (rotatedSurfaceHomologicalCode L).boundaries
+    · -- Then zChainOf g ∉ dualBoundaries — use Z-distance bound.
+      have hzBnd : (rotatedSurfaceHomologicalCode L).zChainOf g ∉
+          (rotatedSurfaceHomologicalCode L).dualBoundaries := by
+        intro h; exact h_not_both ⟨hxBnd, h⟩
+      -- chainZOperator (zChainOf g) is a Z-type non-trivial logical.
+      set gZ : NQubitPauliGroupElement (numQubits L) :=
+        (rotatedSurfaceHomologicalCode L).chainZOperator
+          ((rotatedSurfaceHomologicalCode L).zChainOf g) with hgZ_def
+      have hgZ_isZType : NQubitPauliGroupElement.IsZTypeElement gZ :=
+        Quantum.Stabilizer.Homological.HomologicalCode.chainZOperator_isZType
+          (X := rotatedSurfaceHomologicalCode L) _
+      have hgZ_nl_hom :
+          Quantum.StabilizerGroup.IsNontrivialLogicalOperator gZ
+            (rotatedSurfaceHomologicalCode L).homologicalStabilizerGroup :=
+        (Quantum.Stabilizer.Homological.HomologicalCode.chainZOperator_isNontrivialLogical_iff
+          (X := rotatedSurfaceHomologicalCode L)
+          ((rotatedSurfaceHomologicalCode L).zChainOf g)).mpr ⟨hzCyc, hzBnd⟩
+      have hgZ_nl :
+          Quantum.StabilizerGroup.IsNontrivialLogicalOperator gZ
+            (rotatedSurfaceStabilizerCode L).toStabilizerGroup :=
+        (h_iff_NL gZ).mpr hgZ_nl_hom
+      have hwZ : L ≤ NQubitPauliGroupElement.weight gZ :=
+        weight_ge_L_of_nontrivial_Z_logical L hgZ_isZType hgZ_nl
+      -- weight g ≥ chainWeight (zChainOf g) = weight gZ ≥ L.
+      have h_step1 :
+          (rotatedSurfaceHomologicalCode L).chainWeight
+              ((rotatedSurfaceHomologicalCode L).zChainOf g) ≤
+            NQubitPauliGroupElement.weight g :=
+        Quantum.Stabilizer.Homological.HomologicalCode.weight_ge_chainWeight_zChainOf
+          (X := rotatedSurfaceHomologicalCode L) g
+      have h_step2 :
+          NQubitPauliGroupElement.weight gZ =
+            (rotatedSurfaceHomologicalCode L).chainWeight
+              ((rotatedSurfaceHomologicalCode L).zChainOf g) :=
+        weight_chainZOperator_eq_chainWeight L _
+      omega
+    · -- xChainOf g ∉ boundaries — use X-distance bound.
+      set gX : NQubitPauliGroupElement (numQubits L) :=
+        (rotatedSurfaceHomologicalCode L).chainXOperator
+          ((rotatedSurfaceHomologicalCode L).xChainOf g) with hgX_def
+      have hgX_isXType : NQubitPauliGroupElement.IsXTypeElement gX :=
+        Quantum.Stabilizer.Homological.HomologicalCode.chainXOperator_isXType
+          (X := rotatedSurfaceHomologicalCode L) _
+      have hgX_nl_hom :
+          Quantum.StabilizerGroup.IsNontrivialLogicalOperator gX
+            (rotatedSurfaceHomologicalCode L).homologicalStabilizerGroup :=
+        (Quantum.Stabilizer.Homological.HomologicalCode.chainXOperator_isNontrivialLogical_iff
+          (X := rotatedSurfaceHomologicalCode L)
+          ((rotatedSurfaceHomologicalCode L).xChainOf g)).mpr ⟨hxCyc, hxBnd⟩
+      have hgX_nl :
+          Quantum.StabilizerGroup.IsNontrivialLogicalOperator gX
+            (rotatedSurfaceStabilizerCode L).toStabilizerGroup :=
+        (h_iff_NL gX).mpr hgX_nl_hom
+      have hwX : L ≤ NQubitPauliGroupElement.weight gX :=
+        weight_ge_L_of_nontrivial_X_logical L hgX_isXType hgX_nl
+      have h_step1 :
+          (rotatedSurfaceHomologicalCode L).chainWeight
+              ((rotatedSurfaceHomologicalCode L).xChainOf g) ≤
+            NQubitPauliGroupElement.weight g :=
+        Quantum.Stabilizer.Homological.HomologicalCode.weight_ge_chainWeight_xChainOf
+          (X := rotatedSurfaceHomologicalCode L) g
+      have h_step2 :
+          NQubitPauliGroupElement.weight gX =
+            (rotatedSurfaceHomologicalCode L).chainWeight
+              ((rotatedSurfaceHomologicalCode L).xChainOf g) :=
+        weight_chainXOperator_eq_chainWeight L _
+      omega
+  · -- Witness: `logicalX L` has weight exactly L.
+    refine ⟨logicalX L, ?_, ?_⟩
+    · -- IsNontrivialLogicalOperator (logicalX L) (rotatedSurfaceStabilizerCode L).toStabilizerGroup
+      have hlogX_nl_hom :
+          Quantum.StabilizerGroup.IsNontrivialLogicalOperator (logicalX L)
+            (rotatedSurfaceHomologicalCode L).homologicalStabilizerGroup := by
+        change Quantum.StabilizerGroup.IsNontrivialLogicalOperator
+          ((rotatedSurfaceHomologicalCode L).chainXOperator (middleColChain L)) _
+        exact (Quantum.Stabilizer.Homological.HomologicalCode.chainXOperator_isNontrivialLogical_iff
+          (X := rotatedSurfaceHomologicalCode L) (middleColChain L)).mpr
+          ⟨middleColChain_mem_cycles L, middleColChain_not_mem_boundaries L⟩
+      exact (h_iff_NL (logicalX L)).mpr hlogX_nl_hom
+    · exact logicalX_weight_eq_L L
+
+end RotatedSurfaceCodeN
+end StabilizerGroup
+end Quantum

--- a/QEC/Stabilizer/Codes/RotatedSurfaceCodeNDistanceX.lean
+++ b/QEC/Stabilizer/Codes/RotatedSurfaceCodeNDistanceX.lean
@@ -98,6 +98,488 @@ theorem rowParity_middleColChain (y : Fin L) :
     exact hx
   · intro hcontra; exact absurd (Finset.mem_univ _) hcontra
 
+/-! ## §C — Row parity vanishes on boundaries -/
+
+omit [Fact (Odd L)] [Fact (3 ≤ L)] in
+/-- A Finset that is empty or a 2-element set has card 0 in `ZMod 2`. -/
+private lemma card_empty_or_pair_zmod2_zero {α : Type*} [DecidableEq α] (s : Finset α)
+    (h : s = ∅ ∨ ∃ a b : α, a ≠ b ∧ s = {a, b}) :
+    (s.card : ZMod 2) = 0 := by
+  rcases h with hempty | ⟨a, b, hne, heq⟩
+  · rw [hempty, Finset.card_empty]; rfl
+  · rw [heq, Finset.card_insert_of_notMem (by simp [hne]), Finset.card_singleton]
+    decide
+
+omit [Fact (Odd L)] in
+/-- Per-row intersection of `xSupport xf` with row `y` is either empty or a
+2-element set, hence its card cast to `ZMod 2` is `0`. -/
+private lemma rowFilter_xSupport_card_even
+    (xf : RotatedSurface.XFaceIdx L) (y : Fin L) :
+    (((Finset.univ : Finset (Fin L)).filter
+        (fun x : Fin L => (x, y) ∈ RotatedSurface.xSupport xf)).card : ZMod 2) = 0 := by
+  classical
+  apply card_empty_or_pair_zmod2_zero
+  cases xf with
+  | interior xc =>
+    by_cases hyMatch : y.val = xc.val.2.val ∨ y.val = xc.val.2.val + 1
+    · right
+      refine ⟨RotatedSurface.cornerLo xc.val.1, RotatedSurface.cornerHi xc.val.1, ?_, ?_⟩
+      · intro h; have := congrArg Fin.val h
+        simp [RotatedSurface.cornerLo, RotatedSurface.cornerHi] at this
+      · ext x
+        rw [Finset.mem_filter, Finset.mem_insert, Finset.mem_singleton]
+        rw [RotatedSurface.mem_xSupport_interior_iff]
+        simp only [Finset.mem_univ, true_and]
+        constructor
+        · rintro ⟨hx, _⟩
+          rcases hx with h1 | h1
+          · left; exact Fin.ext h1
+          · right; exact Fin.ext h1
+        · rintro (rfl | rfl)
+          · refine ⟨Or.inl ?_, hyMatch⟩
+            simp [RotatedSurface.cornerLo]
+          · refine ⟨Or.inr ?_, hyMatch⟩
+            simp [RotatedSurface.cornerHi]
+    · left
+      push Not at hyMatch
+      rw [Finset.filter_eq_empty_iff]
+      intro x _
+      rw [RotatedSurface.mem_xSupport_interior_iff]
+      rintro ⟨_, hy⟩
+      rcases hy with h | h
+      · exact hyMatch.1 h
+      · exact hyMatch.2 h
+  | topBdy k =>
+    by_cases hy : y.val = 0
+    · right
+      have h2k : 2 * k.val < L := by
+        have := k.isLt; have h3 : 3 ≤ L := Fact.out; omega
+      have h2k1 : 2 * k.val + 1 < L := by
+        have := k.isLt; have h3 : 3 ≤ L := Fact.out; omega
+      refine ⟨⟨2 * k.val, h2k⟩, ⟨2 * k.val + 1, h2k1⟩, ?_, ?_⟩
+      · intro h; have := congrArg Fin.val h
+        simp at this
+      · ext x
+        rw [Finset.mem_filter, Finset.mem_insert, Finset.mem_singleton]
+        rw [RotatedSurface.mem_xSupport_topBdy_iff]
+        simp only [Finset.mem_univ, true_and]
+        constructor
+        · rintro ⟨_, hx⟩
+          rcases hx with h | h
+          · left; exact Fin.ext h
+          · right; exact Fin.ext h
+        · rintro (rfl | rfl)
+          · exact ⟨hy, Or.inl rfl⟩
+          · exact ⟨hy, Or.inr rfl⟩
+    · left
+      rw [Finset.filter_eq_empty_iff]
+      intro x _
+      rw [RotatedSurface.mem_xSupport_topBdy_iff]
+      rintro ⟨hyz, _⟩
+      exact hy hyz
+  | bottomBdy k =>
+    by_cases hy : y.val = L - 1
+    · right
+      have h2k1 : 2 * k.val + 1 < L := by
+        have := k.isLt; have h3 : 3 ≤ L := Fact.out; omega
+      have h2k2 : 2 * k.val + 2 < L := by
+        have := k.isLt; have h3 : 3 ≤ L := Fact.out; omega
+      refine ⟨⟨2 * k.val + 1, h2k1⟩, ⟨2 * k.val + 2, h2k2⟩, ?_, ?_⟩
+      · intro h; have := congrArg Fin.val h
+        simp at this
+      · ext x
+        rw [Finset.mem_filter, Finset.mem_insert, Finset.mem_singleton]
+        rw [RotatedSurface.mem_xSupport_bottomBdy_iff]
+        simp only [Finset.mem_univ, true_and]
+        constructor
+        · rintro ⟨_, hx⟩
+          rcases hx with h | h
+          · left; exact Fin.ext h
+          · right; exact Fin.ext h
+        · rintro (rfl | rfl)
+          · exact ⟨hy, Or.inl rfl⟩
+          · exact ⟨hy, Or.inr rfl⟩
+    · left
+      rw [Finset.filter_eq_empty_iff]
+      intro x _
+      rw [RotatedSurface.mem_xSupport_bottomBdy_iff]
+      rintro ⟨hyL, _⟩
+      exact hy hyL
+
+/-- `rowParity (rscBoundary2 (Pi.single xf 1)) y = 0`. -/
+private lemma rowParity_boundary2_single (xf : RotatedSurface.XFaceIdx L) (y : Fin L) :
+    rowParity L (RotatedSurface.rscBoundary2 L (Pi.single xf 1)) y = 0 := by
+  classical
+  unfold rowParity
+  rw [show (fun x : Fin L => RotatedSurface.rscBoundary2 L (Pi.single xf 1) (x, y)) =
+      (fun x : Fin L => if (x, y) ∈ RotatedSurface.xSupport xf then (1 : ZMod 2) else 0) by
+    funext x
+    exact boundary2_singleFace_apply L xf (x, y)]
+  rw [Finset.sum_boole]
+  exact rowFilter_xSupport_card_even L xf y
+
+/-- `rowParity (rscBoundary2 f) y = 0` for every X-face chain `f`. -/
+theorem rowParity_rscBoundary2
+    (f : RotatedSurface.XFaceIdx L → ZMod 2) (y : Fin L) :
+    rowParity L (RotatedSurface.rscBoundary2 L f) y = 0 := by
+  classical
+  have hf : f = ∑ xf : RotatedSurface.XFaceIdx L, f xf • (Pi.single xf (1 : ZMod 2)) := by
+    funext xf
+    simp [Finset.sum_apply, Pi.single_apply]
+  conv_lhs => rw [hf]
+  rw [map_sum]
+  unfold rowParity
+  -- ∑ x, (∑ xf, ∂₂(f xf • δ_xf))(x, y) = ∑ xf, f xf * (∑ x, ∂₂(δ_xf)(x, y)) = 0
+  rw [show (fun x : Fin L =>
+      (∑ xf : RotatedSurface.XFaceIdx L,
+        RotatedSurface.rscBoundary2 L (f xf • Pi.single xf 1)) (x, y)) =
+      (fun x : Fin L =>
+        ∑ xf : RotatedSurface.XFaceIdx L,
+          RotatedSurface.rscBoundary2 L (f xf • Pi.single xf 1) (x, y)) by
+    funext x; rw [Finset.sum_apply]]
+  rw [Finset.sum_comm]
+  apply Finset.sum_eq_zero
+  intro xf _
+  have h_smul : ∀ x : Fin L,
+      RotatedSurface.rscBoundary2 L (f xf • Pi.single xf 1) (x, y) =
+        f xf * RotatedSurface.rscBoundary2 L (Pi.single xf 1) (x, y) := fun x => by
+    rw [LinearMap.map_smul]
+    simp [Pi.smul_apply, smul_eq_mul]
+  rw [Finset.sum_congr rfl (fun x _ => h_smul x)]
+  rw [← Finset.mul_sum]
+  rw [show ∑ x : Fin L, RotatedSurface.rscBoundary2 L (Pi.single xf 1) (x, y) =
+      rowParity L (RotatedSurface.rscBoundary2 L (Pi.single xf 1)) y from rfl]
+  rw [rowParity_boundary2_single]
+  ring
+
+/-- `rowParity` vanishes on the boundary submodule. -/
+theorem rowParity_eq_zero_of_mem_boundaries
+    {c : RotatedSurface.VtxIdx L → ZMod 2}
+    (hc : c ∈ RotatedSurface.rscBoundaries L) (y : Fin L) :
+    rowParity L c y = 0 := by
+  rcases hc with ⟨f, rfl⟩
+  exact rowParity_rscBoundary2 L f y
+
+/-! ## §D — `middleColChain ∉ boundaries` and homology characterization
+
+Since `rowParity middleColChain y = 1` (§B) but `rowParity (boundary) y = 0` (§C),
+`middleColChain` cannot be a boundary.  Combined with `dim H₁ = 1` (Stage 3),
+this means every non-trivial cycle is congruent to `middleColChain` modulo
+the boundary submodule.
+-/
+
+/-- `middleColChain` is not a boundary. -/
+theorem middleColChain_not_mem_boundaries :
+    middleColChain L ∉ RotatedSurface.rscBoundaries L := by
+  intro h
+  -- rowParity middleColChain 0 = 1 (§B) ≠ 0 (= rowParity of boundary, §C)
+  have h1 : rowParity L (middleColChain L) ⟨0, by have h3 : 3 ≤ L := Fact.out; omega⟩ = 1 :=
+    rowParity_middleColChain L _
+  have h0 : rowParity L (middleColChain L) ⟨0, by have h3 : 3 ≤ L := Fact.out; omega⟩ = 0 :=
+    rowParity_eq_zero_of_mem_boundaries L h _
+  rw [h1] at h0
+  exact (by decide : (1 : ZMod 2) ≠ 0) h0
+
+/-- The class of `middleColChain` in `rscH1 L` is non-zero. -/
+private lemma middleColChain_class_ne_zero :
+    (Submodule.Quotient.mk
+      (⟨middleColChain L, middleColChain_mem_cycles L⟩ :
+        RotatedSurface.rscCycles L) :
+      RotatedSurface.rscH1 L) ≠ 0 := by
+  intro h
+  -- Submodule.Quotient.mk x = 0 ↔ x ∈ S.  Here S is the comap into cycles.
+  rw [Submodule.Quotient.mk_eq_zero] at h
+  -- h : ⟨middleColChain, _⟩ ∈ Submodule.comap (cycles.subtype) boundaries
+  -- which unfolds to: middleColChain ∈ boundaries
+  exact middleColChain_not_mem_boundaries L h
+
+/-- Every cycle is `0` or `middleColChain` modulo boundaries (since `dim H₁ = 1`). -/
+theorem cycle_sub_middleColChain_mem_boundaries
+    {c : RotatedSurface.VtxIdx L → ZMod 2}
+    (hc_cycle : c ∈ RotatedSurface.rscCycles L)
+    (hc_nontrivial : c ∉ RotatedSurface.rscBoundaries L) :
+    c - middleColChain L ∈ RotatedSurface.rscBoundaries L := by
+  have h_dim : Module.finrank (ZMod 2) (RotatedSurface.rscH1 L) = 1 :=
+    RotatedSurface.rsc_finrank_H1_eq_one (L := L)
+  -- By dim = 1: every element is a scalar multiple of [middleColChain].
+  have h_spans :
+      ∀ w : RotatedSurface.rscH1 L,
+        ∃ a : ZMod 2, a • (Submodule.Quotient.mk
+          (⟨middleColChain L, middleColChain_mem_cycles L⟩ :
+            RotatedSurface.rscCycles L)) = w :=
+    (finrank_eq_one_iff_of_nonzero' _ (middleColChain_class_ne_zero L)).mp h_dim
+  -- Apply to [c].
+  let cCycle : RotatedSurface.rscCycles L := ⟨c, hc_cycle⟩
+  obtain ⟨a, ha⟩ := h_spans (Submodule.Quotient.mk cCycle)
+  -- a is 0 or 1 in ZMod 2.
+  have ha_dichot : a = 0 ∨ a = 1 := by
+    rcases Fin.exists_fin_two.mp ⟨a, rfl⟩ with h | h
+    · left; exact h
+    · right; exact h
+  rcases ha_dichot with ha0 | ha1
+  · -- a = 0: 0 • [middleColChain] = 0 = [c], so c ∈ boundaries.  Contradiction.
+    exfalso
+    rw [ha0, zero_smul] at ha
+    rw [eq_comm, Submodule.Quotient.mk_eq_zero] at ha
+    -- ha : cCycle ∈ Submodule.comap _ boundaries; unfolds to c ∈ boundaries
+    exact hc_nontrivial ha
+  · -- a = 1: [middleColChain] = [c], so c - middleColChain ∈ boundaries.
+    rw [ha1, one_smul] at ha
+    have h_eq : (Submodule.Quotient.mk cCycle : RotatedSurface.rscH1 L) =
+        Submodule.Quotient.mk
+          (⟨middleColChain L, middleColChain_mem_cycles L⟩ :
+            RotatedSurface.rscCycles L) := ha.symm
+    rw [Submodule.Quotient.eq] at h_eq
+    -- h_eq : cCycle - ⟨middleColChain, _⟩ ∈ Submodule.comap _ boundaries
+    -- which unfolds to: c - middleColChain ∈ boundaries
+    exact h_eq
+
+/-- For any non-trivial cycle `c`, `rowParity c y = 1` for every row `y`. -/
+theorem rowParity_eq_one_of_nontrivial
+    {c : RotatedSurface.VtxIdx L → ZMod 2}
+    (hc_cycle : c ∈ RotatedSurface.rscCycles L)
+    (hc_nontrivial : c ∉ RotatedSurface.rscBoundaries L) (y : Fin L) :
+    rowParity L c y = 1 := by
+  -- c = middleColChain + (c - middleColChain); the second is a boundary.
+  have h_diff_boundary :=
+    cycle_sub_middleColChain_mem_boundaries L hc_cycle hc_nontrivial
+  have h_eq : c = middleColChain L + (c - middleColChain L) := by abel
+  rw [h_eq, rowParity_add]
+  rw [rowParity_middleColChain]
+  rw [rowParity_eq_zero_of_mem_boundaries L h_diff_boundary y]
+  ring
+
+/-! ## §E — Weight ≥ L for non-trivial X-logicals -/
+
+omit [Fact (Odd L)] in
+/-- The chain support: vertices where `c v = 1`. -/
+private def chainSupport (c : RotatedSurface.VtxIdx L → ZMod 2) :
+    Finset (RotatedSurface.VtxIdx L) :=
+  Finset.univ.filter (fun v => c v = 1)
+
+/-- `weight (chainXOperator c) = (chainSupport c).card`. -/
+private lemma weight_chainXOperator_eq_chainSupport_card
+    (c : RotatedSurface.VtxIdx L → ZMod 2) :
+    NQubitPauliGroupElement.weight
+      ((RotatedSurface.rotatedSurfaceHomologicalCode L).chainXOperator c) =
+    (chainSupport L c).card := by
+  classical
+  symm
+  -- Bijection v ↦ rscQubitEquiv v from chainSupport L c to operator support.
+  unfold NQubitPauliGroupElement.weight NQubitPauliOperator.weight
+  apply Finset.card_bij (fun v _ => RotatedSurface.rscQubitEquiv L v)
+  · intro v hv
+    rw [chainSupport, Finset.mem_filter] at hv
+    have h_iff :=
+      (Quantum.Stabilizer.Homological.HomologicalCode.mem_support_chainXOperator_iff
+        (X := RotatedSurface.rotatedSurfaceHomologicalCode L) c v).mpr hv.2
+    -- h_iff says edgeEquiv v ∈ support. edgeEquiv = rscQubitEquiv defeq.
+    change (RotatedSurface.rscQubitEquiv L) v ∈ _ at h_iff
+    exact h_iff
+  · intros v1 _ v2 _ heq
+    exact (RotatedSurface.rscQubitEquiv L).injective heq
+  · intros q hq
+    set v := (RotatedSurface.rscQubitEquiv L).symm q
+    have h_q : RotatedSurface.rscQubitEquiv L v = q := Equiv.apply_symm_apply _ _
+    refine ⟨v, ?_, h_q⟩
+    rw [chainSupport, Finset.mem_filter]
+    refine ⟨Finset.mem_univ _, ?_⟩
+    have h_iff :=
+      Quantum.Stabilizer.Homological.HomologicalCode.mem_support_chainXOperator_iff
+        (X := RotatedSurface.rotatedSurfaceHomologicalCode L) c v
+    -- Align edgeEquiv with rscQubitEquiv.
+    change (RotatedSurface.rscQubitEquiv L) v ∈ _ ↔ _ at h_iff
+    rw [h_q] at h_iff
+    exact h_iff.mp hq
+
+omit [Fact (Odd L)] [Fact (3 ≤ L)] in
+/-- `rowParity c y = (filter (c (·, y) = 1) univ).card` cast to `ZMod 2`. -/
+private lemma rowParity_eq_row_card_cast
+    (c : RotatedSurface.VtxIdx L → ZMod 2) (y : Fin L) :
+    rowParity L c y =
+      (((Finset.univ : Finset (Fin L)).filter (fun x => c (x, y) = 1)).card : ZMod 2) := by
+  classical
+  unfold rowParity
+  rw [Finset.card_filter, Nat.cast_sum]
+  apply Finset.sum_congr rfl
+  intro x _
+  by_cases hxy : c (x, y) = 1
+  · rw [hxy]; simp
+  · have h0 : c (x, y) = 0 := by
+      rcases Fin.exists_fin_two.mp ⟨c (x, y), rfl⟩ with h | h
+      · exact h
+      · exact absurd h hxy
+    rw [h0]; simp
+
+omit [Fact (Odd L)] [Fact (3 ≤ L)] in
+/-- The chain support card decomposes row by row. -/
+private lemma chainSupport_card_eq_sum_row_card
+    (c : RotatedSurface.VtxIdx L → ZMod 2) :
+    (chainSupport L c).card =
+      ∑ y : Fin L, ((Finset.univ : Finset (Fin L)).filter (fun x => c (x, y) = 1)).card := by
+  classical
+  unfold chainSupport
+  rw [Finset.card_filter]
+  -- ∑ v : VtxIdx L, if c v = 1 then 1 else 0
+  -- VtxIdx L = Fin L × Fin L; use sum_prod and swap.
+  rw [show ∑ v : RotatedSurface.VtxIdx L, (if c v = 1 then (1 : ℕ) else 0) =
+      ∑ x : Fin L, ∑ y : Fin L, (if c (x, y) = 1 then (1 : ℕ) else 0)
+    from Fintype.sum_prod_type (fun v : RotatedSurface.VtxIdx L =>
+      (if c v = 1 then (1 : ℕ) else 0))]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro y _
+  rw [Finset.card_filter]
+
+/-- For any non-trivial X-cycle `c`, the chain support has cardinality ≥ L. -/
+theorem chainSupport_card_ge_L_of_nontrivial
+    {c : RotatedSurface.VtxIdx L → ZMod 2}
+    (hc_cycle : c ∈ RotatedSurface.rscCycles L)
+    (hc_nontrivial : c ∉ RotatedSurface.rscBoundaries L) :
+    L ≤ (chainSupport L c).card := by
+  -- Each row has odd support ≥ 1; sum is ≥ L.
+  rw [chainSupport_card_eq_sum_row_card]
+  have h_each_row : ∀ y : Fin L,
+      1 ≤ ((Finset.univ : Finset (Fin L)).filter (fun x => c (x, y) = 1)).card := by
+    intro y
+    -- rowParity c y = 1 (since c is non-trivial)
+    have h_rp := rowParity_eq_one_of_nontrivial L hc_cycle hc_nontrivial y
+    -- So the cast of card is 1 in ZMod 2.
+    rw [rowParity_eq_row_card_cast] at h_rp
+    -- Hence card is odd, so ≥ 1.
+    by_contra h_lt
+    push Not at h_lt
+    interval_cases (((Finset.univ : Finset (Fin L)).filter (fun x => c (x, y) = 1)).card)
+    rw [Nat.cast_zero] at h_rp
+    exact (by decide : (1 : ZMod 2) ≠ 0) h_rp.symm
+  calc L = ∑ _ : Fin L, 1 := by simp
+    _ ≤ ∑ y : Fin L,
+        ((Finset.univ : Finset (Fin L)).filter (fun x => c (x, y) = 1)).card :=
+      Finset.sum_le_sum (fun y _ => h_each_row y)
+
+/-- For any non-trivial X-cycle `c`, the chain operator has weight ≥ L. -/
+theorem weight_chainXOperator_ge_L_of_nontrivial
+    {c : RotatedSurface.VtxIdx L → ZMod 2}
+    (hc_cycle : c ∈ RotatedSurface.rscCycles L)
+    (hc_nontrivial : c ∉ RotatedSurface.rscBoundaries L) :
+    L ≤ NQubitPauliGroupElement.weight
+      ((RotatedSurface.rotatedSurfaceHomologicalCode L).chainXOperator c) := by
+  rw [weight_chainXOperator_eq_chainSupport_card]
+  exact chainSupport_card_ge_L_of_nontrivial L hc_cycle hc_nontrivial
+
+/-! ## §F — X-type logical operators have weight ≥ L
+
+To bridge from arbitrary X-type non-trivial logicals to chain operators, we
+use that for any X-type element `g`, `chainXOperator (chainOfXOperator g) = g`.
+-/
+
+/-- For X-type elements, the chain ↔ operator roundtrip in the X-direction. -/
+private lemma chainXOperator_chainOfXOperator_of_isXType
+    (g : NQubitPauliGroupElement (numQubits L))
+    (hgX : NQubitPauliGroupElement.IsXTypeElement g) :
+    (RotatedSurface.rotatedSurfaceHomologicalCode L).chainXOperator
+      ((RotatedSurface.rotatedSurfaceHomologicalCode L).chainOfXOperator g) = g := by
+  apply NQubitPauliGroupElement.ext
+  · -- Phases: both are 0 (chainXOperator always has phase 0; X-type g has phase 0).
+    change (0 : Fin 4) = g.phasePower
+    exact hgX.1.symm
+  · -- Operators: case on g.operators q.
+    funext q
+    -- chainXOperator c at q is X iff ∃ e, edgeEquiv e = q ∧ c e = 1.
+    -- Here c = chainOfXOperator g, so c e = 1 iff g.operators (edgeEquiv e) = X.
+    rcases hgX.2 q with hI | hX
+    · -- g.operators q = I: show chainXOperator gives I at q.
+      change (if ∃ e, _ ∧ _ then PauliOperator.X else PauliOperator.I) = _
+      rw [if_neg]
+      · rw [hI]
+      rintro ⟨e, heq, hc⟩
+      -- hc : chainOfXOperator g e = 1 ↔ g.operators (edgeEquiv e) = X
+      simp only [Quantum.Stabilizer.Homological.HomologicalCode.chainOfXOperator] at hc
+      split_ifs at hc with hgx
+      · -- edge maps to q where g is I, but hc says g there is X — contradiction.
+        rw [heq, hI] at hgx
+        exact (by decide : PauliOperator.I ≠ PauliOperator.X) hgx
+      · exact (by decide : (0 : ZMod 2) ≠ 1) hc
+    · -- g.operators q = X: show chainXOperator gives X at q.
+      change (if ∃ e, _ ∧ _ then PauliOperator.X else PauliOperator.I) = _
+      rw [if_pos]
+      · rw [hX]
+      -- Witness: e = edgeEquiv⁻¹ q
+      set e := (RotatedSurface.rscQubitEquiv L).symm q
+      refine ⟨e, ?_, ?_⟩
+      · -- edgeEquiv e = q
+        change RotatedSurface.rscQubitEquiv L
+            ((RotatedSurface.rscQubitEquiv L).symm q) = q
+        exact Equiv.apply_symm_apply _ _
+      · -- chainOfXOperator g e = 1
+        change (if g.operators (RotatedSurface.rscQubitEquiv L e) = PauliOperator.X
+              then (1 : ZMod 2) else 0) = 1
+        rw [show RotatedSurface.rscQubitEquiv L e = q from Equiv.apply_symm_apply _ _, hX]
+        exact if_pos rfl
+
+/-- Any non-trivial X-type logical of the rotated surface stabilizer code has weight ≥ L. -/
+theorem weight_ge_L_of_nontrivial_X_logical
+    {g : NQubitPauliGroupElement (numQubits L)}
+    (hgX : NQubitPauliGroupElement.IsXTypeElement g)
+    (hgLogical : Quantum.StabilizerGroup.IsNontrivialLogicalOperator g
+      (rotatedSurfaceStabilizerCode L).toStabilizerGroup) :
+    L ≤ NQubitPauliGroupElement.weight g := by
+  -- Step 1: write g as chainXOperator c for some c.
+  set c := (RotatedSurface.rotatedSurfaceHomologicalCode L).chainOfXOperator g
+  have h_g_eq : (RotatedSurface.rotatedSurfaceHomologicalCode L).chainXOperator c = g :=
+    chainXOperator_chainOfXOperator_of_isXType L g hgX
+  -- Step 2: translate to the homological stabilizer group.
+  have h_subg_eq := rotatedSurfaceStabilizerCode_subgroup_eq_homological L
+  have h_logical_hom : Quantum.StabilizerGroup.IsNontrivialLogicalOperator g
+      (RotatedSurface.rotatedSurfaceHomologicalCode L).homologicalStabilizerGroup :=
+    (Quantum.StabilizerGroup.IsNontrivialLogicalOperator_of_toSubgroup_eq g
+      h_subg_eq).mp hgLogical
+  -- Step 3: c is a cycle and not a boundary.
+  rw [← h_g_eq] at h_logical_hom
+  have h_iff := (RotatedSurface.rotatedSurfaceHomologicalCode L)
+    |>.chainXOperator_isNontrivialLogical_iff c
+  obtain ⟨hc_cycle, hc_not_boundary⟩ := h_iff.mp h_logical_hom
+  -- Step 4: weight bound.
+  rw [← h_g_eq]
+  exact weight_chainXOperator_ge_L_of_nontrivial L hc_cycle hc_not_boundary
+
+/-- The logical X has weight exactly `L`. -/
+theorem logicalX_weight_eq_L :
+    NQubitPauliGroupElement.weight (logicalX L) = L := by
+  change NQubitPauliGroupElement.weight
+    ((RotatedSurface.rotatedSurfaceHomologicalCode L).chainXOperator (middleColChain L)) = L
+  rw [weight_chainXOperator_eq_chainSupport_card]
+  -- chainSupport of middleColChain has card L (one qubit per row, exactly).
+  unfold chainSupport
+  -- {v : middleColChain L v = 1} = {(midIdx L, y) : y : Fin L}
+  rw [show (Finset.univ.filter (fun v : RotatedSurface.VtxIdx L =>
+      middleColChain L v = 1)) =
+      (Finset.univ : Finset (Fin L)).image (fun y : Fin L => (midIdx L, y)) by
+    ext v
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_image]
+    rcases v with ⟨vx, vy⟩
+    constructor
+    · intro hv
+      unfold middleColChain at hv
+      simp at hv
+      refine ⟨vy, ?_⟩
+      apply Prod.mk_inj.mpr
+      refine ⟨?_, rfl⟩
+      apply Fin.ext
+      rw [midIdx_val]
+      exact hv.symm
+    · rintro ⟨y, hxy⟩
+      have := Prod.mk_inj.mp hxy
+      obtain ⟨h1, h2⟩ := this
+      unfold middleColChain
+      rw [← h1, ← h2, midIdx_val]
+      simp]
+  rw [Finset.card_image_of_injective _ (by
+    intros y1 y2 hy
+    have := Prod.mk_inj.mp hy
+    exact this.2)]
+  simp
+
 end RotatedSurfaceCodeN
 end StabilizerGroup
 end Quantum

--- a/QEC/Stabilizer/Codes/RotatedSurfaceCodeNDistanceX.lean
+++ b/QEC/Stabilizer/Codes/RotatedSurfaceCodeNDistanceX.lean
@@ -1,0 +1,103 @@
+import Mathlib.Tactic
+import QEC.Stabilizer.Codes.RotatedSurfaceCodeNStabilizerCode
+
+/-!
+# Rotated-surface-code X-distance — Stage 5 foundations
+
+For the parametric rotated surface code (L odd, L ≥ 3), the eventual goal
+is to prove that every non-trivial X-type logical has weight ≥ L (lower
+bound), witnessed exactly by the middle-column X-string `logicalX L`.
+
+This file currently establishes the **row-parity invariant** infrastructure:
+the `rowParity` linear functional, its key value on `middleColChain` (= 1
+for every row), and the linearity properties that anchor the eventual
+proof that `rowParity` vanishes on boundaries and is constant in `y` on
+cycles.
+
+The full lower bound `weight g ≥ L` for non-trivial X-logicals, plus the
+witness packaging `HasCodeDistance`, will follow from:
+
+* `rowParity (∂₂ f) y = 0` for every X-face 2-chain `f` and row `y`
+  (each `xSupport xf` projected to any row has even cardinality —
+   proven by direct case analysis on the three face types).
+* `rowParity c y` is constant in `y` on cycles `c` (summing the relevant
+  interior + boundary Z-face constraints between adjacent rows).
+* `dim H₁ = 1` (Stage 3) ⟹ any non-trivial cycle is homologous to
+  `middleColChain`, so `rowParity c y = 1` for all `y`.
+* Each row contributes ≥ 1 qubit to the support of `c`, giving weight ≥ L.
+
+These remaining steps require substantial Finset bookkeeping over the
+six cases (interior × Z-face, top/bottom-bdy × Z-face) and are deferred
+to follow-up commits.
+-/
+
+namespace Quantum
+namespace StabilizerGroup
+namespace RotatedSurfaceCodeN
+
+open scoped BigOperators
+open NQubitPauliGroupElement
+open Stabilizer.Lattice
+
+variable (L : ℕ) [Fact (Odd L)] [Fact (3 ≤ L)]
+
+/-! ## §A — Row parity functional -/
+
+/-- The row-parity functional at row `y`: parity of `c (x, y)` over `x`. -/
+def rowParity (c : RotatedSurface.VtxIdx L → ZMod 2) (y : Fin L) : ZMod 2 :=
+  ∑ x : Fin L, c (x, y)
+
+omit [Fact (Odd L)] [Fact (3 ≤ L)] in
+@[simp] lemma rowParity_add (c c' : RotatedSurface.VtxIdx L → ZMod 2) (y : Fin L) :
+    rowParity L (c + c') y = rowParity L c y + rowParity L c' y := by
+  unfold rowParity
+  rw [← Finset.sum_add_distrib]
+  apply Finset.sum_congr rfl
+  intros; simp [Pi.add_apply]
+
+omit [Fact (Odd L)] [Fact (3 ≤ L)] in
+@[simp] lemma rowParity_zero (y : Fin L) :
+    rowParity L (0 : RotatedSurface.VtxIdx L → ZMod 2) y = 0 := by
+  unfold rowParity
+  apply Finset.sum_eq_zero
+  intros; rfl
+
+omit [Fact (Odd L)] [Fact (3 ≤ L)] in
+lemma rowParity_smul (a : ZMod 2) (c : RotatedSurface.VtxIdx L → ZMod 2)
+    (y : Fin L) :
+    rowParity L (a • c) y = a * rowParity L c y := by
+  unfold rowParity
+  rw [Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intros; simp [Pi.smul_apply, smul_eq_mul]
+
+/-! ## §B — Row parity of `middleColChain` is `1`
+
+The middle column intersects each row in exactly one qubit (at `x = mid`),
+so the row parity is `1` for every row.  This is the non-zero side of the
+eventual `H₁ → ZMod 2` functional.
+-/
+
+omit [Fact (Odd L)] in
+theorem rowParity_middleColChain (y : Fin L) :
+    rowParity L (middleColChain L) y = 1 := by
+  classical
+  unfold rowParity
+  -- ∑ x, middleColChain (x, y) = if x = mid then 1 else 0 summed → 1.
+  rw [Finset.sum_eq_single (midIdx L)]
+  · unfold middleColChain
+    simp
+  · intro x _ hne
+    unfold middleColChain
+    rw [if_neg]
+    intro hx
+    apply hne
+    apply Fin.ext
+    show x.val = (midIdx L).val
+    rw [midIdx_val]
+    exact hx
+  · intro hcontra; exact absurd (Finset.mem_univ _) hcontra
+
+end RotatedSurfaceCodeN
+end StabilizerGroup
+end Quantum

--- a/QEC/Stabilizer/Codes/RotatedSurfaceCodeNDistanceZ.lean
+++ b/QEC/Stabilizer/Codes/RotatedSurfaceCodeNDistanceZ.lean
@@ -257,6 +257,502 @@ theorem colParity_eq_zero_of_mem_dualBoundaries
   rcases hc with ⟨s, rfl⟩
   exact colParity_rscZCutMap L s x
 
+/-! ## §D — `dim (dualCycles / dualBoundaries) = 1`
+
+We need two rank computations:
+
+* `dim dualCycles = L*L − card XFaceIdx`, via rank-nullity on the abstract
+  `dualBoundary`, whose rank matches `rank rscBoundary2 = card XFaceIdx`
+  (Stage 3) by `Matrix.rank_transpose`.
+
+* `dim dualBoundaries = card ZFaceIdx`, via the bridge
+  `cutMap = rscZCutMap` and Stage 3's `rsc_rank_zCutMap`.
+
+The dual chain-complex law `dualBoundary ∘ cutMap = 0` (which gives
+`dualBoundaries ≤ dualCycles`) is the transpose of `∂₁ ∘ ∂₂ = 0`.
+-/
+
+omit [Fact (Odd L)] [Fact (3 ≤ L)] in
+/-- The X-stab incidence matrix: entry `(xf, v)` is `1` iff `v ∈ xSupport xf`. -/
+def stabXMatrix : Matrix (RotatedSurface.XFaceIdx L) (RotatedSurface.VtxIdx L) (ZMod 2) :=
+  fun xf v => if v ∈ RotatedSurface.xSupport xf then 1 else 0
+
+omit [Fact (Odd L)] [Fact (3 ≤ L)] in
+lemma rscBoundary2_eq_transpose_mulVecLin :
+    RotatedSurface.rscBoundary2 L = (stabXMatrix L).transpose.mulVecLin := by
+  apply LinearMap.ext
+  intro c
+  funext v
+  rw [RotatedSurface.rscBoundary2_apply, Matrix.mulVecLin_apply, Matrix.mulVec, dotProduct]
+  simp only [stabXMatrix, Matrix.transpose_apply]
+  apply Finset.sum_congr rfl
+  intro xf _
+  ring
+
+lemma dualBoundary_apply_eq_mulVec (c : RotatedSurface.VtxIdx L → ZMod 2)
+    (xf : RotatedSurface.XFaceIdx L) :
+    (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundary c xf =
+      (stabXMatrix L).mulVec c xf := by
+  rw [dualBoundary_apply_eq_sum]
+  -- LHS: ∑ v ∈ xSupport xf, c v
+  -- RHS: (stabXMatrix L).mulVec c xf = ∑ v, (stabXMatrix L) xf v * c v
+  rw [Matrix.mulVec, dotProduct]
+  simp only [stabXMatrix]
+  rw [show (fun v : RotatedSurface.VtxIdx L =>
+        (if v ∈ RotatedSurface.xSupport xf then (1 : ZMod 2) else 0) * c v) =
+      (fun v => if v ∈ RotatedSurface.xSupport xf then c v else 0) from
+    funext fun v => by split_ifs <;> simp]
+  rw [← Finset.sum_filter]
+  apply Finset.sum_congr _ (fun _ _ => rfl)
+  ext v; simp
+
+lemma dualBoundary_eq_mulVecLin :
+    (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundary =
+      Matrix.mulVecLin (stabXMatrix L) := by
+  apply LinearMap.ext
+  intro c
+  funext xf
+  rw [dualBoundary_apply_eq_mulVec]
+  rfl
+
+/-- `rank(dualBoundary) = card (XFaceIdx L)`. -/
+theorem rsc_rank_dualBoundary :
+    Module.finrank (ZMod 2)
+        (LinearMap.range (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundary) =
+      Fintype.card (RotatedSurface.XFaceIdx L) := by
+  have h_eq_rank :
+      Module.finrank (ZMod 2)
+          (LinearMap.range (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundary) =
+        Module.finrank (ZMod 2) (LinearMap.range (RotatedSurface.rscBoundary2 L)) := by
+    rw [dualBoundary_eq_mulVecLin, rscBoundary2_eq_transpose_mulVecLin]
+    change Matrix.rank (stabXMatrix L) = Matrix.rank (stabXMatrix L).transpose
+    rw [Matrix.rank_transpose]
+  rw [h_eq_rank]
+  exact RotatedSurface.rsc_rank_boundary2 (L := L)
+
+/-- `dim dualCycles = L*L − card XFaceIdx`. -/
+theorem rsc_finrank_dualCycles :
+    Module.finrank (ZMod 2)
+        (RotatedSurface.rotatedSurfaceHomologicalCode L).dualCycles =
+      L * L - Fintype.card (RotatedSurface.XFaceIdx L) := by
+  have hrn := LinearMap.finrank_range_add_finrank_ker
+    (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundary
+  rw [rsc_rank_dualBoundary] at hrn
+  -- dim C₁ = L*L (via Fintype card of VtxIdx).
+  have h_C1 : Module.finrank (ZMod 2)
+      ((RotatedSurface.rotatedSurfaceHomologicalCode L).C1 → ZMod 2) = L * L := by
+    rw [Module.finrank_fintype_fun_eq_card]
+    change Fintype.card (RotatedSurface.VtxIdx L) = L * L
+    simp [Fintype.card_prod, Fintype.card_fin]
+  rw [h_C1] at hrn
+  change Module.finrank (ZMod 2)
+    (LinearMap.ker (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundary) = _
+  omega
+
+omit [Fact (Odd L)] [Fact (3 ≤ L)] in
+/-- Helper: `rscBoundary1 (Pi.single v 1) zf = 1[v ∈ zSupport zf]`. -/
+private lemma rscBoundary1_pi_single
+    (v : RotatedSurface.VtxIdx L) (zf : RotatedSurface.ZFaceIdx L) :
+    RotatedSurface.rscBoundary1 L (Pi.single v 1) zf =
+      (if v ∈ RotatedSurface.zSupport zf then (1 : ZMod 2) else 0) := by
+  classical
+  rw [RotatedSurface.rscBoundary1_apply]
+  by_cases hv : v ∈ RotatedSurface.zSupport zf
+  · rw [if_pos hv, Finset.sum_eq_single_of_mem v hv]
+    · simp
+    · intro u _ hne
+      simp [hne]
+  · rw [if_neg hv]
+    apply Finset.sum_eq_zero
+    intro u hu
+    have hne : u ≠ v := fun heq => hv (heq ▸ hu)
+    simp [hne]
+
+/-- Bridge: the abstract `cutMap` equals the lattice-side `rscZCutMap`. -/
+lemma cutMap_eq_rscZCutMap :
+    (RotatedSurface.rotatedSurfaceHomologicalCode L).cutMap =
+      RotatedSurface.rscZCutMap L := by
+  apply LinearMap.ext
+  intro s
+  funext v
+  change ∑ zf : RotatedSurface.ZFaceIdx L,
+      s zf * RotatedSurface.rscBoundary1 L (Pi.single v 1) zf = _
+  change _ = ∑ zf : RotatedSurface.ZFaceIdx L,
+      s zf * (if v ∈ RotatedSurface.zSupport zf then (1 : ZMod 2) else 0)
+  apply Finset.sum_congr rfl
+  intro zf _
+  congr 1
+  exact rscBoundary1_pi_single L v zf
+
+/-- `dim dualBoundaries = card ZFaceIdx`. -/
+theorem rsc_finrank_dualBoundaries :
+    Module.finrank (ZMod 2)
+        (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundaries =
+      Fintype.card (RotatedSurface.ZFaceIdx L) := by
+  change Module.finrank (ZMod 2)
+    (LinearMap.range (RotatedSurface.rotatedSurfaceHomologicalCode L).cutMap) = _
+  rw [cutMap_eq_rscZCutMap]
+  exact RotatedSurface.rsc_rank_zCutMap (L := L)
+
+/-- `dualBoundaries ≤ dualCycles` (dual chain-complex law). -/
+theorem dualBoundaries_le_dualCycles :
+    (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundaries ≤
+      (RotatedSurface.rotatedSurfaceHomologicalCode L).dualCycles := by
+  intro c hc
+  rcases hc with ⟨s, rfl⟩
+  -- Goal: cutMap s ∈ dualCycles = ker dualBoundary.
+  change (RotatedSurface.rotatedSurfaceHomologicalCode L).cutMap s ∈
+      LinearMap.ker (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundary
+  rw [LinearMap.mem_ker]
+  funext xf
+  rw [Pi.zero_apply]
+  -- Use boundary2_dualBoundary_transpose specialized to Pi.single xf 1.
+  have h_pair := Quantum.Stabilizer.Homological.HomologicalCode.boundary2_dualBoundary_transpose
+    (X := RotatedSurface.rotatedSurfaceHomologicalCode L) (Pi.single xf 1)
+    ((RotatedSurface.rotatedSurfaceHomologicalCode L).cutMap s)
+  -- h_pair: ∑ e, boundary2 (δ_xf) e * cutMap s e = ∑ p, δ_xf p * dualBoundary (cutMap s) p
+  -- RHS: only the xf term survives.
+  -- Use: ∑ p, Pi.single xf 1 p * g p = g xf for any g.
+  have h_eq : ∀ p : RotatedSurface.XFaceIdx L,
+      (Pi.single xf (1 : ZMod 2) : RotatedSurface.XFaceIdx L → ZMod 2) p *
+        (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundary
+          ((RotatedSurface.rotatedSurfaceHomologicalCode L).cutMap s) p =
+      (Pi.single xf
+          ((RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundary
+            ((RotatedSurface.rotatedSurfaceHomologicalCode L).cutMap s) xf) :
+        RotatedSurface.XFaceIdx L → ZMod 2) p := by
+    intro p
+    by_cases hp : p = xf
+    · subst hp
+      rw [Pi.single_eq_same, Pi.single_eq_same, _root_.one_mul]
+    · rw [Pi.single_apply, if_neg hp, Pi.single_apply, if_neg hp, MulZeroClass.zero_mul]
+  have h_RHS : (∑ p : RotatedSurface.XFaceIdx L,
+      (Pi.single xf 1 : RotatedSurface.XFaceIdx L → ZMod 2) p *
+        (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundary
+          ((RotatedSurface.rotatedSurfaceHomologicalCode L).cutMap s) p) =
+      (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundary
+        ((RotatedSurface.rotatedSurfaceHomologicalCode L).cutMap s) xf := by
+    rw [Finset.sum_congr rfl (fun p _ => h_eq p)]
+    exact Fintype.sum_pi_single' xf _
+  -- Combine h_pair (transpose pairing) and h_RHS (RHS reduction) into a direct equation.
+  have h_eq2 : (∑ e : RotatedSurface.VtxIdx L,
+      (RotatedSurface.rotatedSurfaceHomologicalCode L).boundary2 (Pi.single xf 1) e *
+        (RotatedSurface.rotatedSurfaceHomologicalCode L).cutMap s e) =
+      (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundary
+        ((RotatedSurface.rotatedSurfaceHomologicalCode L).cutMap s) xf := h_pair.trans h_RHS
+  -- The LHS = chainInnerProduct = 0.
+  rw [← h_eq2]
+  exact Quantum.Stabilizer.Homological.HomologicalCode.chainInnerProduct_boundary2_cutMap_eq_zero
+    (X := RotatedSurface.rotatedSurfaceHomologicalCode L) (Pi.single xf 1) s
+
+/-- `dim (dualCycles / dualBoundaries) = 1` for the rotated surface code. -/
+theorem rsc_finrank_dualH1_eq_one :
+    Module.finrank (ZMod 2)
+      ((RotatedSurface.rotatedSurfaceHomologicalCode L).dualCycles ⧸
+        Submodule.comap
+          (RotatedSurface.rotatedSurfaceHomologicalCode L).dualCycles.subtype
+          (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundaries) = 1 := by
+  have h_le := dualBoundaries_le_dualCycles L
+  have h_quot := Submodule.finrank_quotient_add_finrank (R := ZMod 2)
+    (Submodule.comap (RotatedSurface.rotatedSurfaceHomologicalCode L).dualCycles.subtype
+      (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundaries)
+  have h_comap : Module.finrank (ZMod 2)
+      (Submodule.comap (RotatedSurface.rotatedSurfaceHomologicalCode L).dualCycles.subtype
+        (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundaries) =
+      Module.finrank (ZMod 2)
+        (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundaries :=
+    (Submodule.comapSubtypeEquivOfLe h_le).finrank_eq
+  rw [h_comap, rsc_finrank_dualBoundaries, rsc_finrank_dualCycles] at h_quot
+  have hcard := RotatedSurface.card_ZFaceIdx_add_card_XFaceIdx (L := L)
+  have h3 : 3 ≤ L := Fact.out
+  have hLL : 1 ≤ L * L := by nlinarith
+  omega
+
+/-! ## §E — `middleRowChain ∉ dualBoundaries` and homology characterization -/
+
+/-- `middleRowChain` is not a dual boundary. -/
+theorem middleRowChain_not_mem_dualBoundaries :
+    middleRowChain L ∉
+      (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundaries := by
+  intro h
+  have h_rsc : middleRowChain L ∈ LinearMap.range (RotatedSurface.rscZCutMap L) := by
+    rw [← cutMap_eq_rscZCutMap]
+    exact h
+  have h1 : colParity L (middleRowChain L)
+      ⟨0, by have h3 : 3 ≤ L := Fact.out; omega⟩ = 1 :=
+    colParity_middleRowChain L _
+  have h0 : colParity L (middleRowChain L)
+      ⟨0, by have h3 : 3 ≤ L := Fact.out; omega⟩ = 0 :=
+    colParity_eq_zero_of_mem_dualBoundaries L h_rsc _
+  rw [h1] at h0
+  exact (by decide : (1 : ZMod 2) ≠ 0) h0
+
+/-- The class of `middleRowChain` in `dualCycles / dualBoundaries` is non-zero. -/
+private lemma middleRowChain_dual_class_ne_zero :
+    (Submodule.Quotient.mk
+      (⟨middleRowChain L, by
+        -- middleRowChain ∈ dualCycles, proved in Stage 4 as middleRowChain_mem_dualCycles
+        exact middleRowChain_mem_dualCycles L⟩ :
+        (RotatedSurface.rotatedSurfaceHomologicalCode L).dualCycles) :
+      (RotatedSurface.rotatedSurfaceHomologicalCode L).dualCycles ⧸
+        Submodule.comap
+          (RotatedSurface.rotatedSurfaceHomologicalCode L).dualCycles.subtype
+          (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundaries) ≠ 0 := by
+  intro h
+  rw [Submodule.Quotient.mk_eq_zero] at h
+  exact middleRowChain_not_mem_dualBoundaries L h
+
+/-- For non-trivial dual cycle `c`, `c - middleRowChain ∈ dualBoundaries`. -/
+theorem dualCycle_sub_middleRowChain_mem_dualBoundaries
+    {c : RotatedSurface.VtxIdx L → ZMod 2}
+    (hc_cycle : c ∈ (RotatedSurface.rotatedSurfaceHomologicalCode L).dualCycles)
+    (hc_nontrivial : c ∉ (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundaries) :
+    c - middleRowChain L ∈ (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundaries := by
+  have h_dim := rsc_finrank_dualH1_eq_one L
+  have h_spans :
+      ∀ w : (RotatedSurface.rotatedSurfaceHomologicalCode L).dualCycles ⧸
+              Submodule.comap _ (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundaries,
+        ∃ a : ZMod 2, a • (Submodule.Quotient.mk
+          (⟨middleRowChain L, middleRowChain_mem_dualCycles L⟩ :
+            (RotatedSurface.rotatedSurfaceHomologicalCode L).dualCycles)) = w :=
+    (finrank_eq_one_iff_of_nonzero' _ (middleRowChain_dual_class_ne_zero L)).mp h_dim
+  let cCycle : (RotatedSurface.rotatedSurfaceHomologicalCode L).dualCycles := ⟨c, hc_cycle⟩
+  obtain ⟨a, ha⟩ := h_spans (Submodule.Quotient.mk cCycle)
+  have ha_dichot : a = 0 ∨ a = 1 := by
+    rcases Fin.exists_fin_two.mp ⟨a, rfl⟩ with h | h
+    · left; exact h
+    · right; exact h
+  rcases ha_dichot with ha0 | ha1
+  · exfalso
+    rw [ha0, zero_smul] at ha
+    rw [eq_comm, Submodule.Quotient.mk_eq_zero] at ha
+    exact hc_nontrivial ha
+  · rw [ha1, one_smul] at ha
+    have h_eq : (Submodule.Quotient.mk cCycle :
+        (RotatedSurface.rotatedSurfaceHomologicalCode L).dualCycles ⧸ _) =
+        Submodule.Quotient.mk
+          (⟨middleRowChain L, middleRowChain_mem_dualCycles L⟩ :
+            (RotatedSurface.rotatedSurfaceHomologicalCode L).dualCycles) := ha.symm
+    rw [Submodule.Quotient.eq] at h_eq
+    exact h_eq
+
+/-- For non-trivial dual cycle `c`, `colParity c x = 1` for every column `x`. -/
+theorem colParity_eq_one_of_nontrivial
+    {c : RotatedSurface.VtxIdx L → ZMod 2}
+    (hc_cycle : c ∈ (RotatedSurface.rotatedSurfaceHomologicalCode L).dualCycles)
+    (hc_nontrivial : c ∉ (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundaries)
+    (x : Fin L) :
+    colParity L c x = 1 := by
+  have h_diff_boundary :=
+    dualCycle_sub_middleRowChain_mem_dualBoundaries L hc_cycle hc_nontrivial
+  have h_eq : c = middleRowChain L + (c - middleRowChain L) := by abel
+  rw [h_eq, colParity_add]
+  rw [colParity_middleRowChain]
+  -- dualBoundaries unfolds to range cutMap; convert h_diff_boundary to range rscZCutMap.
+  have h_diff_rsc : c - middleRowChain L ∈
+      LinearMap.range (RotatedSurface.rscZCutMap L) := by
+    rw [← cutMap_eq_rscZCutMap]
+    exact h_diff_boundary
+  rw [colParity_eq_zero_of_mem_dualBoundaries L h_diff_rsc x]
+  ring
+
+/-! ## §F — Weight ≥ L for non-trivial Z-logicals -/
+
+omit [Fact (Odd L)] in
+/-- The chain support of `c` is `{v : c v = 1}`. -/
+private def dualChainSupport (c : RotatedSurface.VtxIdx L → ZMod 2) :
+    Finset (RotatedSurface.VtxIdx L) :=
+  Finset.univ.filter (fun v => c v = 1)
+
+/-- `weight (chainZOperator c) = (dualChainSupport c).card`. -/
+private lemma weight_chainZOperator_eq_dualChainSupport_card
+    (c : RotatedSurface.VtxIdx L → ZMod 2) :
+    NQubitPauliGroupElement.weight
+      ((RotatedSurface.rotatedSurfaceHomologicalCode L).chainZOperator c) =
+    (dualChainSupport L c).card := by
+  classical
+  symm
+  unfold NQubitPauliGroupElement.weight NQubitPauliOperator.weight
+  apply Finset.card_bij (fun v _ => RotatedSurface.rscQubitEquiv L v)
+  · intro v hv
+    rw [dualChainSupport, Finset.mem_filter] at hv
+    have h_iff :=
+      (Quantum.Stabilizer.Homological.HomologicalCode.mem_support_chainZOperator_iff
+        (X := RotatedSurface.rotatedSurfaceHomologicalCode L) c v).mpr hv.2
+    change (RotatedSurface.rscQubitEquiv L) v ∈ _ at h_iff
+    exact h_iff
+  · intros v1 _ v2 _ heq
+    exact (RotatedSurface.rscQubitEquiv L).injective heq
+  · intros q hq
+    set v := (RotatedSurface.rscQubitEquiv L).symm q
+    have h_q : RotatedSurface.rscQubitEquiv L v = q := Equiv.apply_symm_apply _ _
+    refine ⟨v, ?_, h_q⟩
+    rw [dualChainSupport, Finset.mem_filter]
+    refine ⟨Finset.mem_univ _, ?_⟩
+    have h_iff :=
+      Quantum.Stabilizer.Homological.HomologicalCode.mem_support_chainZOperator_iff
+        (X := RotatedSurface.rotatedSurfaceHomologicalCode L) c v
+    change (RotatedSurface.rscQubitEquiv L) v ∈ _ ↔ _ at h_iff
+    rw [h_q] at h_iff
+    exact h_iff.mp hq
+
+omit [Fact (Odd L)] [Fact (3 ≤ L)] in
+/-- `colParity c x = (filter (c (x, ·) = 1) univ).card` cast to `ZMod 2`. -/
+private lemma colParity_eq_col_card_cast
+    (c : RotatedSurface.VtxIdx L → ZMod 2) (x : Fin L) :
+    colParity L c x =
+      (((Finset.univ : Finset (Fin L)).filter (fun y => c (x, y) = 1)).card : ZMod 2) := by
+  classical
+  unfold colParity
+  rw [Finset.card_filter, Nat.cast_sum]
+  apply Finset.sum_congr rfl
+  intro y _
+  by_cases hxy : c (x, y) = 1
+  · rw [hxy]; simp
+  · have h0 : c (x, y) = 0 := by
+      rcases Fin.exists_fin_two.mp ⟨c (x, y), rfl⟩ with h | h
+      · exact h
+      · exact absurd h hxy
+    rw [h0]; simp
+
+omit [Fact (Odd L)] [Fact (3 ≤ L)] in
+/-- The dual-chain support card decomposes column by column. -/
+private lemma dualChainSupport_card_eq_sum_col_card
+    (c : RotatedSurface.VtxIdx L → ZMod 2) :
+    (dualChainSupport L c).card =
+      ∑ x : Fin L, ((Finset.univ : Finset (Fin L)).filter (fun y => c (x, y) = 1)).card := by
+  classical
+  unfold dualChainSupport
+  rw [Finset.card_filter]
+  rw [show ∑ v : RotatedSurface.VtxIdx L, (if c v = 1 then (1 : ℕ) else 0) =
+      ∑ x : Fin L, ∑ y : Fin L, (if c (x, y) = 1 then (1 : ℕ) else 0)
+    from Fintype.sum_prod_type (fun v : RotatedSurface.VtxIdx L =>
+      (if c v = 1 then (1 : ℕ) else 0))]
+  apply Finset.sum_congr rfl
+  intro x _
+  rw [Finset.card_filter]
+
+/-- For any non-trivial dual cycle `c`, dual chain support has cardinality ≥ L. -/
+theorem dualChainSupport_card_ge_L_of_nontrivial
+    {c : RotatedSurface.VtxIdx L → ZMod 2}
+    (hc_cycle : c ∈ (RotatedSurface.rotatedSurfaceHomologicalCode L).dualCycles)
+    (hc_nontrivial : c ∉ (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundaries) :
+    L ≤ (dualChainSupport L c).card := by
+  rw [dualChainSupport_card_eq_sum_col_card]
+  have h_each_col : ∀ x : Fin L,
+      1 ≤ ((Finset.univ : Finset (Fin L)).filter (fun y => c (x, y) = 1)).card := by
+    intro x
+    have h_cp := colParity_eq_one_of_nontrivial L hc_cycle hc_nontrivial x
+    rw [colParity_eq_col_card_cast] at h_cp
+    by_contra h_lt
+    push Not at h_lt
+    interval_cases (((Finset.univ : Finset (Fin L)).filter (fun y => c (x, y) = 1)).card)
+    rw [Nat.cast_zero] at h_cp
+    exact (by decide : (1 : ZMod 2) ≠ 0) h_cp.symm
+  calc L = ∑ _ : Fin L, 1 := by simp
+    _ ≤ ∑ x : Fin L,
+        ((Finset.univ : Finset (Fin L)).filter (fun y => c (x, y) = 1)).card :=
+      Finset.sum_le_sum (fun x _ => h_each_col x)
+
+/-- Weight ≥ L for non-trivial Z-cycle. -/
+theorem weight_chainZOperator_ge_L_of_nontrivial
+    {c : RotatedSurface.VtxIdx L → ZMod 2}
+    (hc_cycle : c ∈ (RotatedSurface.rotatedSurfaceHomologicalCode L).dualCycles)
+    (hc_nontrivial : c ∉ (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundaries) :
+    L ≤ NQubitPauliGroupElement.weight
+      ((RotatedSurface.rotatedSurfaceHomologicalCode L).chainZOperator c) := by
+  rw [weight_chainZOperator_eq_dualChainSupport_card]
+  exact dualChainSupport_card_ge_L_of_nontrivial L hc_cycle hc_nontrivial
+
+/-- For Z-type elements, the chain ↔ operator roundtrip. -/
+private lemma chainZOperator_chainOfZOperator_of_isZType
+    (g : NQubitPauliGroupElement (numQubits L))
+    (hgZ : NQubitPauliGroupElement.IsZTypeElement g) :
+    (RotatedSurface.rotatedSurfaceHomologicalCode L).chainZOperator
+      ((RotatedSurface.rotatedSurfaceHomologicalCode L).chainOfZOperator g) = g := by
+  apply NQubitPauliGroupElement.ext
+  · change (0 : Fin 4) = g.phasePower
+    exact hgZ.1.symm
+  · funext q
+    rcases hgZ.2 q with hI | hZ
+    · change (if ∃ e, _ ∧ _ then PauliOperator.Z else PauliOperator.I) = _
+      rw [if_neg]
+      · rw [hI]
+      rintro ⟨e, heq, hc⟩
+      simp only [Quantum.Stabilizer.Homological.HomologicalCode.chainOfZOperator] at hc
+      split_ifs at hc with hgz
+      · rw [heq, hI] at hgz
+        exact (by decide : PauliOperator.I ≠ PauliOperator.Z) hgz
+      · exact (by decide : (0 : ZMod 2) ≠ 1) hc
+    · change (if ∃ e, _ ∧ _ then PauliOperator.Z else PauliOperator.I) = _
+      rw [if_pos]
+      · rw [hZ]
+      set e := (RotatedSurface.rscQubitEquiv L).symm q
+      refine ⟨e, ?_, ?_⟩
+      · change RotatedSurface.rscQubitEquiv L
+            ((RotatedSurface.rscQubitEquiv L).symm q) = q
+        exact Equiv.apply_symm_apply _ _
+      · change (if g.operators (RotatedSurface.rscQubitEquiv L e) = PauliOperator.Z
+              then (1 : ZMod 2) else 0) = 1
+        rw [show RotatedSurface.rscQubitEquiv L e = q from Equiv.apply_symm_apply _ _, hZ]
+        exact if_pos rfl
+
+/-- Any non-trivial Z-type logical of the rotated surface stabilizer code has weight ≥ L. -/
+theorem weight_ge_L_of_nontrivial_Z_logical
+    {g : NQubitPauliGroupElement (numQubits L)}
+    (hgZ : NQubitPauliGroupElement.IsZTypeElement g)
+    (hgLogical : Quantum.StabilizerGroup.IsNontrivialLogicalOperator g
+      (rotatedSurfaceStabilizerCode L).toStabilizerGroup) :
+    L ≤ NQubitPauliGroupElement.weight g := by
+  set c := (RotatedSurface.rotatedSurfaceHomologicalCode L).chainOfZOperator g
+  have h_g_eq : (RotatedSurface.rotatedSurfaceHomologicalCode L).chainZOperator c = g :=
+    chainZOperator_chainOfZOperator_of_isZType L g hgZ
+  have h_subg_eq := rotatedSurfaceStabilizerCode_subgroup_eq_homological L
+  have h_logical_hom : Quantum.StabilizerGroup.IsNontrivialLogicalOperator g
+      (RotatedSurface.rotatedSurfaceHomologicalCode L).homologicalStabilizerGroup :=
+    (Quantum.StabilizerGroup.IsNontrivialLogicalOperator_of_toSubgroup_eq g
+      h_subg_eq).mp hgLogical
+  rw [← h_g_eq] at h_logical_hom
+  have h_iff := (RotatedSurface.rotatedSurfaceHomologicalCode L)
+    |>.chainZOperator_isNontrivialLogical_iff c
+  obtain ⟨hc_cycle, hc_not_boundary⟩ := h_iff.mp h_logical_hom
+  rw [← h_g_eq]
+  exact weight_chainZOperator_ge_L_of_nontrivial L hc_cycle hc_not_boundary
+
+/-- The logical Z has weight exactly `L`. -/
+theorem logicalZ_weight_eq_L :
+    NQubitPauliGroupElement.weight (logicalZ L) = L := by
+  change NQubitPauliGroupElement.weight
+    ((RotatedSurface.rotatedSurfaceHomologicalCode L).chainZOperator (middleRowChain L)) = L
+  rw [weight_chainZOperator_eq_dualChainSupport_card]
+  unfold dualChainSupport
+  rw [show (Finset.univ.filter (fun v : RotatedSurface.VtxIdx L =>
+      middleRowChain L v = 1)) =
+      (Finset.univ : Finset (Fin L)).image (fun x : Fin L => (x, midIdx L)) by
+    ext v
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_image]
+    rcases v with ⟨vx, vy⟩
+    constructor
+    · intro hv
+      unfold middleRowChain at hv
+      simp at hv
+      refine ⟨vx, ?_⟩
+      apply Prod.mk_inj.mpr
+      refine ⟨rfl, ?_⟩
+      apply Fin.ext
+      rw [midIdx_val]
+      exact hv.symm
+    · rintro ⟨x, hxy⟩
+      have := Prod.mk_inj.mp hxy
+      obtain ⟨h1, h2⟩ := this
+      unfold middleRowChain
+      rw [← h1, ← h2, midIdx_val]
+      simp]
+  rw [Finset.card_image_of_injective _ (by
+    intros x1 x2 hx
+    have := Prod.mk_inj.mp hx
+    exact this.1)]
+  simp
 
 end RotatedSurfaceCodeN
 end StabilizerGroup

--- a/QEC/Stabilizer/Codes/RotatedSurfaceCodeNDistanceZ.lean
+++ b/QEC/Stabilizer/Codes/RotatedSurfaceCodeNDistanceZ.lean
@@ -1,0 +1,263 @@
+import Mathlib.Tactic
+import QEC.Stabilizer.Codes.RotatedSurfaceCodeNDistanceX
+
+/-!
+# Rotated-surface-code Z-distance ≥ L
+
+The Z-distance mirror of [RotatedSurfaceCodeNDistanceX](RotatedSurfaceCodeNDistanceX.lean).
+Every non-trivial Z-type logical of `rotatedSurfaceStabilizerCode L` has Pauli
+weight ≥ L, witnessed exactly by `logicalZ L` (the middle-row Z-string).
+
+## Strategy — column-parity invariant (dual side)
+
+Mirroring the row-parity argument: for a 1-chain `c : VtxIdx L → ZMod 2`, define
+
+  `colParity c x := ∑ y, c (x, y) : ZMod 2`.
+
+Three key facts:
+
+* `colParity (rscZCutMap s) x = 0` for every Z-face 0-chain `s` and column `x`
+  (each `zSupport zf` projected to any column has even cardinality).
+* `colParity middleRowChain x = 1` for every column `x`.
+* `dim (dualCycles / dualBoundaries) = 1` (proved here via the transpose-rank
+  bridge to `rsc_rank_boundary2` from Stage 3).
+
+Combining these: for any non-trivial dual cycle `c`, `colParity c x = 1`
+for all `x`, so each column contributes ≥ 1 qubit to the support, giving
+total weight ≥ L.
+-/
+
+namespace Quantum
+namespace StabilizerGroup
+namespace RotatedSurfaceCodeN
+
+open scoped BigOperators
+open NQubitPauliGroupElement
+open Stabilizer.Lattice
+
+variable (L : ℕ) [Fact (Odd L)] [Fact (3 ≤ L)]
+
+/-! ## §A — Column parity functional -/
+
+/-- The column-parity functional at column `x`: parity of `c (x, y)` over `y`. -/
+def colParity (c : RotatedSurface.VtxIdx L → ZMod 2) (x : Fin L) : ZMod 2 :=
+  ∑ y : Fin L, c (x, y)
+
+omit [Fact (Odd L)] [Fact (3 ≤ L)] in
+@[simp] lemma colParity_add (c c' : RotatedSurface.VtxIdx L → ZMod 2) (x : Fin L) :
+    colParity L (c + c') x = colParity L c x + colParity L c' x := by
+  unfold colParity
+  rw [← Finset.sum_add_distrib]
+  apply Finset.sum_congr rfl
+  intros; simp [Pi.add_apply]
+
+omit [Fact (Odd L)] [Fact (3 ≤ L)] in
+@[simp] lemma colParity_zero (x : Fin L) :
+    colParity L (0 : RotatedSurface.VtxIdx L → ZMod 2) x = 0 := by
+  unfold colParity
+  apply Finset.sum_eq_zero
+  intros; rfl
+
+/-! ## §B — Column parity of `middleRowChain` is `1` -/
+
+omit [Fact (Odd L)] in
+theorem colParity_middleRowChain (x : Fin L) :
+    colParity L (middleRowChain L) x = 1 := by
+  classical
+  unfold colParity
+  rw [Finset.sum_eq_single (midIdx L)]
+  · unfold middleRowChain
+    simp
+  · intro y _ hne
+    unfold middleRowChain
+    rw [if_neg]
+    intro hy
+    apply hne
+    apply Fin.ext
+    show y.val = (midIdx L).val
+    rw [midIdx_val]
+    exact hy
+  · intro hcontra; exact absurd (Finset.mem_univ _) hcontra
+
+/-! ## §C — Column parity vanishes on dual boundaries
+
+`dualBoundaries = range rscZCutMap`.  We show that `colParity (rscZCutMap s) x = 0`
+for every Z-face chain `s`, by case analysis on each Z-face type.
+-/
+
+omit [Fact (Odd L)] [Fact (3 ≤ L)] in
+/-- A Finset that is empty or a 2-element set has card 0 in `ZMod 2`. -/
+private lemma card_empty_or_pair_zmod2_zero' {α : Type*} [DecidableEq α] (s : Finset α)
+    (h : s = ∅ ∨ ∃ a b : α, a ≠ b ∧ s = {a, b}) :
+    (s.card : ZMod 2) = 0 := by
+  rcases h with hempty | ⟨a, b, hne, heq⟩
+  · rw [hempty, Finset.card_empty]; rfl
+  · rw [heq, Finset.card_insert_of_notMem (by simp [hne]), Finset.card_singleton]
+    decide
+
+omit [Fact (Odd L)] in
+/-- Per-column intersection of `zSupport zf` with column `x` is either empty
+or a 2-element set. -/
+private lemma colFilter_zSupport_card_even
+    (zf : RotatedSurface.ZFaceIdx L) (x : Fin L) :
+    (((Finset.univ : Finset (Fin L)).filter
+        (fun y : Fin L => (x, y) ∈ RotatedSurface.zSupport zf)).card : ZMod 2) = 0 := by
+  classical
+  apply card_empty_or_pair_zmod2_zero'
+  cases zf with
+  | interior zc =>
+    by_cases hxMatch : x.val = zc.val.1.val ∨ x.val = zc.val.1.val + 1
+    · right
+      refine ⟨RotatedSurface.cornerLo zc.val.2, RotatedSurface.cornerHi zc.val.2, ?_, ?_⟩
+      · intro h; have := congrArg Fin.val h
+        simp [RotatedSurface.cornerLo, RotatedSurface.cornerHi] at this
+      · ext y
+        rw [Finset.mem_filter, Finset.mem_insert, Finset.mem_singleton]
+        rw [RotatedSurface.mem_zSupport_interior_iff]
+        simp only [Finset.mem_univ, true_and]
+        constructor
+        · rintro ⟨_, hy⟩
+          rcases hy with h | h
+          · left; exact Fin.ext h
+          · right; exact Fin.ext h
+        · rintro (rfl | rfl)
+          · refine ⟨hxMatch, Or.inl ?_⟩
+            simp [RotatedSurface.cornerLo]
+          · refine ⟨hxMatch, Or.inr ?_⟩
+            simp [RotatedSurface.cornerHi]
+    · left
+      push Not at hxMatch
+      rw [Finset.filter_eq_empty_iff]
+      intro y _
+      rw [RotatedSurface.mem_zSupport_interior_iff]
+      rintro ⟨hx, _⟩
+      rcases hx with h | h
+      · exact hxMatch.1 h
+      · exact hxMatch.2 h
+  | leftBdy k =>
+    by_cases hx : x.val = 0
+    · right
+      have h2k1 : 2 * k.val + 1 < L := by
+        have := k.isLt; have h3 : 3 ≤ L := Fact.out; omega
+      have h2k2 : 2 * k.val + 2 < L := by
+        have := k.isLt; have h3 : 3 ≤ L := Fact.out; omega
+      refine ⟨⟨2 * k.val + 1, h2k1⟩, ⟨2 * k.val + 2, h2k2⟩, ?_, ?_⟩
+      · intro h; have := congrArg Fin.val h
+        simp at this
+      · ext y
+        rw [Finset.mem_filter, Finset.mem_insert, Finset.mem_singleton]
+        rw [RotatedSurface.mem_zSupport_leftBdy_iff]
+        simp only [Finset.mem_univ, true_and]
+        constructor
+        · rintro ⟨_, hy⟩
+          rcases hy with h | h
+          · left; exact Fin.ext h
+          · right; exact Fin.ext h
+        · rintro (rfl | rfl)
+          · exact ⟨hx, Or.inl rfl⟩
+          · exact ⟨hx, Or.inr rfl⟩
+    · left
+      rw [Finset.filter_eq_empty_iff]
+      intro y _
+      rw [RotatedSurface.mem_zSupport_leftBdy_iff]
+      rintro ⟨hxz, _⟩
+      exact hx hxz
+  | rightBdy k =>
+    by_cases hx : x.val = L - 1
+    · right
+      have h2k : 2 * k.val < L := by
+        have := k.isLt; have h3 : 3 ≤ L := Fact.out; omega
+      have h2k1 : 2 * k.val + 1 < L := by
+        have := k.isLt; have h3 : 3 ≤ L := Fact.out; omega
+      refine ⟨⟨2 * k.val, h2k⟩, ⟨2 * k.val + 1, h2k1⟩, ?_, ?_⟩
+      · intro h; have := congrArg Fin.val h
+        simp at this
+      · ext y
+        rw [Finset.mem_filter, Finset.mem_insert, Finset.mem_singleton]
+        rw [RotatedSurface.mem_zSupport_rightBdy_iff]
+        simp only [Finset.mem_univ, true_and]
+        constructor
+        · rintro ⟨_, hy⟩
+          rcases hy with h | h
+          · left; exact Fin.ext h
+          · right; exact Fin.ext h
+        · rintro (rfl | rfl)
+          · exact ⟨hx, Or.inl rfl⟩
+          · exact ⟨hx, Or.inr rfl⟩
+    · left
+      rw [Finset.filter_eq_empty_iff]
+      intro y _
+      rw [RotatedSurface.mem_zSupport_rightBdy_iff]
+      rintro ⟨hxL, _⟩
+      exact hx hxL
+
+omit [Fact (Odd L)] in
+/-- `colParity (rscZCutMap (Pi.single zf 1)) x = 0`. -/
+private lemma colParity_zCutMap_single (zf : RotatedSurface.ZFaceIdx L) (x : Fin L) :
+    colParity L (RotatedSurface.rscZCutMap L (Pi.single zf 1)) x = 0 := by
+  classical
+  unfold colParity
+  -- (rscZCutMap (Pi.single zf 1)) v = 1[v ∈ zSupport zf]
+  rw [show (fun y : Fin L => RotatedSurface.rscZCutMap L (Pi.single zf 1) (x, y)) =
+      (fun y : Fin L => if (x, y) ∈ RotatedSurface.zSupport zf then (1 : ZMod 2) else 0) by
+    funext y
+    rw [RotatedSurface.rscZCutMap_apply]
+    rw [Finset.sum_eq_single zf]
+    · rw [show (Pi.single zf 1 : RotatedSurface.ZFaceIdx L → ZMod 2) zf = 1 from
+        Pi.single_eq_same _ _]
+      ring
+    · intro zf' _ hne
+      have h0 : (Pi.single zf 1 : RotatedSurface.ZFaceIdx L → ZMod 2) zf' = 0 := by
+        rw [Pi.single_apply, if_neg hne]
+      rw [h0]; ring
+    · intro hcontra; exact absurd (Finset.mem_univ zf) hcontra]
+  rw [Finset.sum_boole]
+  exact colFilter_zSupport_card_even L zf x
+
+omit [Fact (Odd L)] in
+/-- `colParity (rscZCutMap s) x = 0` for every Z-face chain `s`. -/
+theorem colParity_rscZCutMap
+    (s : RotatedSurface.ZFaceIdx L → ZMod 2) (x : Fin L) :
+    colParity L (RotatedSurface.rscZCutMap L s) x = 0 := by
+  classical
+  have hs : s = ∑ zf : RotatedSurface.ZFaceIdx L, s zf • (Pi.single zf (1 : ZMod 2)) := by
+    funext zf
+    simp [Finset.sum_apply, Pi.single_apply]
+  conv_lhs => rw [hs]
+  rw [map_sum]
+  unfold colParity
+  rw [show (fun y : Fin L =>
+      (∑ zf : RotatedSurface.ZFaceIdx L,
+        RotatedSurface.rscZCutMap L (s zf • Pi.single zf 1)) (x, y)) =
+      (fun y : Fin L =>
+        ∑ zf : RotatedSurface.ZFaceIdx L,
+          RotatedSurface.rscZCutMap L (s zf • Pi.single zf 1) (x, y)) by
+    funext y; rw [Finset.sum_apply]]
+  rw [Finset.sum_comm]
+  apply Finset.sum_eq_zero
+  intro zf _
+  have h_smul : ∀ y : Fin L,
+      RotatedSurface.rscZCutMap L (s zf • Pi.single zf 1) (x, y) =
+        s zf * RotatedSurface.rscZCutMap L (Pi.single zf 1) (x, y) := fun y => by
+    rw [LinearMap.map_smul]
+    simp [Pi.smul_apply, smul_eq_mul]
+  rw [Finset.sum_congr rfl (fun y _ => h_smul y)]
+  rw [← Finset.mul_sum]
+  rw [show ∑ y : Fin L, RotatedSurface.rscZCutMap L (Pi.single zf 1) (x, y) =
+      colParity L (RotatedSurface.rscZCutMap L (Pi.single zf 1)) x from rfl]
+  rw [colParity_zCutMap_single]
+  ring
+
+omit [Fact (Odd L)] in
+/-- `colParity` vanishes on the dual-boundaries submodule (range of `rscZCutMap`). -/
+theorem colParity_eq_zero_of_mem_dualBoundaries
+    {c : RotatedSurface.VtxIdx L → ZMod 2}
+    (hc : c ∈ LinearMap.range (RotatedSurface.rscZCutMap L)) (x : Fin L) :
+    colParity L c x = 0 := by
+  rcases hc with ⟨s, rfl⟩
+  exact colParity_rscZCutMap L s x
+
+
+end RotatedSurfaceCodeN
+end StabilizerGroup
+end Quantum

--- a/QEC/Stabilizer/Codes/RotatedSurfaceCodeNStabilizerCode.lean
+++ b/QEC/Stabilizer/Codes/RotatedSurfaceCodeNStabilizerCode.lean
@@ -1,0 +1,1099 @@
+import QEC.Stabilizer.Codes.RotatedSurfaceCodeN
+import QEC.Stabilizer.Core.StabilizerCode
+import QEC.Stabilizer.Core.LogicalOperators
+import QEC.Stabilizer.BinarySymplectic.IndependentEquiv
+import QEC.Stabilizer.BinarySymplectic.CheckMatrix
+import QEC.Stabilizer.Lattice.RotatedSurfaceH1Dimension
+
+/-!
+# Rotated surface code as `StabilizerCode (L*L, 1)`
+
+Upgrades the lattice-side stabilizer family from
+[RotatedSurfaceCodeN.lean](RotatedSurfaceCodeN.lean) to a full
+`StabilizerCode (numQubits L) 1`, encoding 1 logical qubit.
+
+## Strategy
+
+* **Symplectic linear independence.**  The generator list has block
+  structure: a Z-block (rows = `vertexStabOf zf`, Z-half =
+  `1[v ∈ zSupport zf]`, X-half = `0`) followed by an X-block
+  (rows = `faceStabOf xf`, X-half = `1[v ∈ xSupport xf]`, Z-half = `0`).
+  LI of the full row family reduces to LI of each block, which follows
+  immediately from `rscBoundary2_injective` and `rscZCutMap_injective`
+  (proven in Stage 3): no trimming is needed because the rotated surface
+  code has *no* redundant generators.
+
+* **Logical operators.**  With Z-rough left/right boundaries and X-rough
+  top/bottom boundaries, the logical X is a vertical X-string at the
+  middle column `x = (L−1)/2`, and the logical Z is a horizontal Z-string
+  at the middle row `y = (L−1)/2`.  They intersect at the centre qubit
+  `(mid, mid)` exactly once, so they anticommute.
+-/
+
+namespace Quantum
+namespace StabilizerGroup
+namespace RotatedSurfaceCodeN
+
+open scoped BigOperators
+open NQubitPauliGroupElement
+open Stabilizer.Lattice
+-- Open `Lattice` to access `RotatedSurface.*` with one less prefix.
+-- We do NOT open `RotatedSurface` directly to avoid the
+-- `xSupport`/`zSupport` clash with the `NQubitPauliOperator` names.
+
+variable (L : ℕ) [Fact (Odd L)] [Fact (3 ≤ L)]
+
+/-! ## §A — `cutMap (singleVtx _)` and `boundary2 (singleFace _)` indicators
+
+The generic `cutMap`/`boundary2`, applied to the canonical single-cell
+indicators, reduce to `ZMod 2`-valued membership indicators on the
+corresponding `zSupport`/`xSupport` finsets.  We use these as the bridges
+between the abstract symplectic check matrix and the lattice combinatorics.
+-/
+
+omit [Fact (Odd L)] [Fact (3 ≤ L)] in
+/-- `rscBoundary1 (Pi.single v 1) zf = 1[v ∈ zSupport zf]`. -/
+private lemma boundary1_pi_single (v : RotatedSurface.VtxIdx L)
+    (zf : RotatedSurface.ZFaceIdx L) :
+    RotatedSurface.rscBoundary1 L (Pi.single v 1) zf =
+      (if v ∈ RotatedSurface.zSupport zf then (1 : ZMod 2) else 0) := by
+  classical
+  rw [RotatedSurface.rscBoundary1_apply]
+  by_cases hv : v ∈ RotatedSurface.zSupport zf
+  · rw [if_pos hv, Finset.sum_eq_single_of_mem v hv]
+    · simp
+    · intro u _ hne
+      simp [hne]
+  · rw [if_neg hv]
+    apply Finset.sum_eq_zero
+    intro u hu
+    have hne : u ≠ v := fun heq => hv (heq ▸ hu)
+    simp [hne]
+
+/-- The cut-map of `singleVtx zf` reads off the indicator of `zSupport zf`. -/
+lemma cutMap_singleVtx_apply (zf : RotatedSurface.ZFaceIdx L)
+    (v : RotatedSurface.VtxIdx L) :
+    (RotatedSurface.rotatedSurfaceHomologicalCode L).cutMap
+        ((RotatedSurface.rotatedSurfaceHomologicalCode L).singleVtx zf) v =
+      (if v ∈ RotatedSurface.zSupport zf then (1 : ZMod 2) else 0) := by
+  classical
+  rw [show (RotatedSurface.rotatedSurfaceHomologicalCode L).cutMap
+        ((RotatedSurface.rotatedSurfaceHomologicalCode L).singleVtx zf) v =
+      ∑ zf' : RotatedSurface.ZFaceIdx L,
+        (RotatedSurface.rotatedSurfaceHomologicalCode L).singleVtx zf zf' *
+          RotatedSurface.rscBoundary1 L (Pi.single v 1) zf' from rfl]
+  rw [Finset.sum_eq_single zf]
+  · -- (singleVtx zf zf) * (boundary1 (δ_v) zf) = (1 : ZMod 2) * _ = boundary1 (δ_v) zf
+    have hone : (RotatedSurface.rotatedSurfaceHomologicalCode L).singleVtx zf zf =
+        (1 : ZMod 2) := Pi.single_eq_same _ _
+    rw [hone, _root_.one_mul]
+    exact boundary1_pi_single L v zf
+  · intro zf' _ hne
+    have h0 : (RotatedSurface.rotatedSurfaceHomologicalCode L).singleVtx zf zf' =
+        (0 : ZMod 2) := by
+      simp only [Quantum.Stabilizer.Homological.HomologicalCode.singleVtx,
+        Pi.single_apply]
+      exact if_neg hne
+    rw [h0]; ring
+  · intro hcontra; exact absurd (Finset.mem_univ zf) hcontra
+
+/-- `boundary2 (singleFace xf) v = 1[v ∈ xSupport xf]`. -/
+lemma boundary2_singleFace_apply (xf : RotatedSurface.XFaceIdx L)
+    (v : RotatedSurface.VtxIdx L) :
+    (RotatedSurface.rotatedSurfaceHomologicalCode L).boundary2
+        ((RotatedSurface.rotatedSurfaceHomologicalCode L).singleFace xf) v =
+      (if v ∈ RotatedSurface.xSupport xf then (1 : ZMod 2) else 0) := by
+  classical
+  change RotatedSurface.rscBoundary2 L (Pi.single xf 1) v = _
+  rw [RotatedSurface.rscBoundary2_apply]
+  by_cases hv : v ∈ RotatedSurface.xSupport xf
+  · rw [if_pos hv, Finset.sum_eq_single xf]
+    · simp [hv]
+    · intro xf' _ hne
+      simp [hne]
+    · intro hcontra; exact absurd (Finset.mem_univ xf) hcontra
+  · rw [if_neg hv]
+    apply Finset.sum_eq_zero
+    intro xf' _
+    by_cases hxf : xf' = xf
+    · subst hxf
+      simp [hv]
+    · simp [hxf]
+
+/-! ## §B — Symplectic check-matrix entries
+
+Each generator row of the check matrix has a clean closed form:
+`zStab zf` is Z-type, so its X-half is uniformly zero; its Z-half at qubit
+`rscQubitEquiv L v` is `1[v ∈ zSupport zf]`.  Symmetrically for `xStab xf`.
+-/
+
+/-- The inverse of `rscQubitEquiv`, mapping a qubit index back to its data-qubit. -/
+noncomputable def vtxOfQubit (q : Fin (numQubits L)) : RotatedSurface.VtxIdx L :=
+  (RotatedSurface.rscQubitEquiv L).symm q
+
+omit [Fact (Odd L)] in
+@[simp] lemma rscQubitEquiv_vtxOfQubit (q : Fin (numQubits L)) :
+    RotatedSurface.rscQubitEquiv L (vtxOfQubit L q) = q :=
+  (RotatedSurface.rscQubitEquiv L).apply_symm_apply q
+
+omit [Fact (Odd L)] in
+@[simp] lemma vtxOfQubit_rscQubitEquiv (v : RotatedSurface.VtxIdx L) :
+    vtxOfQubit L (RotatedSurface.rscQubitEquiv L v) = v :=
+  (RotatedSurface.rscQubitEquiv L).symm_apply_apply v
+
+/-- X-half symplectic value of a Z-type generator is always zero. -/
+private lemma toSymplectic_zStab_X (zf : RotatedSurface.ZFaceIdx L)
+    (q : Fin (numQubits L)) :
+    NQubitPauliOperator.toSymplectic (zStab L zf).operators
+        (Fin.castAdd (numQubits L) q) = 0 := by
+  rcases (zStab_is_ZType L zf).2 q with hI | hZ
+  · rw [NQubitPauliOperator.toSymplectic_X_part, hI]
+    rfl
+  · rw [NQubitPauliOperator.toSymplectic_X_part, hZ]
+    rfl
+
+/-- Z-half symplectic value of an X-type generator is always zero. -/
+private lemma toSymplectic_xStab_Z (xf : RotatedSurface.XFaceIdx L)
+    (q : Fin (numQubits L)) :
+    NQubitPauliOperator.toSymplectic (xStab L xf).operators
+        (Fin.natAdd (numQubits L) q) = 0 := by
+  rcases (xStab_is_XType L xf).2 q with hI | hX
+  · rw [NQubitPauliOperator.toSymplectic_Z_part, hI]
+    rfl
+  · rw [NQubitPauliOperator.toSymplectic_Z_part, hX]
+    rfl
+
+/-- Z-half symplectic value of `zStab zf` at qubit `q` is the indicator
+`1[vtxOfQubit q ∈ zSupport zf]`. -/
+private lemma toSymplectic_zStab_Z (zf : RotatedSurface.ZFaceIdx L)
+    (q : Fin (numQubits L)) :
+    NQubitPauliOperator.toSymplectic (zStab L zf).operators
+        (Fin.natAdd (numQubits L) q) =
+      (if vtxOfQubit L q ∈ RotatedSurface.zSupport zf then (1 : ZMod 2) else 0) := by
+  classical
+  -- zStab zf = chainZOperator (cutMap (singleVtx zf)), and at qubit q the operator is
+  -- Z iff cutMap (singleVtx zf) at `(edgeEquiv).symm q = vtxOfQubit q` is 1.
+  rw [NQubitPauliOperator.toSymplectic_Z_part]
+  set c : RotatedSurface.VtxIdx L → ZMod 2 :=
+    (RotatedSurface.rotatedSurfaceHomologicalCode L).cutMap
+      ((RotatedSurface.rotatedSurfaceHomologicalCode L).singleVtx zf) with hc
+  have hc_val : c (vtxOfQubit L q) =
+      (if vtxOfQubit L q ∈ RotatedSurface.zSupport zf then (1 : ZMod 2) else 0) := by
+    rw [hc]; exact cutMap_singleVtx_apply L zf (vtxOfQubit L q)
+  -- (zStab L zf).operators q is Z if c (vtxOfQubit q) = 1, else I.
+  change ((zStab L zf).operators q).toSymplecticSingle.2 = _
+  rw [show (zStab L zf).operators q =
+      if ∃ v : RotatedSurface.VtxIdx L,
+        RotatedSurface.rscQubitEquiv L v = q ∧ c v = 1
+      then PauliOperator.Z else PauliOperator.I from rfl]
+  by_cases h1 : c (vtxOfQubit L q) = 1
+  · -- The witness is vtxOfQubit q.
+    have hex : ∃ v : RotatedSurface.VtxIdx L,
+        RotatedSurface.rscQubitEquiv L v = q ∧ c v = 1 :=
+      ⟨vtxOfQubit L q, rscQubitEquiv_vtxOfQubit L q, h1⟩
+    rw [if_pos hex]
+    -- RHS: 1[v ∈ zSupport zf] = 1 since hc_val gives c = 1 here.
+    have : (if vtxOfQubit L q ∈ RotatedSurface.zSupport zf then (1 : ZMod 2) else 0) = 1 := by
+      rw [hc_val] at h1; exact h1
+    rw [this]; rfl
+  · -- c = 0 here, so no witness exists (any witness would have v = vtxOfQubit q by injectivity).
+    have hnotex : ¬ ∃ v : RotatedSurface.VtxIdx L,
+        RotatedSurface.rscQubitEquiv L v = q ∧ c v = 1 := by
+      rintro ⟨v, hv, hcv⟩
+      have hveq : v = vtxOfQubit L q := by
+        apply (RotatedSurface.rscQubitEquiv L).injective
+        rw [rscQubitEquiv_vtxOfQubit, hv]
+      rw [hveq] at hcv
+      exact h1 hcv
+    rw [if_neg hnotex]
+    -- c (vtxOfQubit q) ≠ 1 means c = 0 (ZMod 2 dichotomy), so RHS = 0.
+    have h0 : c (vtxOfQubit L q) = 0 := by
+      rw [hc_val] at h1 ⊢
+      by_cases h : vtxOfQubit L q ∈ RotatedSurface.zSupport zf
+      · rw [if_pos h] at h1; exact absurd rfl h1
+      · rw [if_neg h]
+    have : (if vtxOfQubit L q ∈ RotatedSurface.zSupport zf then (1 : ZMod 2) else 0) = 0 := by
+      rw [hc_val] at h0; exact h0
+    rw [this]; rfl
+
+/-! ### Indexing into the generator list -/
+
+/-- The Z-stab list, sourced from `Finset.univ.toList`. -/
+private noncomputable def zList : List (RotatedSurface.ZFaceIdx L) :=
+  (Finset.univ : Finset (RotatedSurface.ZFaceIdx L)).toList
+
+/-- The X-stab list, sourced from `Finset.univ.toList`. -/
+private noncomputable def xList : List (RotatedSurface.XFaceIdx L) :=
+  (Finset.univ : Finset (RotatedSurface.XFaceIdx L)).toList
+
+omit [Fact (Odd L)] [Fact (3 ≤ L)] in
+private lemma zList_length :
+    (zList L).length = Fintype.card (RotatedSurface.ZFaceIdx L) := by
+  unfold zList
+  rw [Finset.length_toList, Finset.card_univ]
+
+omit [Fact (Odd L)] [Fact (3 ≤ L)] in
+private lemma xList_length :
+    (xList L).length = Fintype.card (RotatedSurface.XFaceIdx L) := by
+  unfold xList
+  rw [Finset.length_toList, Finset.card_univ]
+
+omit [Fact (Odd L)] [Fact (3 ≤ L)] in
+private lemma zList_nodup : (zList L).Nodup := by
+  unfold zList; exact Finset.nodup_toList _
+
+omit [Fact (Odd L)] [Fact (3 ≤ L)] in
+private lemma xList_nodup : (xList L).Nodup := by
+  unfold xList; exact Finset.nodup_toList _
+
+omit [Fact (Odd L)] [Fact (3 ≤ L)] in
+private lemma zList_mem (zf : RotatedSurface.ZFaceIdx L) : zf ∈ zList L := by
+  unfold zList; rw [Finset.mem_toList]; exact Finset.mem_univ _
+
+omit [Fact (Odd L)] [Fact (3 ≤ L)] in
+private lemma xList_mem (xf : RotatedSurface.XFaceIdx L) : xf ∈ xList L := by
+  unfold xList; rw [Finset.mem_toList]; exact Finset.mem_univ _
+
+private lemma generatorsListZ_eq_map :
+    generatorsListZ L = (zList L).map (zStab L) := rfl
+
+private lemma generatorsListX_eq_map :
+    generatorsListX L = (xList L).map (xStab L) := rfl
+
+private lemma generatorsList_length_split :
+    (generatorsList L).length = (zList L).length + (xList L).length := by
+  unfold generatorsList
+  rw [List.length_append, generatorsListZ_eq_map, generatorsListX_eq_map,
+    List.length_map, List.length_map]
+
+/-- The generator at index `k` with `k < (zList L).length` is the Z-stab at
+the `k`-th element of `zList L`. -/
+private lemma get_generatorsList_Z (k : ℕ) (hk : k < (generatorsList L).length)
+    (hkZ : k < (zList L).length) :
+    (generatorsList L).get ⟨k, hk⟩ = zStab L ((zList L).get ⟨k, hkZ⟩) := by
+  change (generatorsListZ L ++ generatorsListX L).get ⟨k, hk⟩ = _
+  rw [List.get_eq_getElem]
+  have hkZ' : k < (generatorsListZ L).length := by
+    change k < ((zList L).map (zStab L)).length
+    rw [List.length_map]; exact hkZ
+  rw [List.getElem_append_left hkZ']
+  -- Goal: (generatorsListZ L)[k] = zStab L (zList L).get ⟨k, hkZ⟩
+  change ((zList L).map (zStab L))[k]'hkZ' = _
+  rw [List.getElem_map]
+  rfl
+
+/-- The generator at index `k` with `k ≥ (zList L).length` is the X-stab at
+position `k - (zList L).length` in `xList L`. -/
+private lemma get_generatorsList_X (k : ℕ) (hk : k < (generatorsList L).length)
+    (hkZge : (zList L).length ≤ k)
+    (hkXsub : k - (zList L).length < (xList L).length) :
+    (generatorsList L).get ⟨k, hk⟩ =
+      xStab L ((xList L).get ⟨k - (zList L).length, hkXsub⟩) := by
+  change (generatorsListZ L ++ generatorsListX L).get ⟨k, hk⟩ = _
+  rw [List.get_eq_getElem]
+  have h_lenZ : (generatorsListZ L).length = (zList L).length := by
+    change ((zList L).map (zStab L)).length = _; rw [List.length_map]
+  have hkZge' : (generatorsListZ L).length ≤ k := h_lenZ.symm ▸ hkZge
+  rw [List.getElem_append_right hkZge']
+  -- Now goal involves `(generatorsListX L)[k - (generatorsListZ L).length]`.
+  -- We need the index expression to match `k - (zList L).length` for List.getElem_map.
+  have hsub_eq : k - (generatorsListZ L).length = k - (zList L).length := by
+    rw [h_lenZ]
+  -- Use the helper rewriting form.
+  have hkXsub' : k - (generatorsListZ L).length < (generatorsListX L).length := by
+    change _ < ((xList L).map (xStab L)).length
+    rw [List.length_map, hsub_eq]; exact hkXsub
+  change ((xList L).map (xStab L))[k - (generatorsListZ L).length]'hkXsub' = _
+  rw [List.getElem_map]
+  -- Now: xStab L ((xList L)[k - (generatorsListZ L).length]) =
+  --      xStab L ((xList L).get ⟨k - (zList L).length, hkXsub⟩)
+  rw [List.get_eq_getElem]
+  congr 2
+
+/-- X-half symplectic value of `xStab xf` at qubit `q` is the indicator
+`1[vtxOfQubit q ∈ xSupport xf]`. -/
+private lemma toSymplectic_xStab_X (xf : RotatedSurface.XFaceIdx L)
+    (q : Fin (numQubits L)) :
+    NQubitPauliOperator.toSymplectic (xStab L xf).operators
+        (Fin.castAdd (numQubits L) q) =
+      (if vtxOfQubit L q ∈ RotatedSurface.xSupport xf then (1 : ZMod 2) else 0) := by
+  classical
+  rw [NQubitPauliOperator.toSymplectic_X_part]
+  set c : RotatedSurface.VtxIdx L → ZMod 2 :=
+    (RotatedSurface.rotatedSurfaceHomologicalCode L).boundary2
+      ((RotatedSurface.rotatedSurfaceHomologicalCode L).singleFace xf) with hc
+  have hc_val : c (vtxOfQubit L q) =
+      (if vtxOfQubit L q ∈ RotatedSurface.xSupport xf then (1 : ZMod 2) else 0) := by
+    rw [hc]; exact boundary2_singleFace_apply L xf (vtxOfQubit L q)
+  change ((xStab L xf).operators q).toSymplecticSingle.1 = _
+  rw [show (xStab L xf).operators q =
+      if ∃ v : RotatedSurface.VtxIdx L,
+        RotatedSurface.rscQubitEquiv L v = q ∧ c v = 1
+      then PauliOperator.X else PauliOperator.I from rfl]
+  by_cases h1 : c (vtxOfQubit L q) = 1
+  · have hex : ∃ v : RotatedSurface.VtxIdx L,
+        RotatedSurface.rscQubitEquiv L v = q ∧ c v = 1 :=
+      ⟨vtxOfQubit L q, rscQubitEquiv_vtxOfQubit L q, h1⟩
+    rw [if_pos hex]
+    have : (if vtxOfQubit L q ∈ RotatedSurface.xSupport xf then (1 : ZMod 2) else 0) = 1 := by
+      rw [hc_val] at h1; exact h1
+    rw [this]; rfl
+  · have hnotex : ¬ ∃ v : RotatedSurface.VtxIdx L,
+        RotatedSurface.rscQubitEquiv L v = q ∧ c v = 1 := by
+      rintro ⟨v, hv, hcv⟩
+      have hveq : v = vtxOfQubit L q := by
+        apply (RotatedSurface.rscQubitEquiv L).injective
+        rw [rscQubitEquiv_vtxOfQubit, hv]
+      rw [hveq] at hcv
+      exact h1 hcv
+    rw [if_neg hnotex]
+    have h0 : c (vtxOfQubit L q) = 0 := by
+      rw [hc_val] at h1 ⊢
+      by_cases h : vtxOfQubit L q ∈ RotatedSurface.xSupport xf
+      · rw [if_pos h] at h1; exact absurd rfl h1
+      · rw [if_neg h]
+    have : (if vtxOfQubit L q ∈ RotatedSurface.xSupport xf then (1 : ZMod 2) else 0) = 0 := by
+      rw [hc_val] at h0; exact h0
+    rw [this]; rfl
+
+/-! ## §C — Symplectic linear independence of the generator list
+
+The argument decomposes the sum at column `natAdd numQubits q` (the Z-half)
+versus `castAdd numQubits q` (the X-half).  At the Z-half, X-block rows
+contribute zero by `toSymplectic_xStab_Z`, leaving only the Z-block sum.
+Reindexing this sum across vertices via `vtxOfQubit` recovers
+`rscZCutMap` applied to the Z-block coefficient function, which is zero
+by hypothesis.  Injectivity of `rscZCutMap` (Stage 3) finishes the Z-side.
+The X-side is the mirror image.
+-/
+
+/-- Z-block index → `ZFaceIdx` via `zList`. -/
+private noncomputable def zfAt (k : ℕ) (hk : k < (zList L).length) :
+    RotatedSurface.ZFaceIdx L :=
+  (zList L).get ⟨k, hk⟩
+
+/-- X-block index → `XFaceIdx` via `xList`. -/
+private noncomputable def xfAt (k : ℕ) (hk : k < (xList L).length) :
+    RotatedSurface.XFaceIdx L :=
+  (xList L).get ⟨k, hk⟩
+
+omit [Fact (Odd L)] [Fact (3 ≤ L)] in
+private lemma zList_get_injective :
+    Function.Injective (fun i : Fin (zList L).length => (zList L).get i) :=
+  List.nodup_iff_injective_get.mp (zList_nodup L)
+
+omit [Fact (Odd L)] [Fact (3 ≤ L)] in
+private lemma xList_get_injective :
+    Function.Injective (fun i : Fin (xList L).length => (xList L).get i) :=
+  List.nodup_iff_injective_get.mp (xList_nodup L)
+
+omit [Fact (Odd L)] [Fact (3 ≤ L)] in
+/-- Bijection `Fin (zList L).length ≃ ZFaceIdx L` from the Nodup list. -/
+private noncomputable def zEquiv :
+    Fin (zList L).length ≃ RotatedSurface.ZFaceIdx L := by
+  refine Equiv.ofBijective (fun i => (zList L).get i) ?_
+  rw [Fintype.bijective_iff_injective_and_card]
+  refine ⟨zList_get_injective L, ?_⟩
+  rw [Fintype.card_fin, zList_length]
+
+omit [Fact (Odd L)] [Fact (3 ≤ L)] in
+/-- Bijection `Fin (xList L).length ≃ XFaceIdx L` from the Nodup list. -/
+private noncomputable def xEquiv :
+    Fin (xList L).length ≃ RotatedSurface.XFaceIdx L := by
+  refine Equiv.ofBijective (fun i => (xList L).get i) ?_
+  rw [Fintype.bijective_iff_injective_and_card]
+  refine ⟨xList_get_injective L, ?_⟩
+  rw [Fintype.card_fin, xList_length]
+
+omit [Fact (Odd L)] [Fact (3 ≤ L)] in
+@[simp] private lemma zEquiv_apply (i : Fin (zList L).length) :
+    zEquiv L i = (zList L).get i := rfl
+
+omit [Fact (Odd L)] [Fact (3 ≤ L)] in
+@[simp] private lemma xEquiv_apply (i : Fin (xList L).length) :
+    xEquiv L i = (xList L).get i := rfl
+
+omit [Fact (Odd L)] [Fact (3 ≤ L)] in
+@[simp] private lemma zEquiv_symm_zfAt (k : ℕ) (hk : k < (zList L).length) :
+    (zEquiv L).symm (zfAt L k hk) = ⟨k, hk⟩ := by
+  apply (zEquiv L).injective
+  rw [Equiv.apply_symm_apply, zEquiv_apply]
+  rfl
+
+omit [Fact (Odd L)] [Fact (3 ≤ L)] in
+@[simp] private lemma xEquiv_symm_xfAt (k : ℕ) (hk : k < (xList L).length) :
+    (xEquiv L).symm (xfAt L k hk) = ⟨k, hk⟩ := by
+  apply (xEquiv L).injective
+  rw [Equiv.apply_symm_apply, xEquiv_apply]
+  rfl
+
+/-- The Z-block coefficient function for a row-coefficient `f`,
+indexed by `ZFaceIdx`. -/
+private noncomputable def coeffsZ
+    (f : Fin (generatorsList L).length → ZMod 2) :
+    RotatedSurface.ZFaceIdx L → ZMod 2 := fun zf =>
+  let i := (zEquiv L).symm zf
+  f ⟨i.val, by
+    have := i.isLt
+    have hsplit := generatorsList_length_split L
+    omega⟩
+
+/-- The X-block coefficient function for a row-coefficient `f`,
+indexed by `XFaceIdx`. -/
+private noncomputable def coeffsX
+    (f : Fin (generatorsList L).length → ZMod 2) :
+    RotatedSurface.XFaceIdx L → ZMod 2 := fun xf =>
+  let i := (xEquiv L).symm xf
+  f ⟨(zList L).length + i.val, by
+    have := i.isLt
+    have hsplit := generatorsList_length_split L
+    omega⟩
+
+private lemma coeffsZ_zfAt (f : Fin (generatorsList L).length → ZMod 2)
+    (k : ℕ) (hkZ : k < (zList L).length)
+    (hkfull : k < (generatorsList L).length) :
+    coeffsZ L f (zfAt L k hkZ) = f ⟨k, hkfull⟩ := by
+  unfold coeffsZ
+  simp [zEquiv_symm_zfAt]
+
+private lemma coeffsX_xfAt (f : Fin (generatorsList L).length → ZMod 2)
+    (k : ℕ) (hkX : k < (xList L).length)
+    (hkfull : (zList L).length + k < (generatorsList L).length) :
+    coeffsX L f (xfAt L k hkX) = f ⟨(zList L).length + k, hkfull⟩ := by
+  unfold coeffsX
+  simp [xEquiv_symm_xfAt]
+
+/-! ### Symplectic linear independence — main theorem -/
+
+set_option maxHeartbeats 800000 in
+-- Bumped: the proof unfolds finRange-sum reindexings, the Z/X block split,
+-- and the rscZCutMap / rscBoundary2 injectivity arguments.
+/-- The rotated-surface code generator list has linearly independent
+check-matrix rows. -/
+theorem rowsLinearIndependent_generatorsList :
+    NQubitPauliGroupElement.rowsLinearIndependent (generatorsList L) := by
+  classical
+  unfold NQubitPauliGroupElement.rowsLinearIndependent
+  rw [Fintype.linearIndependent_iff]
+  intro f hsum
+  -- Stage 1: Reduce hsum at column `natAdd q` to a Z-half equation.
+  have hlen := generatorsList_length_split L
+  -- Define the convenient embedding into Fin (genList).length.
+  set nZ := (zList L).length with hnZ_def
+  set nX := (xList L).length with hnX_def
+  -- The Z-block split: f over Fin (nZ + nX) restricted to indices < nZ vs ≥ nZ.
+  -- (We work directly with index splits instead of introducing custom Embeddings.)
+  --
+  -- Z-half kernel: rscZCutMap (coeffsZ f) = 0.
+  have h_cz_ker : RotatedSurface.rscZCutMap L (coeffsZ L f) = 0 := by
+    funext v
+    rw [Pi.zero_apply]
+    -- Get the column equation at natAdd (rscQubitEquiv v).
+    set q := RotatedSurface.rscQubitEquiv L v with hq_def
+    have h_col := congr_fun hsum (Fin.natAdd (numQubits L) q)
+    simp only [Finset.sum_apply, Pi.smul_apply, smul_eq_mul, Pi.zero_apply,
+      NQubitPauliGroupElement.checkMatrix] at h_col
+    -- h_col : ∑ k, f k * toSymplectic ((genList).get k).operators (natAdd numQubits q) = 0
+    -- Split into Z-block (k.val < nZ) and X-block (k.val ≥ nZ).
+    have h_partition :
+        (Finset.univ : Finset (Fin (generatorsList L).length)) =
+          Finset.univ.filter (fun k => k.val < nZ) ∪
+          Finset.univ.filter (fun k => ¬ k.val < nZ) := by
+      rw [Finset.filter_union_filter_not_eq]
+    have h_disj : Disjoint
+        ((Finset.univ : Finset (Fin (generatorsList L).length)).filter (fun k => k.val < nZ))
+        (Finset.univ.filter (fun k => ¬ k.val < nZ)) :=
+      Finset.disjoint_filter_filter_not _ _ _
+    rw [h_partition, Finset.sum_union h_disj] at h_col
+    -- The X-block sum (k.val ≥ nZ) is 0 because the X-stabs have 0 Z-half.
+    have h_x_zero : ∑ k ∈ (Finset.univ.filter
+        (fun k : Fin (generatorsList L).length => ¬ k.val < nZ)),
+        f k * NQubitPauliOperator.toSymplectic
+          ((generatorsList L).get k).operators (Fin.natAdd (numQubits L) q) = 0 := by
+      apply Finset.sum_eq_zero
+      intro k hk
+      rw [Finset.mem_filter] at hk
+      have hkge : nZ ≤ k.val := Nat.le_of_not_lt hk.2
+      have hksub : k.val - nZ < nX := by
+        have := k.isLt
+        omega
+      have hgetX := get_generatorsList_X L k.val k.isLt hkge hksub
+      rw [hgetX]
+      rw [toSymplectic_xStab_Z]
+      ring
+    rw [h_x_zero, add_zero] at h_col
+    -- Now h_col : ∑ k ∈ Z-block, f k * (Z-half value) = 0
+    -- Convert each Z-block term to use 1[vtxOfQubit q ∈ zSupport(zfAt k.val)].
+    -- Goal: rscZCutMap (coeffsZ f) v = 0, i.e.,
+    --   ∑ zf, coeffsZ f zf * 1[v ∈ zSupport zf] = 0
+    rw [RotatedSurface.rscZCutMap_apply]
+    -- Reindex Z-block sum (over Fin nZ) to a sum over ZFaceIdx L via zEquiv.
+    -- Set up: bij between filter (k.val < nZ) and Fin nZ.
+    have h_bij_lhs :
+        ∑ k ∈ Finset.univ.filter (fun k : Fin (generatorsList L).length => k.val < nZ),
+          f k * NQubitPauliOperator.toSymplectic
+            ((generatorsList L).get k).operators (Fin.natAdd (numQubits L) q) =
+        ∑ i : Fin nZ, f ⟨i.val, by have := i.isLt; omega⟩ *
+            NQubitPauliOperator.toSymplectic
+              ((generatorsList L).get ⟨i.val, by have := i.isLt; omega⟩).operators
+              (Fin.natAdd (numQubits L) q) := by
+      apply Finset.sum_bij (fun (k : Fin (generatorsList L).length)
+        (hk : k ∈ Finset.univ.filter (fun k => k.val < nZ)) =>
+          (⟨k.val, (Finset.mem_filter.mp hk).2⟩ : Fin nZ))
+      · intros; exact Finset.mem_univ _
+      · intros a _ b _ hab
+        rcases a with ⟨a, ha⟩; rcases b with ⟨b, hb⟩
+        simpa using Fin.ext (Fin.mk.inj_iff.mp hab)
+      · intros b _
+        refine ⟨⟨b.val, ?_⟩, ?_, by simp⟩
+        · have := b.isLt; omega
+        · rw [Finset.mem_filter]
+          exact ⟨Finset.mem_univ _, b.isLt⟩
+      · intros; rfl
+    rw [h_bij_lhs] at h_col
+    -- Now h_col is a sum over Fin nZ. Convert toSymplectic to indicator.
+    have h_eval :
+        ∀ i : Fin nZ, f ⟨i.val, by have := i.isLt; omega⟩ *
+            NQubitPauliOperator.toSymplectic
+              ((generatorsList L).get ⟨i.val, by have := i.isLt; omega⟩).operators
+              (Fin.natAdd (numQubits L) q) =
+          f ⟨i.val, by have := i.isLt; omega⟩ *
+            (if v ∈ RotatedSurface.zSupport (zfAt L i.val i.isLt) then (1 : ZMod 2) else 0) := by
+      intro i
+      congr 1
+      have hgetZ := get_generatorsList_Z L i.val (by have := i.isLt; omega) i.isLt
+      rw [hgetZ, toSymplectic_zStab_Z, hq_def, vtxOfQubit_rscQubitEquiv]
+      rfl
+    rw [show ∑ i : Fin nZ, f ⟨i.val, by have := i.isLt; omega⟩ *
+            NQubitPauliOperator.toSymplectic
+              ((generatorsList L).get ⟨i.val, by have := i.isLt; omega⟩).operators
+              (Fin.natAdd (numQubits L) q) =
+        ∑ i : Fin nZ, f ⟨i.val, by have := i.isLt; omega⟩ *
+            (if v ∈ RotatedSurface.zSupport (zfAt L i.val i.isLt) then (1 : ZMod 2) else 0)
+      from Finset.sum_congr rfl (fun i _ => h_eval i)] at h_col
+    -- Reindex `∑ zf, _` to `∑ i, _` via `zEquiv`.
+    have h_target_eq :
+        (∑ zf : RotatedSurface.ZFaceIdx L,
+            coeffsZ L f zf *
+              (if v ∈ RotatedSurface.zSupport zf then (1 : ZMod 2) else 0)) =
+        ∑ i : Fin nZ, f ⟨i.val, by have := i.isLt; omega⟩ *
+            (if v ∈ RotatedSurface.zSupport (zfAt L i.val i.isLt) then (1 : ZMod 2) else 0) := by
+      rw [← Equiv.sum_comp (zEquiv L) _]
+      apply Finset.sum_congr rfl
+      intro i _
+      have hzfAt : zEquiv L i = zfAt L i.val i.isLt := by
+        unfold zfAt; rw [zEquiv_apply]
+      rw [hzfAt]
+      rw [coeffsZ_zfAt L f i.val i.isLt (by have := i.isLt; omega)]
+    rw [h_target_eq]
+    exact h_col
+  -- coeffsZ L f = 0 by rscZCutMap_injective.
+  have h_cz_zero : coeffsZ L f = 0 := by
+    apply RotatedSurface.rscZCutMap_injective
+    rw [h_cz_ker, LinearMap.map_zero]
+  -- For each k < nZ, f k = coeffsZ f (zfAt k) = 0.
+  -- For each k ≥ nZ, similar via X-block.
+  -- X-half kernel: rscBoundary2 (coeffsX f) = 0.
+  have h_cx_ker : RotatedSurface.rscBoundary2 L (coeffsX L f) = 0 := by
+    funext v
+    rw [Pi.zero_apply]
+    set q := RotatedSurface.rscQubitEquiv L v with hq_def
+    have h_col := congr_fun hsum (Fin.castAdd (numQubits L) q)
+    simp only [Finset.sum_apply, Pi.smul_apply, smul_eq_mul, Pi.zero_apply,
+      NQubitPauliGroupElement.checkMatrix] at h_col
+    have h_partition :
+        (Finset.univ : Finset (Fin (generatorsList L).length)) =
+          Finset.univ.filter (fun k => k.val < nZ) ∪
+          Finset.univ.filter (fun k => ¬ k.val < nZ) := by
+      rw [Finset.filter_union_filter_not_eq]
+    have h_disj : Disjoint
+        ((Finset.univ : Finset (Fin (generatorsList L).length)).filter (fun k => k.val < nZ))
+        (Finset.univ.filter (fun k => ¬ k.val < nZ)) :=
+      Finset.disjoint_filter_filter_not _ _ _
+    rw [h_partition, Finset.sum_union h_disj] at h_col
+    -- The Z-block sum is 0 because Z-stabs have 0 X-half.
+    have h_z_zero : ∑ k ∈ (Finset.univ.filter
+        (fun k : Fin (generatorsList L).length => k.val < nZ)),
+        f k * NQubitPauliOperator.toSymplectic
+          ((generatorsList L).get k).operators (Fin.castAdd (numQubits L) q) = 0 := by
+      apply Finset.sum_eq_zero
+      intro k hk
+      rw [Finset.mem_filter] at hk
+      have hkZ : k.val < nZ := hk.2
+      have hgetZ := get_generatorsList_Z L k.val k.isLt hkZ
+      rw [hgetZ]
+      rw [toSymplectic_zStab_X]
+      ring
+    rw [h_z_zero, zero_add] at h_col
+    rw [RotatedSurface.rscBoundary2_apply]
+    -- Reindex X-block sum (filter k.val ≥ nZ) to Fin nX via xEquiv.
+    have h_bij_lhs :
+        ∑ k ∈ Finset.univ.filter (fun k : Fin (generatorsList L).length => ¬ k.val < nZ),
+          f k * NQubitPauliOperator.toSymplectic
+            ((generatorsList L).get k).operators (Fin.castAdd (numQubits L) q) =
+        ∑ i : Fin nX, f ⟨nZ + i.val, by have := i.isLt; omega⟩ *
+            NQubitPauliOperator.toSymplectic
+              ((generatorsList L).get ⟨nZ + i.val, by have := i.isLt; omega⟩).operators
+              (Fin.castAdd (numQubits L) q) := by
+      apply Finset.sum_bij (fun (k : Fin (generatorsList L).length)
+        (hk : k ∈ Finset.univ.filter (fun k => ¬ k.val < nZ)) =>
+          (⟨k.val - nZ, by
+            have hkge : nZ ≤ k.val := Nat.le_of_not_lt (Finset.mem_filter.mp hk).2
+            have := k.isLt
+            omega⟩ : Fin nX))
+      · intros; exact Finset.mem_univ _
+      · intros a ha b hb hab
+        have ha_ge : nZ ≤ a.val := Nat.le_of_not_lt (Finset.mem_filter.mp ha).2
+        have hb_ge : nZ ≤ b.val := Nat.le_of_not_lt (Finset.mem_filter.mp hb).2
+        have h_val : a.val - nZ = b.val - nZ := Fin.mk.inj_iff.mp hab
+        apply Fin.ext; omega
+      · intros b _
+        refine ⟨⟨nZ + b.val, by have := b.isLt; omega⟩, ?_, ?_⟩
+        · rw [Finset.mem_filter]
+          refine ⟨Finset.mem_univ _, ?_⟩
+          simp only [not_lt]
+          exact Nat.le_add_right _ _
+        · apply Fin.ext; simp
+      · intros a ha
+        have ha_ge : nZ ≤ a.val := Nat.le_of_not_lt (Finset.mem_filter.mp ha).2
+        have h_fin_eq : (⟨nZ + (a.val - nZ), by have := a.isLt; omega⟩ :
+            Fin (generatorsList L).length) = a := by
+          apply Fin.ext
+          change nZ + (a.val - nZ) = a.val
+          omega
+        rw [h_fin_eq]
+    rw [h_bij_lhs] at h_col
+    have h_eval :
+        ∀ i : Fin nX, f ⟨nZ + i.val, by have := i.isLt; omega⟩ *
+            NQubitPauliOperator.toSymplectic
+              ((generatorsList L).get ⟨nZ + i.val, by have := i.isLt; omega⟩).operators
+              (Fin.castAdd (numQubits L) q) =
+          f ⟨nZ + i.val, by have := i.isLt; omega⟩ *
+            (if v ∈ RotatedSurface.xSupport (xfAt L i.val i.isLt) then (1 : ZMod 2) else 0) := by
+      intro i
+      congr 1
+      have hge : nZ ≤ nZ + i.val := Nat.le_add_right _ _
+      have hsub : nZ + i.val - nZ < nX := by
+        rw [Nat.add_sub_cancel_left]; exact i.isLt
+      have hgetX := get_generatorsList_X L (nZ + i.val) (by have := i.isLt; omega) hge hsub
+      rw [hgetX, toSymplectic_xStab_X, hq_def, vtxOfQubit_rscQubitEquiv]
+      -- Remaining: xSupport ((xList).get ⟨nZ + i.val - (zList L).length, _⟩) =
+      --             xSupport (xfAt L i.val i.isLt)
+      -- These agree because the inner indices are equal.
+      have h_idx_eq : nZ + i.val - (zList L).length = i.val := by
+        change nZ + i.val - nZ = i.val; omega
+      congr 1
+      unfold xfAt
+      rw [List.get_eq_getElem, List.get_eq_getElem]
+      simp [h_idx_eq]
+    rw [show ∑ i : Fin nX, f ⟨nZ + i.val, by have := i.isLt; omega⟩ *
+            NQubitPauliOperator.toSymplectic
+              ((generatorsList L).get ⟨nZ + i.val, by have := i.isLt; omega⟩).operators
+              (Fin.castAdd (numQubits L) q) =
+        ∑ i : Fin nX, f ⟨nZ + i.val, by have := i.isLt; omega⟩ *
+            (if v ∈ RotatedSurface.xSupport (xfAt L i.val i.isLt) then (1 : ZMod 2) else 0)
+      from Finset.sum_congr rfl (fun i _ => h_eval i)] at h_col
+    have h_target_eq :
+        (∑ xf : RotatedSurface.XFaceIdx L,
+            coeffsX L f xf *
+              (if v ∈ RotatedSurface.xSupport xf then (1 : ZMod 2) else 0)) =
+        ∑ i : Fin nX, f ⟨nZ + i.val, by have := i.isLt; omega⟩ *
+            (if v ∈ RotatedSurface.xSupport (xfAt L i.val i.isLt) then (1 : ZMod 2) else 0) := by
+      rw [← Equiv.sum_comp (xEquiv L) _]
+      apply Finset.sum_congr rfl
+      intro i _
+      have hxfAt : xEquiv L i = xfAt L i.val i.isLt := by
+        unfold xfAt; rw [xEquiv_apply]
+      rw [hxfAt]
+      rw [coeffsX_xfAt L f i.val i.isLt (by have := i.isLt; omega)]
+    rw [h_target_eq]
+    exact h_col
+  have h_cx_zero : coeffsX L f = 0 := by
+    apply RotatedSurface.rscBoundary2_injective
+    rw [h_cx_ker, LinearMap.map_zero]
+  -- Finally combine Z- and X-block to get f = 0.
+  intro j
+  by_cases hjZ : j.val < nZ
+  · -- j is in Z-block
+    have hjz := congr_fun h_cz_zero (zfAt L j.val hjZ)
+    rw [coeffsZ_zfAt L f j.val hjZ j.isLt] at hjz
+    have : (⟨j.val, j.isLt⟩ : Fin (generatorsList L).length) = j := Fin.ext rfl
+    rw [this] at hjz
+    exact hjz
+  · -- j is in X-block
+    push Not at hjZ
+    have hjX : j.val - nZ < nX := by
+      have := j.isLt; omega
+    have hjx := congr_fun h_cx_zero (xfAt L (j.val - nZ) hjX)
+    have h_idx_eq : nZ + (j.val - nZ) = j.val := by omega
+    rw [coeffsX_xfAt L f (j.val - nZ) hjX (by rw [h_idx_eq]; exact j.isLt)] at hjx
+    have : (⟨nZ + (j.val - nZ), by rw [h_idx_eq]; exact j.isLt⟩ :
+        Fin (generatorsList L).length) = j := by
+      apply Fin.ext; exact h_idx_eq
+    rw [this] at hjx
+    exact hjx
+
+/-- The rotated-surface generator list is an independent generating set. -/
+theorem generators_independent :
+    StabilizerGroup.GeneratorsIndependent (numQubits L) (generatorsList L) :=
+  StabilizerGroup.GeneratorsIndependent_of_rowsLinearIndependent (numQubits L)
+    (generatorsList L) (rowsLinearIndependent_generatorsList L)
+
+/-! ## §D — Logical operators
+
+Logical X is supported on the middle column `x = (L−1)/2`, and logical Z
+on the middle row `y = (L−1)/2`.  They intersect at the centre qubit
+`(mid, mid)` exactly once, so they anticommute.
+-/
+
+/-- The middle row/column index `(L − 1) / 2`. -/
+def midIdx : Fin L :=
+  ⟨(L - 1) / 2, by
+    have h3 : 3 ≤ L := Fact.out
+    have : (L - 1) / 2 < L := by omega
+    exact this⟩
+
+omit [Fact (Odd L)] in
+@[simp] lemma midIdx_val : (midIdx L).val = (L - 1) / 2 := rfl
+
+/-- The middle-column 1-chain: 1 on qubits with `x = (L − 1) / 2`, else 0. -/
+def middleColChain : RotatedSurface.VtxIdx L → ZMod 2 :=
+  fun v => if v.1.val = (L - 1) / 2 then 1 else 0
+
+/-- The middle-row 1-chain: 1 on qubits with `y = (L − 1) / 2`, else 0. -/
+def middleRowChain : RotatedSurface.VtxIdx L → ZMod 2 :=
+  fun v => if v.2.val = (L - 1) / 2 then 1 else 0
+
+/-- The middle column is a 1-cycle: `∂₁(middleColChain) = 0`. -/
+theorem middleColChain_mem_cycles :
+    middleColChain L ∈ RotatedSurface.rscCycles L := by
+  classical
+  change RotatedSurface.rscBoundary1 L (middleColChain L) = 0
+  have h3 : 3 ≤ L := Fact.out
+  have hmid_pos : 0 < (L - 1) / 2 := by omega
+  have hmid_lt : (L - 1) / 2 < L - 1 := by omega
+  funext zf
+  rw [Pi.zero_apply, RotatedSurface.rscBoundary1_apply]
+  cases zf with
+  | interior zc =>
+    -- zSupport interior = faceQubits = 4-element set; x-coords are c.1.val twice
+    -- and c.1.val+1 twice.  Sum pairs cancel in ZMod 2.
+    rw [show RotatedSurface.zSupport (RotatedSurface.ZFaceIdx.interior zc) =
+        RotatedSurface.faceQubits zc.val from rfl]
+    -- The four corners; corner.1 has val = c.1.val ("lo") or c.1.val + 1 ("hi").
+    set a := zc.val.1.val with ha_def
+    -- middleColChain at (cornerLo c.1, _) = 1[a = mid]
+    -- middleColChain at (cornerHi c.1, _) = 1[a+1 = mid]
+    have h_chain_lo : ∀ b : Fin L, middleColChain L
+        (RotatedSurface.cornerLo zc.val.1, b) =
+          (if a = (L - 1) / 2 then (1 : ZMod 2) else 0) := fun _ => rfl
+    have h_chain_hi : ∀ b : Fin L, middleColChain L
+        (RotatedSurface.cornerHi zc.val.1, b) =
+          (if a + 1 = (L - 1) / 2 then (1 : ZMod 2) else 0) := fun _ => rfl
+    -- The four x-coords cornerLo, cornerHi as Fin L are distinct.
+    have h_loHi_ne : RotatedSurface.cornerLo zc.val.1 ≠ RotatedSurface.cornerHi zc.val.1 := by
+      intro h; have := congrArg Fin.val h
+      simp [RotatedSurface.cornerLo, RotatedSurface.cornerHi] at this
+    have h_loHi_ne2 : RotatedSurface.cornerLo zc.val.2 ≠ RotatedSurface.cornerHi zc.val.2 := by
+      intro h; have := congrArg Fin.val h
+      simp [RotatedSurface.cornerLo, RotatedSurface.cornerHi] at this
+    -- Compute the sum using the indicator characterization.
+    -- middleColChain depends only on the first coordinate; the four corners pair
+    -- (lo, lo)+(lo, hi) and (hi, lo)+(hi, hi). Each pair has the same x-coord.
+    rw [show ∑ v ∈ RotatedSurface.faceQubits zc.val, middleColChain L v =
+        middleColChain L (RotatedSurface.cornerLo zc.val.1,
+          RotatedSurface.cornerLo zc.val.2) +
+        middleColChain L (RotatedSurface.cornerHi zc.val.1,
+          RotatedSurface.cornerLo zc.val.2) +
+        middleColChain L (RotatedSurface.cornerLo zc.val.1,
+          RotatedSurface.cornerHi zc.val.2) +
+        middleColChain L (RotatedSurface.cornerHi zc.val.1,
+          RotatedSurface.cornerHi zc.val.2) from ?_]
+    · rw [h_chain_lo, h_chain_hi, h_chain_lo, h_chain_hi]
+      have h_2 : (2 : ZMod 2) = 0 := by decide
+      have h_dist : ∀ x y : ZMod 2, x + y + x + y = 2 * x + 2 * y := fun _ _ => by ring
+      rw [h_dist]
+      rw [h_2, zero_mul, zero_mul, add_zero]
+    · -- Show the explicit 4-term sum equals the Finset.sum.
+      unfold RotatedSurface.faceQubits
+      rw [Finset.sum_insert (by
+          simp only [Finset.mem_insert, Finset.mem_singleton, Prod.mk.injEq, not_or]
+          refine ⟨fun hp => h_loHi_ne hp.1, fun hp => h_loHi_ne2 hp.2,
+            fun hp => h_loHi_ne hp.1⟩)]
+      rw [Finset.sum_insert (by
+          simp only [Finset.mem_insert, Finset.mem_singleton, Prod.mk.injEq, not_or]
+          refine ⟨fun hp => h_loHi_ne (hp.1).symm, fun hp => h_loHi_ne2 hp.2⟩)]
+      rw [Finset.sum_insert (by
+          simp only [Finset.mem_singleton, Prod.mk.injEq, not_and]
+          intro hp _; exact h_loHi_ne hp)]
+      rw [Finset.sum_singleton]
+      ring
+  | leftBdy k =>
+    -- Every qubit in zSupport(leftBdy k) has x = 0 ≠ mid.
+    apply Finset.sum_eq_zero
+    intro v hv
+    rw [RotatedSurface.mem_zSupport_leftBdy_iff] at hv
+    obtain ⟨hv1, _⟩ := hv
+    unfold middleColChain
+    rw [hv1]
+    rw [if_neg (by omega)]
+  | rightBdy k =>
+    -- Every qubit in zSupport(rightBdy k) has x = L-1 ≠ mid.
+    apply Finset.sum_eq_zero
+    intro v hv
+    rw [RotatedSurface.mem_zSupport_rightBdy_iff] at hv
+    obtain ⟨hv1, _⟩ := hv
+    unfold middleColChain
+    rw [hv1]
+    rw [if_neg (by omega)]
+
+/-- `dualBoundary c xf = ∑ v ∈ xSupport xf, c v` (the indicator characterization). -/
+lemma dualBoundary_apply_eq_sum (c : RotatedSurface.VtxIdx L → ZMod 2)
+    (xf : RotatedSurface.XFaceIdx L) :
+    (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundary c xf =
+      ∑ v ∈ RotatedSurface.xSupport xf, c v := by
+  classical
+  -- Step 1: unfold dualBoundary; convert each summand to its indicator form.
+  have h_step1 : (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundary c xf =
+      ∑ v : RotatedSurface.VtxIdx L,
+        c v * (if v ∈ RotatedSurface.xSupport xf then (1 : ZMod 2) else 0) := by
+    rw [show (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundary c xf =
+        ∑ v : RotatedSurface.VtxIdx L, c v *
+          (RotatedSurface.rotatedSurfaceHomologicalCode L).boundary2 (Pi.single xf 1) v from rfl]
+    apply Finset.sum_congr rfl
+    intro v _
+    have hb2 := boundary2_singleFace_apply L xf v
+    change _ * (RotatedSurface.rotatedSurfaceHomologicalCode L).boundary2
+        ((RotatedSurface.rotatedSurfaceHomologicalCode L).singleFace xf) v = _
+    rw [hb2]
+  rw [h_step1]
+  -- Step 2: restructure the indicator multiplication to use Finset.sum_filter.
+  have h_step2 : (∑ v : RotatedSurface.VtxIdx L,
+      c v * (if v ∈ RotatedSurface.xSupport xf then (1 : ZMod 2) else 0)) =
+      ∑ v : RotatedSurface.VtxIdx L,
+        (if v ∈ RotatedSurface.xSupport xf then c v else 0) := by
+    apply Finset.sum_congr rfl
+    intro v _
+    by_cases hv : v ∈ RotatedSurface.xSupport xf
+    · rw [if_pos hv, if_pos hv, _root_.mul_one]
+    · rw [if_neg hv, if_neg hv, MulZeroClass.mul_zero]
+  rw [h_step2]
+  rw [← Finset.sum_filter]
+  apply Finset.sum_congr ?_ (fun _ _ => rfl)
+  ext v; simp
+
+/-- The middle row is a dual 1-cycle: `dualBoundary (middleRowChain) = 0`. -/
+theorem middleRowChain_mem_dualCycles :
+    middleRowChain L ∈ (RotatedSurface.rotatedSurfaceHomologicalCode L).dualCycles := by
+  classical
+  change (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundary
+      (middleRowChain L) = 0
+  have h3 : 3 ≤ L := Fact.out
+  have hmid_pos : 0 < (L - 1) / 2 := by omega
+  have hmid_lt : (L - 1) / 2 < L - 1 := by omega
+  funext xf
+  rw [Pi.zero_apply, dualBoundary_apply_eq_sum]
+  cases xf with
+  | interior xc =>
+    -- Symmetric to middleColChain interior case: y-coords pair-cancel.
+    rw [show RotatedSurface.xSupport (RotatedSurface.XFaceIdx.interior xc) =
+        RotatedSurface.faceQubits xc.val from rfl]
+    set b := xc.val.2.val with hb_def
+    have h_chain_lo : ∀ a : Fin L, middleRowChain L
+        (a, RotatedSurface.cornerLo xc.val.2) =
+          (if b = (L - 1) / 2 then (1 : ZMod 2) else 0) := fun _ => rfl
+    have h_chain_hi : ∀ a : Fin L, middleRowChain L
+        (a, RotatedSurface.cornerHi xc.val.2) =
+          (if b + 1 = (L - 1) / 2 then (1 : ZMod 2) else 0) := fun _ => rfl
+    have h_loHi_ne : RotatedSurface.cornerLo xc.val.1 ≠ RotatedSurface.cornerHi xc.val.1 := by
+      intro h; have := congrArg Fin.val h
+      simp [RotatedSurface.cornerLo, RotatedSurface.cornerHi] at this
+    have h_loHi_ne2 : RotatedSurface.cornerLo xc.val.2 ≠ RotatedSurface.cornerHi xc.val.2 := by
+      intro h; have := congrArg Fin.val h
+      simp [RotatedSurface.cornerLo, RotatedSurface.cornerHi] at this
+    rw [show ∑ v ∈ RotatedSurface.faceQubits xc.val, middleRowChain L v =
+        middleRowChain L (RotatedSurface.cornerLo xc.val.1,
+          RotatedSurface.cornerLo xc.val.2) +
+        middleRowChain L (RotatedSurface.cornerHi xc.val.1,
+          RotatedSurface.cornerLo xc.val.2) +
+        middleRowChain L (RotatedSurface.cornerLo xc.val.1,
+          RotatedSurface.cornerHi xc.val.2) +
+        middleRowChain L (RotatedSurface.cornerHi xc.val.1,
+          RotatedSurface.cornerHi xc.val.2) from ?_]
+    · rw [h_chain_lo, h_chain_lo, h_chain_hi, h_chain_hi]
+      have h_2 : (2 : ZMod 2) = 0 := by decide
+      have h_dist : ∀ x y : ZMod 2, x + x + y + y = 2 * x + 2 * y := fun _ _ => by ring
+      rw [h_dist]
+      rw [h_2, zero_mul, zero_mul, add_zero]
+    · unfold RotatedSurface.faceQubits
+      rw [Finset.sum_insert (by
+          simp only [Finset.mem_insert, Finset.mem_singleton, Prod.mk.injEq, not_or]
+          refine ⟨fun hp => h_loHi_ne hp.1, fun hp => h_loHi_ne2 hp.2,
+            fun hp => h_loHi_ne hp.1⟩)]
+      rw [Finset.sum_insert (by
+          simp only [Finset.mem_insert, Finset.mem_singleton, Prod.mk.injEq, not_or]
+          refine ⟨fun hp => h_loHi_ne (hp.1).symm, fun hp => h_loHi_ne2 hp.2⟩)]
+      rw [Finset.sum_insert (by
+          simp only [Finset.mem_singleton, Prod.mk.injEq, not_and]
+          intro hp _; exact h_loHi_ne hp)]
+      rw [Finset.sum_singleton]
+      ring
+  | topBdy k =>
+    -- All qubits have y = 0 ≠ mid.
+    apply Finset.sum_eq_zero
+    intro v hv
+    rw [RotatedSurface.mem_xSupport_topBdy_iff] at hv
+    obtain ⟨hv2, _⟩ := hv
+    unfold middleRowChain
+    rw [hv2]
+    rw [if_neg (by omega)]
+  | bottomBdy k =>
+    -- All qubits have y = L - 1 ≠ mid.
+    apply Finset.sum_eq_zero
+    intro v hv
+    rw [RotatedSurface.mem_xSupport_bottomBdy_iff] at hv
+    obtain ⟨hv2, _⟩ := hv
+    unfold middleRowChain
+    rw [hv2]
+    rw [if_neg (by omega)]
+
+/-! ### Logical operators and centralizer membership -/
+
+/-- The logical X operator: vertical X-string at column `(L − 1) / 2`. -/
+noncomputable def logicalX : NQubitPauliGroupElement (numQubits L) :=
+  (RotatedSurface.rotatedSurfaceHomologicalCode L).chainXOperator (middleColChain L)
+
+/-- The logical Z operator: horizontal Z-string at row `(L − 1) / 2`. -/
+noncomputable def logicalZ : NQubitPauliGroupElement (numQubits L) :=
+  (RotatedSurface.rotatedSurfaceHomologicalCode L).chainZOperator (middleRowChain L)
+
+/-- Logical X is in the centralizer of the homological stabilizer group. -/
+lemma logicalX_mem_centralizer_homological :
+    logicalX L ∈ StabilizerGroup.centralizer
+      (RotatedSurface.rotatedSurfaceHomologicalCode L).homologicalStabilizerGroup := by
+  rw [show logicalX L = (RotatedSurface.rotatedSurfaceHomologicalCode L).chainXOperator
+      (middleColChain L) from rfl]
+  have h := (RotatedSurface.rotatedSurfaceHomologicalCode L)
+      |>.chainXOperator_mem_centralizer_iff_mem_cycles (middleColChain L)
+  exact h.mpr (middleColChain_mem_cycles L)
+
+/-- Logical Z is in the centralizer of the homological stabilizer group. -/
+lemma logicalZ_mem_centralizer_homological :
+    logicalZ L ∈ StabilizerGroup.centralizer
+      (RotatedSurface.rotatedSurfaceHomologicalCode L).homologicalStabilizerGroup := by
+  rw [show logicalZ L =
+      (RotatedSurface.rotatedSurfaceHomologicalCode L).chainZOperator
+        (middleRowChain L) from rfl]
+  have h := (RotatedSurface.rotatedSurfaceHomologicalCode L)
+      |>.chainZOperator_mem_centralizer_iff_mem_dualCycles (middleRowChain L)
+  exact h.mpr (middleRowChain_mem_dualCycles L)
+
+/-- The chain inner product of `middleColChain` and `middleRowChain` is 1
+(they share exactly the centre qubit `(mid, mid)`). -/
+private lemma chainInnerProduct_middleCol_middleRow :
+    Quantum.Stabilizer.Homological.HomologicalCode.chainInnerProduct
+        (X := RotatedSurface.rotatedSurfaceHomologicalCode L)
+        (middleColChain L) (middleRowChain L) = 1 := by
+  classical
+  -- Reduce the sum to the single contributing term at (mid, mid).
+  change ∑ v : RotatedSurface.VtxIdx L, middleColChain L v * middleRowChain L v = 1
+  rw [Finset.sum_eq_single (a := (midIdx L, midIdx L))]
+  · unfold middleColChain middleRowChain
+    simp
+  · intro v _ hne
+    unfold middleColChain middleRowChain
+    by_cases h1 : v.1.val = (L - 1) / 2
+    · by_cases h2 : v.2.val = (L - 1) / 2
+      · exfalso
+        apply hne
+        rcases v with ⟨v1, v2⟩
+        congr 1
+        · exact Fin.ext h1
+        · exact Fin.ext h2
+      · rw [if_pos h1, if_neg h2, MulZeroClass.mul_zero]
+    · rw [if_neg h1, MulZeroClass.zero_mul]
+  · intro hcontra; exact absurd (Finset.mem_univ _) hcontra
+
+/-- Logical X and logical Z anticommute. -/
+theorem logicalX_anticommute_logicalZ :
+    NQubitPauliGroupElement.Anticommute (logicalX L) (logicalZ L) := by
+  have h_not_commute : ¬ ((logicalX L) * (logicalZ L) = (logicalZ L) * (logicalX L)) := by
+    intro h
+    have h_inner :=
+      ((RotatedSurface.rotatedSurfaceHomologicalCode L).chainXOperator_commutes_chainZOperator_iff
+        (middleColChain L) (middleRowChain L)).mp h
+    rw [chainInnerProduct_middleCol_middleRow] at h_inner
+    exact (by decide : (1 : ZMod 2) ≠ 0) h_inner
+  rcases NQubitPauliGroupElement.commute_or_anticommute (logicalX L) (logicalZ L) with h | h
+  · exact absurd h h_not_commute
+  · exact h
+
+/-! ### Logical operator package — translated to `stabilizerGroup` -/
+
+/-- Logical X is in the centralizer of the lattice-side `stabilizerGroup`. -/
+lemma logicalX_mem_centralizer :
+    logicalX L ∈ StabilizerGroup.centralizer (stabilizerGroup L) := by
+  rw [show StabilizerGroup.centralizer (stabilizerGroup L) =
+      StabilizerGroup.centralizer
+        (RotatedSurface.rotatedSurfaceHomologicalCode L).homologicalStabilizerGroup from
+    StabilizerGroup.centralizer_eq_of_toSubgroup_eq _ _
+      (stabilizerGroup_toSubgroup_eq_homologicalStabilizerGroup L)]
+  exact logicalX_mem_centralizer_homological L
+
+/-- Logical Z is in the centralizer of the lattice-side `stabilizerGroup`. -/
+lemma logicalZ_mem_centralizer :
+    logicalZ L ∈ StabilizerGroup.centralizer (stabilizerGroup L) := by
+  rw [show StabilizerGroup.centralizer (stabilizerGroup L) =
+      StabilizerGroup.centralizer
+        (RotatedSurface.rotatedSurfaceHomologicalCode L).homologicalStabilizerGroup from
+    StabilizerGroup.centralizer_eq_of_toSubgroup_eq _ _
+      (stabilizerGroup_toSubgroup_eq_homologicalStabilizerGroup L)]
+  exact logicalZ_mem_centralizer_homological L
+
+/-- The logical qubit operator package (single logical qubit). -/
+noncomputable def logicalOps :
+    Fin 1 → LogicalQubitOps (numQubits L) (stabilizerGroup L) :=
+  fun _ =>
+    { xOp := logicalX L
+      zOp := logicalZ L
+      x_mem_centralizer := logicalX_mem_centralizer L
+      z_mem_centralizer := logicalZ_mem_centralizer L
+      anticommute := logicalX_anticommute_logicalZ L }
+
+/-! ### Final assembly — `StabilizerCode (L * L) 1` -/
+
+/-- The rotated surface code packaged as a `StabilizerCode (L * L) 1`. -/
+noncomputable def rotatedSurfaceStabilizerCode :
+    StabilizerGroup.StabilizerCode (numQubits L) 1 where
+  hk := by
+    have h3 : 3 ≤ L := Fact.out
+    have : 1 ≤ L * L := by nlinarith
+    exact this
+  generatorsList := generatorsList L
+  generators_length := generatorsList_length L
+  generators_phaseZero := allPhaseZero_generatorsList L
+  generators_independent := generators_independent L
+  generators_commute := by
+    rw [listToSet_generatorsList]; exact generators_commute L
+  closure_no_neg_identity := by
+    rw [listToSet_generatorsList]; exact negIdentity_not_mem L
+  logicalOps := logicalOps L
+  logical_commute_cross := fun ℓ ℓ' h => (h (Subsingleton.elim ℓ ℓ')).elim
+
+/-- The rotated-surface stabilizer code's subgroup matches the canonical
+`stabilizerGroup L`. -/
+theorem rotatedSurfaceStabilizerCode_subgroup_eq :
+    (rotatedSurfaceStabilizerCode L).toStabilizerGroup.toSubgroup =
+      (stabilizerGroup L).toSubgroup := rfl
+
+/-- Bridge: the rotated-surface stabilizer code's subgroup matches the abstract
+homological stabilizer group. -/
+theorem rotatedSurfaceStabilizerCode_subgroup_eq_homological :
+    (rotatedSurfaceStabilizerCode L).toStabilizerGroup.toSubgroup =
+      (RotatedSurface.rotatedSurfaceHomologicalCode L).homologicalStabilizerGroup.toSubgroup := by
+  rw [rotatedSurfaceStabilizerCode_subgroup_eq,
+    stabilizerGroup_toSubgroup_eq_homologicalStabilizerGroup]
+
+end RotatedSurfaceCodeN
+end StabilizerGroup
+end Quantum

--- a/QEC/Stabilizer/Lattice.lean
+++ b/QEC/Stabilizer/Lattice.lean
@@ -15,4 +15,5 @@ import QEC.Stabilizer.Lattice.ToricChainComplex
 import QEC.Stabilizer.Lattice.RotatedSurfaceCellComplex
 import QEC.Stabilizer.Lattice.RotatedSurfaceBoundaryMaps
 import QEC.Stabilizer.Lattice.RotatedSurfaceChainComplex
+import QEC.Stabilizer.Lattice.RotatedSurfaceH1Dimension
 

--- a/QEC/Stabilizer/Lattice.lean
+++ b/QEC/Stabilizer/Lattice.lean
@@ -14,4 +14,5 @@ import QEC.Stabilizer.Lattice.ToricDualWrappingInvariants
 import QEC.Stabilizer.Lattice.ToricChainComplex
 import QEC.Stabilizer.Lattice.RotatedSurfaceCellComplex
 import QEC.Stabilizer.Lattice.RotatedSurfaceBoundaryMaps
+import QEC.Stabilizer.Lattice.RotatedSurfaceChainComplex
 

--- a/QEC/Stabilizer/Lattice.lean
+++ b/QEC/Stabilizer/Lattice.lean
@@ -12,4 +12,6 @@ import QEC.Stabilizer.Lattice.ToricLogicalCorrespondenceX
 import QEC.Stabilizer.Lattice.ToricLogicalCorrespondenceZ
 import QEC.Stabilizer.Lattice.ToricDualWrappingInvariants
 import QEC.Stabilizer.Lattice.ToricChainComplex
+import QEC.Stabilizer.Lattice.RotatedSurfaceCellComplex
+import QEC.Stabilizer.Lattice.RotatedSurfaceBoundaryMaps
 

--- a/QEC/Stabilizer/Lattice/RotatedSurfaceBoundaryMaps.lean
+++ b/QEC/Stabilizer/Lattice/RotatedSurfaceBoundaryMaps.lean
@@ -1,0 +1,573 @@
+import Mathlib.Tactic
+import QEC.Stabilizer.Lattice.RotatedSurfaceCellComplex
+
+/-!
+# Rotated-surface-code boundary maps
+
+The boundary maps `∂₂ : C₂ → C₁` and `∂₁ : C₁ → C₀` for the rotated surface
+code, plus the chain-complex law `∂₁ ∘ ∂₂ = 0`.
+
+The chain-complex law unwinds to: for every `(zf, xf)` pair, the cardinality
+`|zSupport zf ∩ xSupport xf|` is even.  Since all supports have size `2` or
+`4` and the colours alternate, each intersection is either empty or shares
+a single 2-qubit edge.  We prove this case-by-case (3 × 3 = 9 cases) via
+`Nat`-level membership characterisations and `omega`.
+-/
+
+namespace Quantum
+namespace Stabilizer
+namespace Lattice
+namespace RotatedSurface
+
+open scoped BigOperators
+
+/-! ## Membership characterisations (ℕ-coordinate level) -/
+
+lemma mem_faceQubits_iff {L : ℕ} (c : FaceCornerIdx L) (v : VtxIdx L) :
+    v ∈ faceQubits c ↔
+      (v.1.val = c.1.val ∨ v.1.val = c.1.val + 1) ∧
+      (v.2.val = c.2.val ∨ v.2.val = c.2.val + 1) := by
+  obtain ⟨v1, v2⟩ := v
+  simp_all [faceQubits, cornerLo, cornerHi, Finset.mem_insert,
+    Finset.mem_singleton, Fin.ext_iff]
+  tauto
+
+lemma mem_zSupport_interior_iff {L : ℕ}
+    (c : ZInteriorCornerIdx L) (v : VtxIdx L) :
+    v ∈ zSupport (.interior c) ↔
+      (v.1.val = c.val.1.val ∨ v.1.val = c.val.1.val + 1) ∧
+      (v.2.val = c.val.2.val ∨ v.2.val = c.val.2.val + 1) := by
+  rw [zSupport_interior]; exact mem_faceQubits_iff _ _
+
+lemma mem_xSupport_interior_iff {L : ℕ}
+    (c : XInteriorCornerIdx L) (v : VtxIdx L) :
+    v ∈ xSupport (.interior c) ↔
+      (v.1.val = c.val.1.val ∨ v.1.val = c.val.1.val + 1) ∧
+      (v.2.val = c.val.2.val ∨ v.2.val = c.val.2.val + 1) := by
+  rw [xSupport_interior]; exact mem_faceQubits_iff _ _
+
+lemma mem_zSupport_leftBdy_iff {L : ℕ} (k : RscBdyIdx L) (v : VtxIdx L) :
+    v ∈ zSupport (.leftBdy k) ↔
+      v.1.val = 0 ∧ (v.2.val = 2 * k.val + 1 ∨ v.2.val = 2 * k.val + 2) := by
+  obtain ⟨v1, v2⟩ := v
+  simp_all [zSupport, Finset.mem_insert, Finset.mem_singleton, Fin.ext_iff]
+  tauto
+
+lemma mem_zSupport_rightBdy_iff {L : ℕ} (k : RscBdyIdx L) (v : VtxIdx L) :
+    v ∈ zSupport (.rightBdy k) ↔
+      v.1.val = L - 1 ∧ (v.2.val = 2 * k.val ∨ v.2.val = 2 * k.val + 1) := by
+  obtain ⟨v1, v2⟩ := v
+  simp_all [zSupport, Finset.mem_insert, Finset.mem_singleton, Fin.ext_iff]
+  tauto
+
+lemma mem_xSupport_topBdy_iff {L : ℕ} (k : RscBdyIdx L) (v : VtxIdx L) :
+    v ∈ xSupport (.topBdy k) ↔
+      v.2.val = 0 ∧ (v.1.val = 2 * k.val ∨ v.1.val = 2 * k.val + 1) := by
+  obtain ⟨v1, v2⟩ := v
+  simp_all [xSupport, Finset.mem_insert, Finset.mem_singleton, Fin.ext_iff]
+  tauto
+
+lemma mem_xSupport_bottomBdy_iff {L : ℕ} (k : RscBdyIdx L) (v : VtxIdx L) :
+    v ∈ xSupport (.bottomBdy k) ↔
+      v.2.val = L - 1 ∧ (v.1.val = 2 * k.val + 1 ∨ v.1.val = 2 * k.val + 2) := by
+  obtain ⟨v1, v2⟩ := v
+  simp_all [xSupport, Finset.mem_insert, Finset.mem_singleton, Fin.ext_iff]
+  tauto
+
+/-! ## Cardinalities of the boundary supports -/
+
+lemma xSupport_topBdy_card {L : ℕ} (k : RscBdyIdx L) :
+    (xSupport (.topBdy k)).card = 2 := by
+  unfold xSupport
+  rw [Finset.card_insert_of_notMem, Finset.card_singleton]
+  rw [Finset.mem_singleton]
+  intro h
+  have h := congrArg (fun p : VtxIdx L => p.1.val) h
+  simp at h
+
+lemma xSupport_bottomBdy_card {L : ℕ} (k : RscBdyIdx L) :
+    (xSupport (.bottomBdy k)).card = 2 := by
+  unfold xSupport
+  rw [Finset.card_insert_of_notMem, Finset.card_singleton]
+  rw [Finset.mem_singleton]
+  intro h
+  have h := congrArg (fun p : VtxIdx L => p.1.val) h
+  simp at h
+
+lemma zSupport_leftBdy_card {L : ℕ} (k : RscBdyIdx L) :
+    (zSupport (.leftBdy k)).card = 2 := by
+  unfold zSupport
+  rw [Finset.card_insert_of_notMem, Finset.card_singleton]
+  rw [Finset.mem_singleton]
+  intro h
+  have h := congrArg (fun p : VtxIdx L => p.2.val) h
+  simp at h
+
+lemma zSupport_rightBdy_card {L : ℕ} (k : RscBdyIdx L) :
+    (zSupport (.rightBdy k)).card = 2 := by
+  unfold zSupport
+  rw [Finset.card_insert_of_notMem, Finset.card_singleton]
+  rw [Finset.mem_singleton]
+  intro h
+  have h := congrArg (fun p : VtxIdx L => p.2.val) h
+  simp at h
+
+/-! ## Boundary maps -/
+
+/-- `∂₂ : C₂ → C₁` for the rotated surface code. -/
+def rscBoundary2 (L : ℕ) :
+    (XFaceIdx L → ZMod 2) →ₗ[ZMod 2] (VtxIdx L → ZMod 2) where
+  toFun c v := ∑ xf : XFaceIdx L, c xf * (if v ∈ xSupport xf then 1 else 0)
+  map_add' c d := by
+    funext v
+    simp only [Pi.add_apply, add_mul, Finset.sum_add_distrib]
+  map_smul' a c := by
+    funext v
+    simp only [RingHom.id_apply, Pi.smul_apply, smul_eq_mul, Finset.mul_sum,
+      mul_assoc]
+
+/-- `∂₁ : C₁ → C₀` for the rotated surface code. -/
+def rscBoundary1 (L : ℕ) :
+    (VtxIdx L → ZMod 2) →ₗ[ZMod 2] (ZFaceIdx L → ZMod 2) where
+  toFun c zf := ∑ v ∈ zSupport zf, c v
+  map_add' c d := by
+    funext zf
+    simp only [Pi.add_apply, Finset.sum_add_distrib]
+  map_smul' a c := by
+    funext zf
+    simp only [RingHom.id_apply, Pi.smul_apply, smul_eq_mul, Finset.mul_sum]
+
+@[simp] theorem rscBoundary2_apply (L : ℕ) (c : XFaceIdx L → ZMod 2)
+    (v : VtxIdx L) :
+    rscBoundary2 L c v =
+      ∑ xf : XFaceIdx L, c xf * (if v ∈ xSupport xf then 1 else 0) := rfl
+
+@[simp] theorem rscBoundary1_apply (L : ℕ) (c : VtxIdx L → ZMod 2)
+    (zf : ZFaceIdx L) :
+    rscBoundary1 L c zf = ∑ v ∈ zSupport zf, c v := rfl
+
+/-! ## Intersection-cardinality lemmas -/
+
+section InterCard
+variable {L : ℕ}
+
+/-- Indicator-sum equals cardinality of intersection (cast into `ZMod 2`). -/
+private lemma sum_indicator_eq_inter_card (zf : ZFaceIdx L) (xf : XFaceIdx L) :
+    (∑ v ∈ zSupport zf, (if v ∈ xSupport xf then (1 : ZMod 2) else 0)) =
+      ((zSupport zf ∩ xSupport xf).card : ZMod 2) := by
+  rw [Finset.sum_boole]; rfl
+
+private lemma cast_card_zero_of_eq_empty {α : Type*}
+    {s : Finset α} (h : s = ∅) : (s.card : ZMod 2) = 0 := by simp [h]
+
+private lemma cast_card_two_zmod : ((2 : ℕ) : ZMod 2) = 0 := by decide
+
+/-- If `s = {v0, v1}` with `v0 ≠ v1`, then the cardinality cast to `ZMod 2` is `0`. -/
+private lemma cast_card_zero_of_eq_pair {α : Type*} [DecidableEq α]
+    {s : Finset α} {v0 v1 : α} (h_eq : s = {v0, v1}) (hne : v0 ≠ v1) :
+    (s.card : ZMod 2) = 0 := by
+  rw [h_eq, Finset.card_insert_of_notMem (by simpa using hne),
+    Finset.card_singleton]
+  decide
+
+/-! ### Boundary × boundary — empty in all 4 cases. -/
+
+private lemma inter_leftBdy_topBdy_empty (k k' : RscBdyIdx L) :
+    zSupport (.leftBdy k) ∩ xSupport (.topBdy k') = ∅ := by
+  rw [← Finset.not_nonempty_iff_eq_empty]
+  rintro ⟨v, hv⟩
+  rw [Finset.mem_inter, mem_zSupport_leftBdy_iff, mem_xSupport_topBdy_iff] at hv
+  omega
+
+private lemma inter_leftBdy_bottomBdy_empty (k k' : RscBdyIdx L) :
+    zSupport (.leftBdy k) ∩ xSupport (.bottomBdy k') = ∅ := by
+  rw [← Finset.not_nonempty_iff_eq_empty]
+  rintro ⟨v, hv⟩
+  rw [Finset.mem_inter, mem_zSupport_leftBdy_iff, mem_xSupport_bottomBdy_iff] at hv
+  have := k'.isLt; omega
+
+private lemma inter_rightBdy_topBdy_empty (k k' : RscBdyIdx L) :
+    zSupport (.rightBdy k) ∩ xSupport (.topBdy k') = ∅ := by
+  rw [← Finset.not_nonempty_iff_eq_empty]
+  rintro ⟨v, hv⟩
+  rw [Finset.mem_inter, mem_zSupport_rightBdy_iff, mem_xSupport_topBdy_iff] at hv
+  have := k'.isLt; omega
+
+private lemma inter_rightBdy_bottomBdy_empty (k k' : RscBdyIdx L) :
+    zSupport (.rightBdy k) ∩ xSupport (.bottomBdy k') = ∅ := by
+  rw [← Finset.not_nonempty_iff_eq_empty]
+  rintro ⟨v, hv⟩
+  rw [Finset.mem_inter, mem_zSupport_rightBdy_iff, mem_xSupport_bottomBdy_iff] at hv
+  have hk := k.isLt
+  have hk' := k'.isLt
+  omega
+
+/-! ### Interior × boundary
+
+In each case the intersection is *either* empty *or* equals the
+boundary stab's support.  We dispatch the nonempty branch via
+`Finset.inter_eq_right` / `Finset.inter_eq_left`. -/
+
+private lemma inter_interior_topBdy_card_even
+    (zc : ZInteriorCornerIdx L) (k : RscBdyIdx L) :
+    ((zSupport (.interior zc) ∩ xSupport (.topBdy k)).card : ZMod 2) = 0 := by
+  have hpar : (zc.val.1.val + zc.val.2.val) % 2 = 0 := zc.property
+  by_cases hb_eq : zc.val.2.val = 0
+  · by_cases ha_eq : zc.val.1.val = 2 * k.val
+    · have h_eq : zSupport (.interior zc) ∩ xSupport (.topBdy k) =
+          xSupport (.topBdy k) := by
+        rw [Finset.inter_eq_right]
+        intro w hw
+        rw [mem_xSupport_topBdy_iff] at hw
+        rw [mem_zSupport_interior_iff]
+        obtain ⟨hw2, hw1⟩ := hw
+        refine ⟨?_, Or.inl ?_⟩
+        · rcases hw1 with h | h
+          · left; omega
+          · right; omega
+        · omega
+      rw [h_eq, xSupport_topBdy_card]
+      exact cast_card_two_zmod
+    · apply cast_card_zero_of_eq_empty
+      rw [← Finset.not_nonempty_iff_eq_empty]
+      rintro ⟨w, hw⟩
+      rw [Finset.mem_inter, mem_zSupport_interior_iff,
+        mem_xSupport_topBdy_iff] at hw
+      obtain ⟨⟨hwz1, _⟩, _, hwx1⟩ := hw
+      rcases hwz1 with h | h <;> rcases hwx1 with h' | h' <;> omega
+  · apply cast_card_zero_of_eq_empty
+    rw [← Finset.not_nonempty_iff_eq_empty]
+    rintro ⟨w, hw⟩
+    rw [Finset.mem_inter, mem_zSupport_interior_iff,
+      mem_xSupport_topBdy_iff] at hw
+    obtain ⟨⟨_, hwz2⟩, hwx2, _⟩ := hw
+    rcases hwz2 with h | h <;> omega
+
+private lemma inter_interior_bottomBdy_card_even [Fact (Odd L)]
+    (zc : ZInteriorCornerIdx L) (k : RscBdyIdx L) :
+    ((zSupport (.interior zc) ∩ xSupport (.bottomBdy k)).card : ZMod 2) = 0 := by
+  have hpar : (zc.val.1.val + zc.val.2.val) % 2 = 0 := zc.property
+  have hL_odd : L % 2 = 1 := Nat.odd_iff.mp Fact.out
+  have hkLt : 2 * k.val + 2 < L := by have := k.isLt; omega
+  by_cases hb_eq : zc.val.2.val + 1 = L - 1
+  · by_cases ha_eq : zc.val.1.val = 2 * k.val + 1
+    · have h_eq : zSupport (.interior zc) ∩ xSupport (.bottomBdy k) =
+          xSupport (.bottomBdy k) := by
+        rw [Finset.inter_eq_right]
+        intro w hw
+        rw [mem_xSupport_bottomBdy_iff] at hw
+        rw [mem_zSupport_interior_iff]
+        obtain ⟨hw2, hw1⟩ := hw
+        refine ⟨?_, Or.inr ?_⟩
+        · rcases hw1 with h | h
+          · left; omega
+          · right; omega
+        · omega
+      rw [h_eq, xSupport_bottomBdy_card]
+      exact cast_card_two_zmod
+    · apply cast_card_zero_of_eq_empty
+      rw [← Finset.not_nonempty_iff_eq_empty]
+      rintro ⟨w, hw⟩
+      rw [Finset.mem_inter, mem_zSupport_interior_iff,
+        mem_xSupport_bottomBdy_iff] at hw
+      obtain ⟨⟨hwz1, _⟩, _, hwx1⟩ := hw
+      rcases hwz1 with h | h <;> rcases hwx1 with h' | h' <;> omega
+  · apply cast_card_zero_of_eq_empty
+    rw [← Finset.not_nonempty_iff_eq_empty]
+    rintro ⟨w, hw⟩
+    rw [Finset.mem_inter, mem_zSupport_interior_iff,
+      mem_xSupport_bottomBdy_iff] at hw
+    obtain ⟨⟨_, hwz2⟩, hwx2, _⟩ := hw
+    rcases hwz2 with h | h <;> omega
+
+private lemma inter_leftBdy_interior_card_even
+    (k : RscBdyIdx L) (xc : XInteriorCornerIdx L) :
+    ((zSupport (.leftBdy k) ∩ xSupport (.interior xc)).card : ZMod 2) = 0 := by
+  have hpar : (xc.val.1.val + xc.val.2.val) % 2 = 1 := xc.property
+  have hkLt : 2 * k.val + 2 < L := by have := k.isLt; omega
+  by_cases ha_eq : xc.val.1.val = 0
+  · by_cases hb_eq : xc.val.2.val = 2 * k.val + 1
+    · have h_eq : zSupport (.leftBdy k) ∩ xSupport (.interior xc) =
+          zSupport (.leftBdy k) := by
+        rw [Finset.inter_eq_left]
+        intro w hw
+        rw [mem_zSupport_leftBdy_iff] at hw
+        rw [mem_xSupport_interior_iff]
+        obtain ⟨hw1, hw2⟩ := hw
+        refine ⟨Or.inl ?_, ?_⟩
+        · omega
+        · rcases hw2 with h | h
+          · left; omega
+          · right; omega
+      rw [h_eq, zSupport_leftBdy_card]
+      exact cast_card_two_zmod
+    · apply cast_card_zero_of_eq_empty
+      rw [← Finset.not_nonempty_iff_eq_empty]
+      rintro ⟨w, hw⟩
+      rw [Finset.mem_inter, mem_zSupport_leftBdy_iff,
+        mem_xSupport_interior_iff] at hw
+      obtain ⟨⟨_, hwz2⟩, _, hwx2⟩ := hw
+      rcases hwz2 with h | h <;> rcases hwx2 with h' | h' <;> omega
+  · apply cast_card_zero_of_eq_empty
+    rw [← Finset.not_nonempty_iff_eq_empty]
+    rintro ⟨w, hw⟩
+    rw [Finset.mem_inter, mem_zSupport_leftBdy_iff,
+      mem_xSupport_interior_iff] at hw
+    obtain ⟨⟨hwz1, _⟩, hwx1, _⟩ := hw
+    rcases hwx1 with h | h <;> omega
+
+private lemma inter_rightBdy_interior_card_even [Fact (Odd L)]
+    (k : RscBdyIdx L) (xc : XInteriorCornerIdx L) :
+    ((zSupport (.rightBdy k) ∩ xSupport (.interior xc)).card : ZMod 2) = 0 := by
+  have hpar : (xc.val.1.val + xc.val.2.val) % 2 = 1 := xc.property
+  have hL_odd : L % 2 = 1 := Nat.odd_iff.mp Fact.out
+  have hkLt : 2 * k.val + 1 < L := by have := k.isLt; omega
+  by_cases ha_eq : xc.val.1.val + 1 = L - 1
+  · by_cases hb_eq : xc.val.2.val = 2 * k.val
+    · have h_eq : zSupport (.rightBdy k) ∩ xSupport (.interior xc) =
+          zSupport (.rightBdy k) := by
+        rw [Finset.inter_eq_left]
+        intro w hw
+        rw [mem_zSupport_rightBdy_iff] at hw
+        rw [mem_xSupport_interior_iff]
+        obtain ⟨hw1, hw2⟩ := hw
+        refine ⟨Or.inr ?_, ?_⟩
+        · omega
+        · rcases hw2 with h | h
+          · left; omega
+          · right; omega
+      rw [h_eq, zSupport_rightBdy_card]
+      exact cast_card_two_zmod
+    · apply cast_card_zero_of_eq_empty
+      rw [← Finset.not_nonempty_iff_eq_empty]
+      rintro ⟨w, hw⟩
+      rw [Finset.mem_inter, mem_zSupport_rightBdy_iff,
+        mem_xSupport_interior_iff] at hw
+      obtain ⟨⟨_, hwz2⟩, _, hwx2⟩ := hw
+      rcases hwz2 with h | h <;> rcases hwx2 with h' | h' <;> omega
+  · apply cast_card_zero_of_eq_empty
+    rw [← Finset.not_nonempty_iff_eq_empty]
+    rintro ⟨w, hw⟩
+    rw [Finset.mem_inter, mem_zSupport_rightBdy_iff,
+      mem_xSupport_interior_iff] at hw
+    obtain ⟨⟨hwz1, _⟩, hwx1, _⟩ := hw
+    rcases hwx1 with h | h <;> omega
+
+/-! ### Interior × interior
+
+For two opposite-parity 2×2 faces the intersection is either empty
+(anchors farther than `1` apart) or exactly a 2-qubit shared edge.
+We case-split on `Δa, Δb ∈ {0, ±1}` and dispatch each via
+`Finset.ext` to an explicit two-element finset. -/
+
+/-- Helper: the intersection of the face supports collapses to a 2-qubit
+edge whenever both anchors are within distance `1` (column-wise and
+row-wise).  Used inside the interior-interior proof. -/
+private lemma inter_inter_two_card
+    {α : Type*} [DecidableEq α] {s : Finset α} {q0 q1 : α}
+    (h_eq : s = ({q0, q1} : Finset α)) (hne : q0 ≠ q1) :
+    (s.card : ZMod 2) = 0 :=
+  cast_card_zero_of_eq_pair h_eq hne
+
+private lemma inter_interior_interior_card_even
+    (zc : ZInteriorCornerIdx L) (xc : XInteriorCornerIdx L) :
+    ((zSupport (.interior zc) ∩ xSupport (.interior xc)).card : ZMod 2) = 0 := by
+  have hpz : (zc.val.1.val + zc.val.2.val) % 2 = 0 := zc.property
+  have hpx : (xc.val.1.val + xc.val.2.val) % 2 = 1 := xc.property
+  have hza : zc.val.1.val + 1 < L := by have := zc.val.1.isLt; omega
+  have hzb : zc.val.2.val + 1 < L := by have := zc.val.2.isLt; omega
+  have hxa : xc.val.1.val + 1 < L := by have := xc.val.1.isLt; omega
+  have hxb : xc.val.2.val + 1 < L := by have := xc.val.2.isLt; omega
+  have hzaLo : zc.val.1.val < L := by omega
+  have hzbLo : zc.val.2.val < L := by omega
+  by_cases hcol_far : zc.val.1.val + 2 ≤ xc.val.1.val ∨
+                       xc.val.1.val + 2 ≤ zc.val.1.val
+  · apply cast_card_zero_of_eq_empty
+    rw [← Finset.not_nonempty_iff_eq_empty]
+    rintro ⟨w, hw⟩
+    rw [Finset.mem_inter, mem_zSupport_interior_iff,
+      mem_xSupport_interior_iff] at hw
+    obtain ⟨⟨hwz1, _⟩, hwx1, _⟩ := hw
+    rcases hwz1 with h | h <;> rcases hwx1 with h' | h' <;> omega
+  · push Not at hcol_far
+    by_cases hrow_far : zc.val.2.val + 2 ≤ xc.val.2.val ∨
+                         xc.val.2.val + 2 ≤ zc.val.2.val
+    · apply cast_card_zero_of_eq_empty
+      rw [← Finset.not_nonempty_iff_eq_empty]
+      rintro ⟨w, hw⟩
+      rw [Finset.mem_inter, mem_zSupport_interior_iff,
+        mem_xSupport_interior_iff] at hw
+      obtain ⟨⟨_, hwz2⟩, _, hwx2⟩ := hw
+      rcases hwz2 with h | h <;> rcases hwx2 with h' | h' <;> omega
+    · push Not at hrow_far
+      have hΔa : zc.val.1.val = xc.val.1.val ∨
+                 zc.val.1.val + 1 = xc.val.1.val ∨
+                 zc.val.1.val = xc.val.1.val + 1 := by omega
+      have hΔb : zc.val.2.val = xc.val.2.val ∨
+                 zc.val.2.val + 1 = xc.val.2.val ∨
+                 zc.val.2.val = xc.val.2.val + 1 := by omega
+      rcases hΔa with hda | hda | hda <;>
+        rcases hΔb with hdb | hdb | hdb
+      -- Parity-excluded: (=, =), and (±1, ±1).
+      -- Valid:           (=, +1), (=, -1), (+1, =), (-1, =).
+      all_goals first
+        | (exfalso; omega)
+        | skip
+      -- (Δa, Δb) = (=, +1):  edge at row xc.b = zc.b + 1
+      · -- hda : zc.1.val = xc.1.val, hdb : zc.2.val + 1 = xc.2.val
+        refine cast_card_zero_of_eq_pair (v0 :=
+          ((⟨zc.val.1.val, hzaLo⟩ : Fin L), (⟨zc.val.2.val + 1, hzb⟩ : Fin L)))
+          (v1 :=
+          ((⟨zc.val.1.val + 1, hza⟩ : Fin L), (⟨zc.val.2.val + 1, hzb⟩ : Fin L)))
+          ?_ ?_
+        · ext w
+          obtain ⟨w1, w2⟩ := w
+          simp only [Finset.mem_inter, Finset.mem_insert, Finset.mem_singleton,
+            mem_zSupport_interior_iff, mem_xSupport_interior_iff,
+            Prod.mk.injEq, Fin.ext_iff]
+          constructor
+          · rintro ⟨⟨h1, h2⟩, h1', h2'⟩
+            rcases h2 with hyL | hyL <;>
+              rcases h2' with hyR | hyR <;>
+              rcases h1 with hxL | hxL <;>
+              first
+                | (left; exact ⟨by omega, by omega⟩)
+                | (right; exact ⟨by omega, by omega⟩)
+          · rintro (⟨h1, h2⟩ | ⟨h1, h2⟩) <;>
+              refine ⟨⟨?_, ?_⟩, ?_, ?_⟩ <;> omega
+        · intro h
+          have : zc.val.1.val = zc.val.1.val + 1 := by
+            have hh := congrArg (fun p : VtxIdx L => p.1.val) h
+            simp at hh
+          omega
+      -- (Δa, Δb) = (=, -1):  edge at row zc.b = xc.b + 1
+      · -- hda : zc.1.val = xc.1.val, hdb : zc.2.val = xc.2.val + 1
+        refine cast_card_zero_of_eq_pair (v0 :=
+          ((⟨zc.val.1.val, hzaLo⟩ : Fin L), (⟨zc.val.2.val, hzbLo⟩ : Fin L)))
+          (v1 :=
+          ((⟨zc.val.1.val + 1, hza⟩ : Fin L), (⟨zc.val.2.val, hzbLo⟩ : Fin L)))
+          ?_ ?_
+        · ext w
+          obtain ⟨w1, w2⟩ := w
+          simp only [Finset.mem_inter, Finset.mem_insert, Finset.mem_singleton,
+            mem_zSupport_interior_iff, mem_xSupport_interior_iff,
+            Prod.mk.injEq, Fin.ext_iff]
+          constructor
+          · rintro ⟨⟨h1, h2⟩, h1', h2'⟩
+            rcases h2 with hyL | hyL <;>
+              rcases h2' with hyR | hyR <;>
+              rcases h1 with hxL | hxL <;>
+              first
+                | (left; exact ⟨by omega, by omega⟩)
+                | (right; exact ⟨by omega, by omega⟩)
+          · rintro (⟨h1, h2⟩ | ⟨h1, h2⟩) <;>
+              refine ⟨⟨?_, ?_⟩, ?_, ?_⟩ <;> omega
+        · intro h
+          have : zc.val.1.val = zc.val.1.val + 1 := by
+            have hh := congrArg (fun p : VtxIdx L => p.1.val) h
+            simp at hh
+          omega
+      -- (Δa, Δb) = (+1, =):  edge at column xc.a = zc.a + 1
+      · -- hda : zc.1.val + 1 = xc.1.val, hdb : zc.2.val = xc.2.val
+        refine cast_card_zero_of_eq_pair (v0 :=
+          ((⟨zc.val.1.val + 1, hza⟩ : Fin L), (⟨zc.val.2.val, hzbLo⟩ : Fin L)))
+          (v1 :=
+          ((⟨zc.val.1.val + 1, hza⟩ : Fin L), (⟨zc.val.2.val + 1, hzb⟩ : Fin L)))
+          ?_ ?_
+        · ext w
+          obtain ⟨w1, w2⟩ := w
+          simp only [Finset.mem_inter, Finset.mem_insert, Finset.mem_singleton,
+            mem_zSupport_interior_iff, mem_xSupport_interior_iff,
+            Prod.mk.injEq, Fin.ext_iff]
+          constructor
+          · rintro ⟨⟨h1, h2⟩, h1', h2'⟩
+            rcases h1 with hxL | hxL <;>
+              rcases h1' with hxR | hxR <;>
+              rcases h2 with hyL | hyL <;>
+              first
+                | (left; exact ⟨by omega, by omega⟩)
+                | (right; exact ⟨by omega, by omega⟩)
+          · rintro (⟨h1, h2⟩ | ⟨h1, h2⟩) <;>
+              refine ⟨⟨?_, ?_⟩, ?_, ?_⟩ <;> omega
+        · intro h
+          have : zc.val.2.val = zc.val.2.val + 1 := by
+            have hh := congrArg (fun p : VtxIdx L => p.2.val) h
+            simp at hh
+          omega
+      -- (Δa, Δb) = (-1, =):  edge at column zc.a = xc.a + 1
+      · -- hda : zc.1.val = xc.1.val + 1, hdb : zc.2.val = xc.2.val
+        refine cast_card_zero_of_eq_pair (v0 :=
+          ((⟨zc.val.1.val, hzaLo⟩ : Fin L), (⟨zc.val.2.val, hzbLo⟩ : Fin L)))
+          (v1 :=
+          ((⟨zc.val.1.val, hzaLo⟩ : Fin L), (⟨zc.val.2.val + 1, hzb⟩ : Fin L)))
+          ?_ ?_
+        · ext w
+          obtain ⟨w1, w2⟩ := w
+          simp only [Finset.mem_inter, Finset.mem_insert, Finset.mem_singleton,
+            mem_zSupport_interior_iff, mem_xSupport_interior_iff,
+            Prod.mk.injEq, Fin.ext_iff]
+          constructor
+          · rintro ⟨⟨h1, h2⟩, h1', h2'⟩
+            rcases h1 with hxL | hxL <;>
+              rcases h1' with hxR | hxR <;>
+              rcases h2 with hyL | hyL <;>
+              first
+                | (left; exact ⟨by omega, by omega⟩)
+                | (right; exact ⟨by omega, by omega⟩)
+          · rintro (⟨h1, h2⟩ | ⟨h1, h2⟩) <;>
+              refine ⟨⟨?_, ?_⟩, ?_, ?_⟩ <;> omega
+        · intro h
+          have : zc.val.2.val = zc.val.2.val + 1 := by
+            have hh := congrArg (fun p : VtxIdx L => p.2.val) h
+            simp at hh
+          omega
+
+end InterCard
+
+/-! ## Main chain-complex law -/
+
+/-- For every `(zf, xf)` pair the intersection has even cardinality in
+`ZMod 2`.  Dispatches to the 9 per-case lemmas above. -/
+private lemma inter_card_even {L : ℕ} [Fact (Odd L)]
+    (zf : ZFaceIdx L) (xf : XFaceIdx L) :
+    ((zSupport zf ∩ xSupport xf).card : ZMod 2) = 0 := by
+  cases zf with
+  | interior zc => cases xf with
+    | interior xc => exact inter_interior_interior_card_even zc xc
+    | topBdy k => exact inter_interior_topBdy_card_even zc k
+    | bottomBdy k => exact inter_interior_bottomBdy_card_even zc k
+  | leftBdy k => cases xf with
+    | interior xc => exact inter_leftBdy_interior_card_even k xc
+    | topBdy k' =>
+        exact cast_card_zero_of_eq_empty (inter_leftBdy_topBdy_empty k k')
+    | bottomBdy k' =>
+        exact cast_card_zero_of_eq_empty (inter_leftBdy_bottomBdy_empty k k')
+  | rightBdy k => cases xf with
+    | interior xc => exact inter_rightBdy_interior_card_even k xc
+    | topBdy k' =>
+        exact cast_card_zero_of_eq_empty (inter_rightBdy_topBdy_empty k k')
+    | bottomBdy k' =>
+        exact cast_card_zero_of_eq_empty (inter_rightBdy_bottomBdy_empty k k')
+
+/-- Chain-complex law: `∂₁ ∘ ∂₂ = 0`. -/
+theorem rscBoundary_comp_zero (L : ℕ) [Fact (Odd L)] :
+    (rscBoundary1 L).comp (rscBoundary2 L) = 0 := by
+  ext c zf
+  simp only [LinearMap.comp_apply, rscBoundary1_apply, rscBoundary2_apply,
+    LinearMap.zero_apply, Pi.zero_apply]
+  rw [Finset.sum_comm]
+  refine Finset.sum_eq_zero ?_
+  intro xf _
+  rw [← Finset.mul_sum, sum_indicator_eq_inter_card, inter_card_even, mul_zero]
+
+/-- Pointwise corollary of `rscBoundary_comp_zero`. -/
+theorem rscBoundary_comp_zero_apply (L : ℕ) [Fact (Odd L)]
+    (c : XFaceIdx L → ZMod 2) :
+    rscBoundary1 L (rscBoundary2 L c) = 0 := by
+  have h := congrArg (fun T => T c) (rscBoundary_comp_zero L)
+  simpa using h
+
+end RotatedSurface
+end Lattice
+end Stabilizer
+end Quantum

--- a/QEC/Stabilizer/Lattice/RotatedSurfaceCellComplex.lean
+++ b/QEC/Stabilizer/Lattice/RotatedSurfaceCellComplex.lean
@@ -1,0 +1,191 @@
+import Mathlib.Tactic
+
+/-!
+# Rotated-surface-code cell complex types
+
+Type-level scaffolding for the parametric `RotatedSurfaceCodeN`, paralleling the
+toric `CellComplexTypes`.  For an `L × L` rotated surface code (intended `L`
+odd, `L ≥ 3`):
+
+* `VtxIdx L = Fin L × Fin L` — data qubits, indexed `(x, y)` with `x` the
+  column (`0 = leftmost`) and `y` the row (`0 = topmost`).
+* `ZFaceIdx L` / `XFaceIdx L` — Z- and X-stabilizer slots, each split into
+  three constructors: interior 2×2 face, plus two opposite-edge boundary
+  weight-2 stabs.  Their union has the standard `(L² − 1)/2` count for `L`
+  odd.
+
+The interior face at corner `(x, y) ∈ Fin (L-1) × Fin (L-1)` covers the four
+qubits `(x, y), (x+1, y), (x, y+1), (x+1, y+1)`.  Its colour alternates with
+`(x + y) mod 2`: **Z if even, X if odd**.  Boundary stabs are placed so that
+the checkerboard parity closes up; see `zSupport` / `xSupport` for the exact
+coordinates.
+
+`zSupport zf` / `xSupport xf` return the `Finset` of qubits each stab acts
+on.  These are the building blocks for the boundary maps `rscBoundary1` /
+`rscBoundary2` in `RotatedSurfaceBoundaryMaps.lean`.
+
+## L = 3 sanity check
+
+At `L = 3` the eight stabs collapse to four interior 2×2 faces (two Z, two X)
+and four weight-2 boundary stabs (one each on top/bottom/left/right).  The
+qubit supports (under row-major indexing `(x, y) ↦ y * L + x`) are
+documented case-by-case below; they match the existing
+`RotatedSurfaceCode3.lean` generators **up to a fixed permutation of qubit
+indices**.  The retire-equivalence (Stage 8 of the Phase-3 plan) handles
+that permutation explicitly.
+-/
+
+namespace Quantum
+namespace Stabilizer
+namespace Lattice
+namespace RotatedSurface
+
+open scoped BigOperators
+
+/-- Data qubits on an `L × L` rotated surface code, indexed `(x, y)` with `x`
+the column (`0 = leftmost`) and `y` the row (`0 = topmost`). -/
+abbrev VtxIdx (L : ℕ) : Type := Fin L × Fin L
+
+/-- 1-chains: `ZMod 2`-valued functions on data qubits. -/
+abbrev C1 (L : ℕ) : Type := VtxIdx L → ZMod 2
+
+/-- Top-left corner of an interior 2×2 face.  Such a face covers qubits
+`(x, y), (x+1, y), (x, y+1), (x+1, y+1)`, so `x, y ∈ Fin (L-1)`. -/
+abbrev FaceCornerIdx (L : ℕ) : Type := Fin (L - 1) × Fin (L - 1)
+
+/-- Interior Z-face corners: `(x + y)` even.  Anchored at `(x, y)`. -/
+def ZInteriorCornerIdx (L : ℕ) : Type :=
+  { c : FaceCornerIdx L // (c.1.val + c.2.val) % 2 = 0 }
+
+/-- Interior X-face corners: `(x + y)` odd. -/
+def XInteriorCornerIdx (L : ℕ) : Type :=
+  { c : FaceCornerIdx L // (c.1.val + c.2.val) % 2 = 1 }
+
+instance (L : ℕ) : DecidableEq (ZInteriorCornerIdx L) := Subtype.instDecidableEq
+instance (L : ℕ) : DecidableEq (XInteriorCornerIdx L) := Subtype.instDecidableEq
+instance (L : ℕ) : Fintype (ZInteriorCornerIdx L) := Subtype.fintype _
+instance (L : ℕ) : Fintype (XInteriorCornerIdx L) := Subtype.fintype _
+
+/-- Boundary-stab index for a single rough/smooth edge.  There are
+`(L-1)/2` boundary stabs per side, parameterised here by `Fin ((L-1)/2)`. -/
+abbrev RscBdyIdx (L : ℕ) : Type := Fin ((L - 1) / 2)
+
+/-- Z-stabilizer slots: interior Z-faces ⊕ left-boundary ⊕ right-boundary.
+
+* `interior c` — the 2×2 face anchored at `c`.
+* `leftBdy k` — the weight-2 left-edge stab covering `(0, 2k+1), (0, 2k+2)`.
+* `rightBdy k` — the weight-2 right-edge stab covering `(L-1, 2k), (L-1, 2k+1)`.
+
+The left-right asymmetry (`+1, +2` vs `+0, +1`) keeps the boundary stabs
+parity-aligned with the checkerboard of interior faces.
+-/
+inductive ZFaceIdx (L : ℕ)
+  | interior (c : ZInteriorCornerIdx L) : ZFaceIdx L
+  | leftBdy (k : RscBdyIdx L) : ZFaceIdx L
+  | rightBdy (k : RscBdyIdx L) : ZFaceIdx L
+  deriving DecidableEq
+
+/-- X-stabilizer slots: interior X-faces ⊕ top-boundary ⊕ bottom-boundary.
+
+* `interior c` — the 2×2 face anchored at `c`.
+* `topBdy k` — the weight-2 top-edge stab covering `(2k, 0), (2k+1, 0)`.
+* `bottomBdy k` — the weight-2 bottom-edge stab covering
+  `(2k+1, L-1), (2k+2, L-1)`.
+-/
+inductive XFaceIdx (L : ℕ)
+  | interior (c : XInteriorCornerIdx L) : XFaceIdx L
+  | topBdy (k : RscBdyIdx L) : XFaceIdx L
+  | bottomBdy (k : RscBdyIdx L) : XFaceIdx L
+  deriving DecidableEq
+
+/-- Equivalence to a sum-of-three coproduct, used to derive `Fintype`. -/
+def zFaceIdxEquivSum (L : ℕ) :
+    ZFaceIdx L ≃ (ZInteriorCornerIdx L ⊕ RscBdyIdx L ⊕ RscBdyIdx L) where
+  toFun
+    | .interior c => Sum.inl c
+    | .leftBdy k => Sum.inr (Sum.inl k)
+    | .rightBdy k => Sum.inr (Sum.inr k)
+  invFun
+    | Sum.inl c => .interior c
+    | Sum.inr (Sum.inl k) => .leftBdy k
+    | Sum.inr (Sum.inr k) => .rightBdy k
+  left_inv := by rintro (_ | _ | _) <;> rfl
+  right_inv := by rintro (_ | _ | _) <;> rfl
+
+/-- Equivalence to a sum-of-three coproduct, used to derive `Fintype`. -/
+def xFaceIdxEquivSum (L : ℕ) :
+    XFaceIdx L ≃ (XInteriorCornerIdx L ⊕ RscBdyIdx L ⊕ RscBdyIdx L) where
+  toFun
+    | .interior c => Sum.inl c
+    | .topBdy k => Sum.inr (Sum.inl k)
+    | .bottomBdy k => Sum.inr (Sum.inr k)
+  invFun
+    | Sum.inl c => .interior c
+    | Sum.inr (Sum.inl k) => .topBdy k
+    | Sum.inr (Sum.inr k) => .bottomBdy k
+  left_inv := by rintro (_ | _ | _) <;> rfl
+  right_inv := by rintro (_ | _ | _) <;> rfl
+
+instance (L : ℕ) : Fintype (ZFaceIdx L) :=
+  Fintype.ofEquiv _ (zFaceIdxEquivSum L).symm
+
+instance (L : ℕ) : Fintype (XFaceIdx L) :=
+  Fintype.ofEquiv _ (xFaceIdxEquivSum L).symm
+
+/-- Cast a `Fin (L-1)` index into `Fin L` (low embedding). -/
+@[inline] def cornerLo {L : ℕ} (i : Fin (L - 1)) : Fin L :=
+  ⟨i.val, by have := i.isLt; omega⟩
+
+/-- Cast a `Fin (L-1)` index plus one into `Fin L` (high embedding). -/
+@[inline] def cornerHi {L : ℕ} (i : Fin (L - 1)) : Fin L :=
+  ⟨i.val + 1, by have := i.isLt; omega⟩
+
+/-- The four qubits of the 2×2 face anchored at corner `c`. -/
+def faceQubits {L : ℕ} (c : FaceCornerIdx L) : Finset (VtxIdx L) :=
+  {(cornerLo c.1, cornerLo c.2),
+   (cornerHi c.1, cornerLo c.2),
+   (cornerLo c.1, cornerHi c.2),
+   (cornerHi c.1, cornerHi c.2)}
+
+/-- Qubits acted on by the Z-stabilizer `zf`. -/
+def zSupport {L : ℕ} : ZFaceIdx L → Finset (VtxIdx L)
+  | .interior c => faceQubits c.val
+  | .leftBdy k =>
+      let x0 : Fin L := ⟨0, by have := k.isLt; omega⟩
+      let y1 : Fin L := ⟨2 * k.val + 1, by have := k.isLt; omega⟩
+      let y2 : Fin L := ⟨2 * k.val + 2, by have := k.isLt; omega⟩
+      {(x0, y1), (x0, y2)}
+  | .rightBdy k =>
+      let xR : Fin L := ⟨L - 1, by have := k.isLt; omega⟩
+      let y0 : Fin L := ⟨2 * k.val, by have := k.isLt; omega⟩
+      let y1 : Fin L := ⟨2 * k.val + 1, by have := k.isLt; omega⟩
+      {(xR, y0), (xR, y1)}
+
+/-- Qubits acted on by the X-stabilizer `xf`. -/
+def xSupport {L : ℕ} : XFaceIdx L → Finset (VtxIdx L)
+  | .interior c => faceQubits c.val
+  | .topBdy k =>
+      let y0 : Fin L := ⟨0, by have := k.isLt; omega⟩
+      let x0 : Fin L := ⟨2 * k.val, by have := k.isLt; omega⟩
+      let x1 : Fin L := ⟨2 * k.val + 1, by have := k.isLt; omega⟩
+      {(x0, y0), (x1, y0)}
+  | .bottomBdy k =>
+      let yB : Fin L := ⟨L - 1, by have := k.isLt; omega⟩
+      let x1 : Fin L := ⟨2 * k.val + 1, by have := k.isLt; omega⟩
+      let x2 : Fin L := ⟨2 * k.val + 2, by have := k.isLt; omega⟩
+      {(x1, yB), (x2, yB)}
+
+/-- Membership in the Z-support of an interior face unfolds to the
+explicit four-qubit set. -/
+lemma zSupport_interior {L : ℕ} (c : ZInteriorCornerIdx L) :
+    zSupport (ZFaceIdx.interior c) = faceQubits c.val := rfl
+
+/-- Membership in the X-support of an interior face unfolds to the
+explicit four-qubit set. -/
+lemma xSupport_interior {L : ℕ} (c : XInteriorCornerIdx L) :
+    xSupport (XFaceIdx.interior c) = faceQubits c.val := rfl
+
+end RotatedSurface
+end Lattice
+end Stabilizer
+end Quantum

--- a/QEC/Stabilizer/Lattice/RotatedSurfaceChainComplex.lean
+++ b/QEC/Stabilizer/Lattice/RotatedSurfaceChainComplex.lean
@@ -83,29 +83,33 @@ noncomputable def rscQubitEquiv [Fact (0 < L)] :
 
 /-! ## The `HomologicalCode` instance -/
 
+/-- Positivity of `L` follows from `Fact (3 ≤ L)`.  Registered as an instance
+so the qubit-equivalence and other `[Fact (0 < L)]`-requiring lemmas resolve
+automatically downstream. -/
+instance pos_of_three_le {L : ℕ} [Fact (3 ≤ L)] : Fact (0 < L) :=
+  ⟨lt_of_lt_of_le (by decide : 0 < 3) Fact.out⟩
+
 /-- The rotated-surface-code chain complex packaged as a generic
 `HomologicalCode`.  Consumers of `Homological.HomologicalCode`'s API
 (generic stabilizer construction, CSS distance bridge, etc.) can
 operate on this without re-deriving any lattice-specific facts. -/
 noncomputable def rotatedSurfaceHomologicalCode [Fact (Odd L)] [Fact (3 ≤ L)] :
-    Quantum.Stabilizer.Homological.HomologicalCode := by
-  haveI : Fact (0 < L) := ⟨by have := (Fact.out : (3 ≤ L)); omega⟩
-  exact
-    { C0 := ZFaceIdx L
-      C1 := VtxIdx L
-      C2 := XFaceIdx L
-      decEq0 := inferInstance
-      decEq1 := inferInstance
-      decEq2 := inferInstance
-      fin0 := inferInstance
-      fin1 := inferInstance
-      fin2 := inferInstance
-      boundary1 := rscBoundary1 L
-      boundary2 := rscBoundary2 L
-      boundary_comp := rscBoundary_comp_zero L
-      numQubits := L * L
-      numQubits_eq := by simp [Fintype.card_prod, Fintype.card_fin]
-      edgeEquiv := rscQubitEquiv L }
+    Quantum.Stabilizer.Homological.HomologicalCode where
+  C0 := ZFaceIdx L
+  C1 := VtxIdx L
+  C2 := XFaceIdx L
+  decEq0 := inferInstance
+  decEq1 := inferInstance
+  decEq2 := inferInstance
+  fin0 := inferInstance
+  fin1 := inferInstance
+  fin2 := inferInstance
+  boundary1 := rscBoundary1 L
+  boundary2 := rscBoundary2 L
+  boundary_comp := rscBoundary_comp_zero L
+  numQubits := L * L
+  numQubits_eq := by simp [Fintype.card_prod, Fintype.card_fin]
+  edgeEquiv := rscQubitEquiv L
 
 /-! ## RFL bridges
 

--- a/QEC/Stabilizer/Lattice/RotatedSurfaceChainComplex.lean
+++ b/QEC/Stabilizer/Lattice/RotatedSurfaceChainComplex.lean
@@ -1,0 +1,156 @@
+import Mathlib.Tactic
+import QEC.Stabilizer.Homological
+import QEC.Stabilizer.Lattice.RotatedSurfaceBoundaryMaps
+import QEC.Stabilizer.Lattice.GridIndexing
+
+/-!
+# Rotated-surface-code chain complex as an instance of `HomologicalCode`
+
+Packages the boundary maps `rscBoundary1` / `rscBoundary2` from
+[RotatedSurfaceBoundaryMaps](RotatedSurfaceBoundaryMaps.lean) into a generic
+`HomologicalCode` instance, plus rfl-bridges relating the lattice-specific
+submodules (`rscCycles`, `rscBoundaries`, `rscH1`) to the abstract versions.
+
+The qubit indexing is the standard row-major map `(x, y) ↦ y * L + x`,
+packaged via `rscQubitEquiv` as an `Equiv VtxIdx L ≃ Fin (L * L)`.
+-/
+
+namespace Quantum
+namespace Stabilizer
+namespace Lattice
+namespace RotatedSurface
+
+open scoped BigOperators
+
+/-! ## Lattice-specific cycles / boundaries / `H₁`
+
+These mirror the toric `toricCycles` / `toricBoundaries` / `toricH1`
+definitions, providing a stable API surface for downstream files that
+reason against the rotated-surface chain complex directly. -/
+
+variable (L : ℕ)
+
+/-- 1-cycles: kernel of `∂₁`. -/
+def rscCycles [Fact (Odd L)] : Submodule (ZMod 2) (VtxIdx L → ZMod 2) :=
+  LinearMap.ker (rscBoundary1 L)
+
+/-- 1-boundaries: range of `∂₂`. -/
+def rscBoundaries : Submodule (ZMod 2) (VtxIdx L → ZMod 2) :=
+  LinearMap.range (rscBoundary2 L)
+
+/-- Every boundary is a cycle (`∂₁ ∘ ∂₂ = 0`). -/
+theorem rscBoundaries_le_rscCycles [Fact (Odd L)] :
+    rscBoundaries L ≤ rscCycles L := by
+  intro c hc
+  rcases hc with ⟨f, rfl⟩
+  exact rscBoundary_comp_zero_apply L f
+
+/-- First homology `H₁ = Z₁ / B₁` for the rotated surface code. -/
+abbrev rscH1 [Fact (Odd L)] : Type :=
+  rscCycles L ⧸ Submodule.comap (rscCycles L).subtype (rscBoundaries L)
+
+/-! ## Row-major qubit indexing -/
+
+/-- Row-major qubit indexing: `(x, y) ↦ y * L + x`.  This is the
+canonical bijection `VtxIdx L ≃ Fin (L * L)` and matches the convention
+used elsewhere in the codebase (`Lattice.rowMajor_injective`). -/
+def vtxToQubitIdx (p : VtxIdx L) : Fin (L * L) :=
+  ⟨p.2.val * L + p.1.val, by
+    have h1 := p.1.isLt
+    have h2 := p.2.isLt
+    calc p.2.val * L + p.1.val
+        < p.2.val * L + L := by omega
+      _ = (p.2.val + 1) * L := by ring
+      _ ≤ L * L := Nat.mul_le_mul_right _ h2⟩
+
+@[simp] lemma vtxToQubitIdx_val (p : VtxIdx L) :
+    (vtxToQubitIdx L p).val = p.2.val * L + p.1.val := rfl
+
+lemma vtxToQubitIdx_injective [Fact (0 < L)] :
+    Function.Injective (vtxToQubitIdx L) := by
+  intro p q hpq
+  have h := Fin.mk.inj_iff.mp hpq
+  exact rowMajor_injective L h
+
+/-- The canonical row-major bijection `VtxIdx L ≃ Fin (L * L)`. -/
+noncomputable def rscQubitEquiv [Fact (0 < L)] :
+    VtxIdx L ≃ Fin (L * L) := by
+  have hbij : Function.Bijective (vtxToQubitIdx L) := by
+    rw [Fintype.bijective_iff_injective_and_card]
+    refine ⟨vtxToQubitIdx_injective L, ?_⟩
+    simp [Fintype.card_prod, Fintype.card_fin]
+  exact Equiv.ofBijective _ hbij
+
+/-! ## The `HomologicalCode` instance -/
+
+/-- The rotated-surface-code chain complex packaged as a generic
+`HomologicalCode`.  Consumers of `Homological.HomologicalCode`'s API
+(generic stabilizer construction, CSS distance bridge, etc.) can
+operate on this without re-deriving any lattice-specific facts. -/
+noncomputable def rotatedSurfaceHomologicalCode [Fact (Odd L)] [Fact (3 ≤ L)] :
+    Quantum.Stabilizer.Homological.HomologicalCode := by
+  haveI : Fact (0 < L) := ⟨by have := (Fact.out : (3 ≤ L)); omega⟩
+  exact
+    { C0 := ZFaceIdx L
+      C1 := VtxIdx L
+      C2 := XFaceIdx L
+      decEq0 := inferInstance
+      decEq1 := inferInstance
+      decEq2 := inferInstance
+      fin0 := inferInstance
+      fin1 := inferInstance
+      fin2 := inferInstance
+      boundary1 := rscBoundary1 L
+      boundary2 := rscBoundary2 L
+      boundary_comp := rscBoundary_comp_zero L
+      numQubits := L * L
+      numQubits_eq := by simp [Fintype.card_prod, Fintype.card_fin]
+      edgeEquiv := rscQubitEquiv L }
+
+/-! ## RFL bridges
+
+These all hold definitionally — the proofs are `rfl`.  They give
+downstream code a stable interface for translating between
+lattice-specific and abstract names. -/
+
+variable [Fact (Odd L)] [Fact (3 ≤ L)]
+
+theorem rotatedSurfaceHomologicalCode_C0 :
+    (rotatedSurfaceHomologicalCode L).C0 = ZFaceIdx L := rfl
+
+theorem rotatedSurfaceHomologicalCode_C1 :
+    (rotatedSurfaceHomologicalCode L).C1 = VtxIdx L := rfl
+
+theorem rotatedSurfaceHomologicalCode_C2 :
+    (rotatedSurfaceHomologicalCode L).C2 = XFaceIdx L := rfl
+
+theorem rotatedSurfaceHomologicalCode_boundary1 :
+    (rotatedSurfaceHomologicalCode L).boundary1 = rscBoundary1 L := rfl
+
+theorem rotatedSurfaceHomologicalCode_boundary2 :
+    (rotatedSurfaceHomologicalCode L).boundary2 = rscBoundary2 L := rfl
+
+theorem rotatedSurfaceHomologicalCode_numQubits :
+    (rotatedSurfaceHomologicalCode L).numQubits = L * L := rfl
+
+/-- The lattice-specific 1-cycle submodule equals the generic version. -/
+theorem rotatedSurfaceHomologicalCode_cycles_eq :
+    rscCycles L = (rotatedSurfaceHomologicalCode L).cycles := rfl
+
+/-- The lattice-specific 1-boundary submodule equals the generic version. -/
+theorem rotatedSurfaceHomologicalCode_boundaries_eq :
+    rscBoundaries L = (rotatedSurfaceHomologicalCode L).boundaries := rfl
+
+/-- The lattice-specific `H₁` definition agrees with the generic one. -/
+theorem rotatedSurfaceHomologicalCode_H1_eq :
+    rscH1 L = (rotatedSurfaceHomologicalCode L).H1 := rfl
+
+/-- `boundaries ≤ cycles` follows from the generic chain-complex law. -/
+theorem rotatedSurfaceHomologicalCode_boundaries_le_cycles :
+    rscBoundaries L ≤ rscCycles L :=
+  (rotatedSurfaceHomologicalCode L).boundaries_le_cycles
+
+end RotatedSurface
+end Lattice
+end Stabilizer
+end Quantum

--- a/QEC/Stabilizer/Lattice/RotatedSurfaceH1Dimension.lean
+++ b/QEC/Stabilizer/Lattice/RotatedSurfaceH1Dimension.lean
@@ -1,0 +1,802 @@
+import Mathlib.Tactic
+import Mathlib.LinearAlgebra.Matrix.Rank
+import Mathlib.LinearAlgebra.Matrix.ToLin
+import QEC.Stabilizer.Lattice.RotatedSurfaceChainComplex
+
+/-!
+# `dim H₁ = 1` for the rotated surface code
+
+The rotated surface code at `L × L` (odd `L ≥ 3`) has `dim H₁ = 1` — one
+logical qubit.  The proof rests on the *anchor-qubit* trick:
+
+* Each X-stabiliser has a unique "anchor" qubit (its row-major minimum)
+  that no other X-stabiliser covers.  Hence the X-stab indicator family
+  is linearly independent — `ker rscBoundary2 = ⊥`.
+* The same argument for Z-stabs gives `ker cutMap = ⊥`.
+* Combined with the cardinality identity `|X-stabs| + |Z-stabs| = L² − 1`
+  (for `L` odd) and the abstract rank-nullity from `HomologicalCode`,
+  we conclude `dim H₁ = 1`.
+-/
+
+namespace Quantum
+namespace Stabilizer
+namespace Lattice
+namespace RotatedSurface
+
+open scoped BigOperators
+
+/-! ## Basic ambient facts -/
+
+variable {L : ℕ}
+
+private lemma rsc_facts [Fact (Odd L)] [Fact (3 ≤ L)] :
+    (3 ≤ L) ∧ (L % 2 = 1) ∧ (0 < L) ∧ ((L - 1) % 2 = 0) := by
+  have hLodd : L % 2 = 1 := Nat.odd_iff.mp Fact.out
+  have hLge : 3 ≤ L := Fact.out
+  refine ⟨hLge, hLodd, by omega, ?_⟩
+  omega
+
+/-- `2 * ((L − 1) / 2) = L − 1` when `L` is odd. -/
+private lemma two_mul_half_pred [Fact (Odd L)] : 2 * ((L - 1) / 2) = L - 1 := by
+  have hLodd : L % 2 = 1 := Nat.odd_iff.mp Fact.out
+  have h_pos : 1 ≤ L := by
+    rcases (Fact.out : Odd L) with ⟨m, hm⟩
+    omega
+  have h4 : (L - 1) % 2 = 0 := by omega
+  have hdvd : 2 ∣ (L - 1) := Nat.dvd_of_mod_eq_zero h4
+  rw [Nat.mul_comm]
+  exact Nat.div_mul_cancel hdvd
+
+/-- `2 * k.val + 2 ≤ L − 1` for any boundary index `k`. -/
+private lemma rsc_bdy_idx_lt [Fact (Odd L)] [Fact (3 ≤ L)] (k : RscBdyIdx L) :
+    2 * k.val + 2 ≤ L - 1 := by
+  have hk : k.val < (L - 1) / 2 := k.isLt
+  have h2div : 2 * ((L - 1) / 2) = L - 1 := two_mul_half_pred
+  omega
+
+/-! ## Cardinalities -/
+
+section Cardinality
+
+/-- The Z- and X-interior corner subtypes partition `Fin (L-1) × Fin (L-1)`. -/
+lemma card_ZInteriorCornerIdx_add_card_XInteriorCornerIdx :
+    Fintype.card (ZInteriorCornerIdx L) +
+      Fintype.card (XInteriorCornerIdx L) = (L - 1) ^ 2 := by
+  classical
+  have hz : Fintype.card (ZInteriorCornerIdx L) =
+      (Finset.univ.filter
+        (fun c : Fin (L - 1) × Fin (L - 1) => (c.1.val + c.2.val) % 2 = 0)).card := by
+    simp [ZInteriorCornerIdx, Fintype.card_subtype]
+  have hx : Fintype.card (XInteriorCornerIdx L) =
+      (Finset.univ.filter
+        (fun c : Fin (L - 1) × Fin (L - 1) => (c.1.val + c.2.val) % 2 = 1)).card := by
+    simp [XInteriorCornerIdx, Fintype.card_subtype]
+  rw [hz, hx]
+  have h_compl :
+      (Finset.univ.filter
+          (fun c : Fin (L - 1) × Fin (L - 1) => (c.1.val + c.2.val) % 2 = 1)) =
+        (Finset.univ.filter
+          (fun c : Fin (L - 1) × Fin (L - 1) => ¬ (c.1.val + c.2.val) % 2 = 0)) := by
+    apply Finset.filter_congr
+    intro c _
+    omega
+  rw [h_compl, Finset.card_filter_add_card_filter_not]
+  simp [Fintype.card_prod, Fintype.card_fin, sq]
+
+lemma card_RscBdyIdx : Fintype.card (RscBdyIdx L) = (L - 1) / 2 := by simp [RscBdyIdx]
+
+lemma card_ZFaceIdx_via_equiv :
+    Fintype.card (ZFaceIdx L) =
+      Fintype.card (ZInteriorCornerIdx L) + 2 * ((L - 1) / 2) := by
+  rw [Fintype.card_congr (zFaceIdxEquivSum L), Fintype.card_sum, Fintype.card_sum,
+    card_RscBdyIdx]
+  ring
+
+lemma card_XFaceIdx_via_equiv :
+    Fintype.card (XFaceIdx L) =
+      Fintype.card (XInteriorCornerIdx L) + 2 * ((L - 1) / 2) := by
+  rw [Fintype.card_congr (xFaceIdxEquivSum L), Fintype.card_sum, Fintype.card_sum,
+    card_RscBdyIdx]
+  ring
+
+/-- For `L` odd, `|ZFaceIdx L| + |XFaceIdx L| = L² − 1`. -/
+lemma card_ZFaceIdx_add_card_XFaceIdx [Fact (Odd L)] :
+    Fintype.card (ZFaceIdx L) + Fintype.card (XFaceIdx L) = L * L - 1 := by
+  have hL_odd : L % 2 = 1 := Nat.odd_iff.mp Fact.out
+  have hL_pos : 1 ≤ L := by
+    have : Odd L := Fact.out
+    rcases this with ⟨m, hm⟩
+    omega
+  rw [card_ZFaceIdx_via_equiv, card_XFaceIdx_via_equiv]
+  have hsum :
+      Fintype.card (ZInteriorCornerIdx L) +
+        Fintype.card (XInteriorCornerIdx L) = (L - 1) ^ 2 :=
+    card_ZInteriorCornerIdx_add_card_XInteriorCornerIdx
+  have h_half : 2 * ((L - 1) / 2) = L - 1 := two_mul_half_pred
+  have hL2 : 1 ≤ L * L := by nlinarith [hL_pos]
+  have hexpand : (L - 1) ^ 2 + 2 * (L - 1) = L * L - 1 := by
+    zify [hL_pos, hL2]; ring
+  have hcombine :
+      (Fintype.card (ZInteriorCornerIdx L) + 2 * ((L - 1) / 2)) +
+        (Fintype.card (XInteriorCornerIdx L) + 2 * ((L - 1) / 2)) =
+      (L - 1) ^ 2 + 2 * (L - 1) := by
+    rw [h_half]; linarith
+  rw [hcombine, hexpand]
+
+end Cardinality
+
+/-! ## Finrank of chain spaces -/
+
+lemma rsc_finrank_C1 (L : ℕ) :
+    Module.finrank (ZMod 2) (VtxIdx L → ZMod 2) = L * L := by
+  rw [Module.finrank_fintype_fun_eq_card]
+  simp [VtxIdx, Fintype.card_prod, Fintype.card_fin]
+
+lemma rsc_finrank_C0 (L : ℕ) :
+    Module.finrank (ZMod 2) (ZFaceIdx L → ZMod 2) = Fintype.card (ZFaceIdx L) := by
+  rw [Module.finrank_fintype_fun_eq_card]
+
+lemma rsc_finrank_C2 (L : ℕ) :
+    Module.finrank (ZMod 2) (XFaceIdx L → ZMod 2) = Fintype.card (XFaceIdx L) := by
+  rw [Module.finrank_fintype_fun_eq_card]
+
+/-! ## Anchor-qubit framework
+
+For each X- (resp. Z-) stabilizer we assign a unique "anchor" qubit:
+its lex-minimum supported qubit.  The argument shows that distinct
+stabilisers of the same colour have distinct anchors, each anchor is in
+the corresponding support, and each anchor is the lex-min of its
+support.  This gives a row-echelon decomposition forcing linear
+independence within each colour. -/
+
+/-- Row-major qubit index. -/
+@[reducible] def qubitIdx (v : VtxIdx L) : ℕ := v.2.val * L + v.1.val
+
+lemma qubitIdx_def (v : VtxIdx L) : qubitIdx v = v.2.val * L + v.1.val := rfl
+
+/-- "Anchor" qubit index of an X-stabilizer. -/
+def xAnchorIdx : XFaceIdx L → ℕ
+  | .interior c => c.val.2.val * L + c.val.1.val
+  | .topBdy k => 2 * k.val
+  | .bottomBdy k => (L - 1) * L + 2 * k.val + 1
+
+@[simp] lemma xAnchorIdx_interior (c : XInteriorCornerIdx L) :
+    xAnchorIdx (XFaceIdx.interior c) = c.val.2.val * L + c.val.1.val := rfl
+
+@[simp] lemma xAnchorIdx_topBdy (k : RscBdyIdx L) :
+    xAnchorIdx (XFaceIdx.topBdy k) = 2 * k.val := rfl
+
+@[simp] lemma xAnchorIdx_bottomBdy (k : RscBdyIdx L) :
+    xAnchorIdx (XFaceIdx.bottomBdy k) = (L - 1) * L + 2 * k.val + 1 := rfl
+
+/-- "Anchor" qubit index of a Z-stabilizer. -/
+def zAnchorIdx : ZFaceIdx L → ℕ
+  | .interior c => c.val.2.val * L + c.val.1.val
+  | .leftBdy k => (2 * k.val + 1) * L
+  | .rightBdy k => 2 * k.val * L + (L - 1)
+
+@[simp] lemma zAnchorIdx_interior (c : ZInteriorCornerIdx L) :
+    zAnchorIdx (ZFaceIdx.interior c) = c.val.2.val * L + c.val.1.val := rfl
+
+@[simp] lemma zAnchorIdx_leftBdy (k : RscBdyIdx L) :
+    zAnchorIdx (ZFaceIdx.leftBdy k) = (2 * k.val + 1) * L := rfl
+
+@[simp] lemma zAnchorIdx_rightBdy (k : RscBdyIdx L) :
+    zAnchorIdx (ZFaceIdx.rightBdy k) = 2 * k.val * L + (L - 1) := rfl
+
+/-! ### X-anchor properties -/
+
+variable [Fact (Odd L)] [Fact (3 ≤ L)]
+
+/-- The qubit at `xAnchorIdx xf` is in `xSupport xf`. -/
+lemma xAnchor_mem_xSupport (xf : XFaceIdx L) :
+    ∃ v : VtxIdx L, v ∈ xSupport xf ∧ qubitIdx v = xAnchorIdx xf := by
+  have ⟨h1, h2, h3, h4⟩ := rsc_facts (L := L)
+  cases xf with
+  | interior c =>
+      have h_a : c.val.1.val < L := by have := c.val.1.isLt; omega
+      have h_b : c.val.2.val < L := by have := c.val.2.isLt; omega
+      refine ⟨(⟨c.val.1.val, h_a⟩, ⟨c.val.2.val, h_b⟩), ?_, ?_⟩
+      · rw [xSupport_interior]
+        unfold faceQubits cornerLo cornerHi
+        simp [Finset.mem_insert]
+      · simp [qubitIdx]
+  | topBdy k =>
+      have hk := rsc_bdy_idx_lt k
+      refine ⟨(⟨2 * k.val, by omega⟩, ⟨0, h3⟩), ?_, ?_⟩
+      · rw [mem_xSupport_topBdy_iff]; exact ⟨rfl, Or.inl rfl⟩
+      · simp [qubitIdx]
+  | bottomBdy k =>
+      have hk := rsc_bdy_idx_lt k
+      refine ⟨(⟨2 * k.val + 1, by omega⟩, ⟨L - 1, by omega⟩), ?_, ?_⟩
+      · rw [mem_xSupport_bottomBdy_iff]; exact ⟨rfl, Or.inl rfl⟩
+      · simp [qubitIdx]; ring
+
+/-- Every qubit in `xSupport xf` has `qubitIdx ≥ xAnchorIdx xf`. -/
+lemma xAnchor_le_qubitIdx_of_mem (xf : XFaceIdx L) (v : VtxIdx L)
+    (hv : v ∈ xSupport xf) : xAnchorIdx xf ≤ qubitIdx v := by
+  have ⟨h1, h2, h3, h4⟩ := rsc_facts (L := L)
+  cases xf with
+  | interior c =>
+      rw [xSupport_interior, mem_faceQubits_iff] at hv
+      obtain ⟨hx, hy⟩ := hv
+      simp only [xAnchorIdx_interior, qubitIdx_def]
+      rcases hx with hx | hx <;> rcases hy with hy | hy <;> nlinarith
+  | topBdy k =>
+      rw [mem_xSupport_topBdy_iff] at hv
+      obtain ⟨h_y, h_x⟩ := hv
+      simp only [xAnchorIdx_topBdy, qubitIdx_def]
+      rcases h_x with h | h <;> omega
+  | bottomBdy k =>
+      rw [mem_xSupport_bottomBdy_iff] at hv
+      obtain ⟨h_y, h_x⟩ := hv
+      simp only [xAnchorIdx_bottomBdy, qubitIdx_def]
+      rcases h_x with h | h <;> nlinarith
+
+/-- Distinct X-stabs have distinct anchors. -/
+lemma xAnchorIdx_injective : Function.Injective (xAnchorIdx : XFaceIdx L → ℕ) := by
+  have ⟨h1, h2, h3, h4⟩ := rsc_facts (L := L)
+  intro xf xf' heq
+  cases xf with
+  | interior c => cases xf' with
+    | interior c' =>
+        simp only [xAnchorIdx_interior] at heq
+        have h_a : c.val.1.val < L := by have := c.val.1.isLt; omega
+        have h_a' : c'.val.1.val < L := by have := c'.val.1.isLt; omega
+        -- y*L + x = y'*L + x' with x, x' < L → x = x' ∧ y = y'.
+        have hx_eq : c.val.1.val = c'.val.1.val := by
+          have hmod : (c.val.2.val * L + c.val.1.val) % L =
+              (c'.val.2.val * L + c'.val.1.val) % L := by rw [heq]
+          rw [Nat.add_comm (c.val.2.val * L) c.val.1.val,
+              Nat.add_comm (c'.val.2.val * L) c'.val.1.val,
+              Nat.add_mul_mod_self_right, Nat.add_mul_mod_self_right,
+              Nat.mod_eq_of_lt h_a, Nat.mod_eq_of_lt h_a'] at hmod
+          exact hmod
+        have hy_eq : c.val.2.val = c'.val.2.val := by
+          have : c.val.2.val * L = c'.val.2.val * L := by linarith
+          exact Nat.eq_of_mul_eq_mul_right h3 this
+        congr 1
+        refine Subtype.ext ?_
+        refine Prod.ext ?_ ?_
+        · exact Fin.ext hx_eq
+        · exact Fin.ext hy_eq
+    | topBdy k =>
+        exfalso
+        simp only [xAnchorIdx_interior, xAnchorIdx_topBdy] at heq
+        have hp : (c.val.1.val + c.val.2.val) % 2 = 1 := c.property
+        have h_a := c.val.1.isLt
+        have h_b := c.val.2.isLt
+        have hk := rsc_bdy_idx_lt k
+        -- Case-split on y = 0 or y ≥ 1.
+        rcases Nat.eq_zero_or_pos c.val.2.val with hy | hy
+        · -- y = 0: x = 2k from heq. Parity hp: x odd. 2k even. ⊥.
+          rw [hy] at heq; simp at heq; omega
+        · -- y ≥ 1: y * L ≥ L > 2k.
+          have h_prod : L ≤ c.val.2.val * L := by
+            calc L = 1 * L := (one_mul L).symm
+              _ ≤ c.val.2.val * L := Nat.mul_le_mul_right L hy
+          omega
+    | bottomBdy k =>
+        exfalso
+        simp only [xAnchorIdx_interior, xAnchorIdx_bottomBdy] at heq
+        have h_a := c.val.1.isLt
+        have h_b := c.val.2.isLt
+        have hk := rsc_bdy_idx_lt k
+        -- LHS < (L - 1) * L ≤ RHS, contradicts heq.
+        have h_lhs_bound : c.val.2.val * L + c.val.1.val < (L - 1) * L := by
+          calc c.val.2.val * L + c.val.1.val
+              < c.val.2.val * L + L := by omega
+            _ = (c.val.2.val + 1) * L := by ring
+            _ ≤ (L - 1) * L := Nat.mul_le_mul_right L (by omega)
+        omega
+  | topBdy k => cases xf' with
+    | interior c' =>
+        exfalso
+        simp only [xAnchorIdx_topBdy, xAnchorIdx_interior] at heq
+        have hp : (c'.val.1.val + c'.val.2.val) % 2 = 1 := c'.property
+        have h_a := c'.val.1.isLt
+        have h_b := c'.val.2.isLt
+        have hk := rsc_bdy_idx_lt k
+        rcases Nat.eq_zero_or_pos c'.val.2.val with hy | hy
+        · rw [hy] at heq; simp at heq; omega
+        · have h_prod : L ≤ c'.val.2.val * L := by
+            calc L = 1 * L := (one_mul L).symm
+              _ ≤ c'.val.2.val * L := Nat.mul_le_mul_right L hy
+          omega
+    | topBdy k' =>
+        simp only [xAnchorIdx_topBdy] at heq
+        congr 1
+        ext
+        omega
+    | bottomBdy k' =>
+        exfalso
+        simp only [xAnchorIdx_topBdy, xAnchorIdx_bottomBdy] at heq
+        have hk := rsc_bdy_idx_lt k
+        have hk' := rsc_bdy_idx_lt k'
+        -- top idx = 2k < L, but bottom idx = (L-1)*L + ... ≥ (L-1)*L ≥ L.
+        have h_prod : L ≤ (L - 1) * L := by
+          have := Nat.mul_le_mul_right L (show 1 ≤ L - 1 from by omega)
+          linarith
+        omega
+  | bottomBdy k => cases xf' with
+    | interior c' =>
+        exfalso
+        simp only [xAnchorIdx_bottomBdy, xAnchorIdx_interior] at heq
+        have h_a := c'.val.1.isLt
+        have h_b := c'.val.2.isLt
+        have hk := rsc_bdy_idx_lt k
+        have h_rhs_bound : c'.val.2.val * L + c'.val.1.val < (L - 1) * L := by
+          calc c'.val.2.val * L + c'.val.1.val
+              < c'.val.2.val * L + L := by omega
+            _ = (c'.val.2.val + 1) * L := by ring
+            _ ≤ (L - 1) * L := Nat.mul_le_mul_right L (by omega)
+        omega
+    | topBdy k' =>
+        exfalso
+        simp only [xAnchorIdx_bottomBdy, xAnchorIdx_topBdy] at heq
+        have hk := rsc_bdy_idx_lt k
+        have hk' := rsc_bdy_idx_lt k'
+        have h_prod : L ≤ (L - 1) * L := by
+          have := Nat.mul_le_mul_right L (show 1 ≤ L - 1 from by omega)
+          linarith
+        omega
+    | bottomBdy k' =>
+        simp only [xAnchorIdx_bottomBdy] at heq
+        congr 1
+        ext
+        omega
+
+/-! ### Z-anchor properties -/
+
+lemma zAnchor_mem_zSupport (zf : ZFaceIdx L) :
+    ∃ v : VtxIdx L, v ∈ zSupport zf ∧ qubitIdx v = zAnchorIdx zf := by
+  have ⟨h1, h2, h3, h4⟩ := rsc_facts (L := L)
+  cases zf with
+  | interior c =>
+      have h_a : c.val.1.val < L := by have := c.val.1.isLt; omega
+      have h_b : c.val.2.val < L := by have := c.val.2.isLt; omega
+      refine ⟨(⟨c.val.1.val, h_a⟩, ⟨c.val.2.val, h_b⟩), ?_, ?_⟩
+      · rw [zSupport_interior]
+        unfold faceQubits cornerLo cornerHi
+        simp [Finset.mem_insert]
+      · simp [qubitIdx]
+  | leftBdy k =>
+      have hk := rsc_bdy_idx_lt k
+      refine ⟨(⟨0, h3⟩, ⟨2 * k.val + 1, by omega⟩), ?_, ?_⟩
+      · rw [mem_zSupport_leftBdy_iff]; exact ⟨rfl, Or.inl rfl⟩
+      · simp [qubitIdx]
+  | rightBdy k =>
+      have hk := rsc_bdy_idx_lt k
+      refine ⟨(⟨L - 1, by omega⟩, ⟨2 * k.val, by omega⟩), ?_, ?_⟩
+      · rw [mem_zSupport_rightBdy_iff]; exact ⟨rfl, Or.inl rfl⟩
+      · simp [qubitIdx]
+
+lemma zAnchor_le_qubitIdx_of_mem (zf : ZFaceIdx L) (v : VtxIdx L)
+    (hv : v ∈ zSupport zf) : zAnchorIdx zf ≤ qubitIdx v := by
+  have ⟨h1, h2, h3, h4⟩ := rsc_facts (L := L)
+  cases zf with
+  | interior c =>
+      rw [zSupport_interior, mem_faceQubits_iff] at hv
+      obtain ⟨hx, hy⟩ := hv
+      simp only [zAnchorIdx_interior, qubitIdx_def]
+      rcases hx with hx | hx <;> rcases hy with hy | hy <;> nlinarith
+  | leftBdy k =>
+      rw [mem_zSupport_leftBdy_iff] at hv
+      obtain ⟨h_x, h_y⟩ := hv
+      simp only [zAnchorIdx_leftBdy, qubitIdx_def]
+      rcases h_y with h | h <;> nlinarith
+  | rightBdy k =>
+      rw [mem_zSupport_rightBdy_iff] at hv
+      obtain ⟨h_x, h_y⟩ := hv
+      simp only [zAnchorIdx_rightBdy, qubitIdx_def]
+      rcases h_y with h | h <;> nlinarith
+
+lemma zAnchorIdx_injective : Function.Injective (zAnchorIdx : ZFaceIdx L → ℕ) := by
+  have ⟨h1, h2, h3, h4⟩ := rsc_facts (L := L)
+  intro zf zf' heq
+  cases zf with
+  | interior c => cases zf' with
+    | interior c' =>
+        simp only [zAnchorIdx_interior] at heq
+        have h_a : c.val.1.val < L := by have := c.val.1.isLt; omega
+        have h_a' : c'.val.1.val < L := by have := c'.val.1.isLt; omega
+        have hx_eq : c.val.1.val = c'.val.1.val := by
+          have hmod : (c.val.2.val * L + c.val.1.val) % L =
+              (c'.val.2.val * L + c'.val.1.val) % L := by rw [heq]
+          rw [Nat.add_comm (c.val.2.val * L) c.val.1.val,
+              Nat.add_comm (c'.val.2.val * L) c'.val.1.val,
+              Nat.add_mul_mod_self_right, Nat.add_mul_mod_self_right,
+              Nat.mod_eq_of_lt h_a, Nat.mod_eq_of_lt h_a'] at hmod
+          exact hmod
+        have hy_eq : c.val.2.val = c'.val.2.val := by
+          have : c.val.2.val * L = c'.val.2.val * L := by linarith
+          exact Nat.eq_of_mul_eq_mul_right h3 this
+        congr 1
+        refine Subtype.ext ?_
+        refine Prod.ext ?_ ?_
+        · exact Fin.ext hx_eq
+        · exact Fin.ext hy_eq
+    | leftBdy k =>
+        -- interior z (parity even): y*L + x.  leftBdy: (2k+1)*L.
+        -- For equal: y*L + x = (2k+1)*L. So x = (2k+1-y)*L. With x < L,
+        -- need 2k+1 = y (so x = 0). Then y odd. But interior z has x+y even,
+        -- so x = 0 and y odd gives x+y odd. Contradiction.
+        exfalso
+        simp only [zAnchorIdx_interior, zAnchorIdx_leftBdy] at heq
+        have hp : (c.val.1.val + c.val.2.val) % 2 = 0 := c.property
+        have h_a := c.val.1.isLt
+        have h_b := c.val.2.isLt
+        have hk := rsc_bdy_idx_lt k
+        -- Case: c.val.1.val = 0 or > 0.
+        rcases Nat.eq_zero_or_pos c.val.1.val with hx | hx
+        · -- x = 0: heq says y*L = (2k+1)*L, so y = 2k+1. Parity: x+y = 2k+1 odd. ⊥.
+          rw [hx] at heq
+          have : c.val.2.val = 2 * k.val + 1 := by
+            have hy_eq : c.val.2.val * L = (2 * k.val + 1) * L := by linarith
+            exact Nat.eq_of_mul_eq_mul_right h3 hy_eq
+          omega
+        · -- x ≥ 1: y*L + x ≠ (2k+1)*L (multiple of L) since x < L.
+          have hmod : (c.val.2.val * L + c.val.1.val) % L = ((2 * k.val + 1) * L) % L := by
+            rw [heq]
+          rw [Nat.add_comm (c.val.2.val * L) c.val.1.val,
+              Nat.add_mul_mod_self_right, Nat.mul_mod_left,
+              Nat.mod_eq_of_lt (by omega : c.val.1.val < L)] at hmod
+          omega
+    | rightBdy k =>
+        -- interior z: y*L + x.  rightBdy: 2k*L + (L-1).
+        -- mod L: x = L-1. But x ∈ Fin (L-1), x < L-1.
+        exfalso
+        simp only [zAnchorIdx_interior, zAnchorIdx_rightBdy] at heq
+        have h_a := c.val.1.isLt
+        have hk := rsc_bdy_idx_lt k
+        have hmod : (c.val.2.val * L + c.val.1.val) % L =
+            (2 * k.val * L + (L - 1)) % L := by rw [heq]
+        rw [Nat.add_comm (c.val.2.val * L) c.val.1.val,
+            Nat.add_mul_mod_self_right, Nat.add_comm (2 * k.val * L) (L - 1),
+            Nat.add_mul_mod_self_right, Nat.mod_eq_of_lt (by omega : c.val.1.val < L),
+            Nat.mod_eq_of_lt (by omega : L - 1 < L)] at hmod
+        omega
+  | leftBdy k => cases zf' with
+    | interior c' =>
+        exfalso
+        simp only [zAnchorIdx_leftBdy, zAnchorIdx_interior] at heq
+        have hp : (c'.val.1.val + c'.val.2.val) % 2 = 0 := c'.property
+        have h_a := c'.val.1.isLt
+        have h_b := c'.val.2.isLt
+        have hk := rsc_bdy_idx_lt k
+        rcases Nat.eq_zero_or_pos c'.val.1.val with hx | hx
+        · rw [hx] at heq
+          have : c'.val.2.val = 2 * k.val + 1 := by
+            have hy_eq : (2 * k.val + 1) * L = c'.val.2.val * L := by linarith
+            exact Nat.eq_of_mul_eq_mul_right h3 hy_eq.symm
+          omega
+        · have hmod : ((2 * k.val + 1) * L) % L =
+              (c'.val.2.val * L + c'.val.1.val) % L := by rw [heq]
+          rw [Nat.add_comm (c'.val.2.val * L) c'.val.1.val,
+              Nat.add_mul_mod_self_right, Nat.mul_mod_left,
+              Nat.mod_eq_of_lt (by omega : c'.val.1.val < L)] at hmod
+          omega
+    | leftBdy k' =>
+        simp only [zAnchorIdx_leftBdy] at heq
+        have : 2 * k.val + 1 = 2 * k'.val + 1 :=
+          Nat.eq_of_mul_eq_mul_right h3 heq
+        congr 1
+        ext
+        omega
+    | rightBdy k' =>
+        -- leftBdy: (2k+1)*L mod L = 0. rightBdy: 2k'*L + L-1 mod L = L-1 ≠ 0.
+        exfalso
+        simp only [zAnchorIdx_leftBdy, zAnchorIdx_rightBdy] at heq
+        have hk := rsc_bdy_idx_lt k
+        have hk' := rsc_bdy_idx_lt k'
+        have hmod : ((2 * k.val + 1) * L) % L =
+            (2 * k'.val * L + (L - 1)) % L := by rw [heq]
+        rw [show ((2 * k.val + 1) * L : ℕ) = 0 + (2 * k.val + 1) * L from by ring,
+            Nat.add_mul_mod_self_right, Nat.zero_mod,
+            Nat.add_comm (2 * k'.val * L) (L - 1),
+            Nat.add_mul_mod_self_right,
+            Nat.mod_eq_of_lt (by omega : L - 1 < L)] at hmod
+        omega
+  | rightBdy k => cases zf' with
+    | interior c' =>
+        exfalso
+        simp only [zAnchorIdx_rightBdy, zAnchorIdx_interior] at heq
+        have h_a := c'.val.1.isLt
+        have hk := rsc_bdy_idx_lt k
+        have hmod : (2 * k.val * L + (L - 1)) % L =
+            (c'.val.2.val * L + c'.val.1.val) % L := by rw [heq]
+        rw [Nat.add_comm (2 * k.val * L) (L - 1), Nat.add_mul_mod_self_right,
+            Nat.add_comm (c'.val.2.val * L) c'.val.1.val,
+            Nat.add_mul_mod_self_right,
+            Nat.mod_eq_of_lt (by omega : L - 1 < L),
+            Nat.mod_eq_of_lt (by omega : c'.val.1.val < L)] at hmod
+        omega
+    | leftBdy k' =>
+        exfalso
+        simp only [zAnchorIdx_rightBdy, zAnchorIdx_leftBdy] at heq
+        have hk := rsc_bdy_idx_lt k
+        have hk' := rsc_bdy_idx_lt k'
+        have hmod : (2 * k.val * L + (L - 1)) % L =
+            ((2 * k'.val + 1) * L) % L := by rw [heq]
+        rw [Nat.add_comm (2 * k.val * L) (L - 1), Nat.add_mul_mod_self_right,
+            show ((2 * k'.val + 1) * L : ℕ) = 0 + (2 * k'.val + 1) * L from by ring,
+            Nat.add_mul_mod_self_right, Nat.zero_mod,
+            Nat.mod_eq_of_lt (by omega : L - 1 < L)] at hmod
+        omega
+    | rightBdy k' =>
+        simp only [zAnchorIdx_rightBdy] at heq
+        have : 2 * k.val * L = 2 * k'.val * L := by linarith
+        have h_kk : 2 * k.val = 2 * k'.val := Nat.eq_of_mul_eq_mul_right h3 this
+        congr 1
+        ext
+        omega
+
+/-! ## ker(`rscBoundary2`) = ⊥
+
+Combining the X-anchor properties, the indicator family of X-stabs is
+linearly independent, so the boundary map `∂₂` is injective. -/
+
+theorem rscBoundary2_injective : Function.Injective (rscBoundary2 L) := by
+  rw [← LinearMap.ker_eq_bot, Submodule.eq_bot_iff]
+  intro f hf
+  simp only [LinearMap.mem_ker] at hf
+  funext xf
+  by_contra hne
+  let S : Finset (XFaceIdx L) := Finset.univ.filter (fun xf' => f xf' ≠ 0)
+  have hS_ne : S.Nonempty := ⟨xf, Finset.mem_filter.mpr ⟨Finset.mem_univ _, hne⟩⟩
+  obtain ⟨xf_min, hxf_min_mem, hxf_min_min⟩ :=
+    S.exists_min_image xAnchorIdx hS_ne
+  have hxf_min_ne : f xf_min ≠ 0 := (Finset.mem_filter.mp hxf_min_mem).2
+  obtain ⟨v_min, hv_min_supp, hv_min_idx⟩ := xAnchor_mem_xSupport xf_min
+  have hval : (rscBoundary2 L f) v_min = f xf_min := by
+    rw [rscBoundary2_apply, Finset.sum_eq_single xf_min]
+    · simp [hv_min_supp]
+    · intro xf' _ hne'
+      by_cases hf' : f xf' = 0
+      · simp [hf']
+      · have hxf'_in : xf' ∈ S := Finset.mem_filter.mpr ⟨Finset.mem_univ _, hf'⟩
+        have hge := hxf_min_min xf' hxf'_in
+        have hlt : xAnchorIdx xf_min < xAnchorIdx xf' := by
+          apply lt_of_le_of_ne hge
+          intro h
+          exact hne' (xAnchorIdx_injective h.symm)
+        have hnotin : v_min ∉ xSupport xf' := by
+          intro hv_in
+          have := xAnchor_le_qubitIdx_of_mem xf' v_min hv_in
+          omega
+        simp [hnotin]
+    · intro h; exact absurd (Finset.mem_univ xf_min) h
+  have : (rscBoundary2 L f) v_min = 0 := by rw [hf]; rfl
+  rw [hval] at this
+  exact hxf_min_ne this
+
+/-- The kernel of `rscBoundary2` is `⊥`. -/
+theorem rscBoundary2_ker_eq_bot :
+    LinearMap.ker (rscBoundary2 L) = ⊥ := by
+  rw [LinearMap.ker_eq_bot]
+  exact rscBoundary2_injective
+
+/-- `rank(∂₂) = |XFaceIdx L|`. -/
+theorem rsc_rank_boundary2 :
+    Module.finrank (ZMod 2) (LinearMap.range (rscBoundary2 L)) =
+      Fintype.card (XFaceIdx L) := by
+  have hrn := LinearMap.finrank_range_add_finrank_ker (rscBoundary2 L)
+  rw [show Module.finrank (ZMod 2) (LinearMap.ker (rscBoundary2 L)) = 0 from ?_] at hrn
+  · rw [rsc_finrank_C2] at hrn
+    omega
+  · rw [rscBoundary2_ker_eq_bot]
+    exact finrank_bot (ZMod 2) (XFaceIdx L → ZMod 2)
+
+/-! ## The Z-side cut map and its kernel
+
+The map `rscZCutMap`: `s : ZFaceIdx → ZMod 2` ↦ `(v : VtxIdx) ↦ ∑_{zf ∋ v} s zf`.
+This is the indicator-combination map for Z-stabilisers, dual to `rscBoundary1`
+in the transpose sense. -/
+
+/-- The Z-stab indicator combination map. -/
+def rscZCutMap (L : ℕ) :
+    (ZFaceIdx L → ZMod 2) →ₗ[ZMod 2] (VtxIdx L → ZMod 2) where
+  toFun s v := ∑ zf : ZFaceIdx L, s zf * (if v ∈ zSupport zf then 1 else 0)
+  map_add' s t := by
+    funext v
+    simp only [Pi.add_apply, add_mul, Finset.sum_add_distrib]
+  map_smul' a s := by
+    funext v
+    simp only [RingHom.id_apply, Pi.smul_apply, smul_eq_mul, Finset.mul_sum, mul_assoc]
+
+@[simp] theorem rscZCutMap_apply (L : ℕ) (s : ZFaceIdx L → ZMod 2) (v : VtxIdx L) :
+    rscZCutMap L s v =
+      ∑ zf : ZFaceIdx L, s zf * (if v ∈ zSupport zf then 1 else 0) := rfl
+
+theorem rscZCutMap_injective : Function.Injective (rscZCutMap L) := by
+  rw [← LinearMap.ker_eq_bot, Submodule.eq_bot_iff]
+  intro s hs
+  simp only [LinearMap.mem_ker] at hs
+  funext zf
+  by_contra hne
+  let S : Finset (ZFaceIdx L) := Finset.univ.filter (fun zf' => s zf' ≠ 0)
+  have hS_ne : S.Nonempty := ⟨zf, Finset.mem_filter.mpr ⟨Finset.mem_univ _, hne⟩⟩
+  obtain ⟨zf_min, hzf_min_mem, hzf_min_min⟩ :=
+    S.exists_min_image zAnchorIdx hS_ne
+  have hzf_min_ne : s zf_min ≠ 0 := (Finset.mem_filter.mp hzf_min_mem).2
+  obtain ⟨v_min, hv_min_supp, hv_min_idx⟩ := zAnchor_mem_zSupport zf_min
+  have hval : (rscZCutMap L s) v_min = s zf_min := by
+    rw [rscZCutMap_apply, Finset.sum_eq_single zf_min]
+    · simp [hv_min_supp]
+    · intro zf' _ hne'
+      by_cases hs' : s zf' = 0
+      · simp [hs']
+      · have hzf'_in : zf' ∈ S := Finset.mem_filter.mpr ⟨Finset.mem_univ _, hs'⟩
+        have hge := hzf_min_min zf' hzf'_in
+        have hlt : zAnchorIdx zf_min < zAnchorIdx zf' := by
+          apply lt_of_le_of_ne hge
+          intro h
+          exact hne' (zAnchorIdx_injective h.symm)
+        have hnotin : v_min ∉ zSupport zf' := by
+          intro hv_in
+          have := zAnchor_le_qubitIdx_of_mem zf' v_min hv_in
+          omega
+        simp [hnotin]
+    · intro h; exact absurd (Finset.mem_univ zf_min) h
+  have : (rscZCutMap L s) v_min = 0 := by rw [hs]; rfl
+  rw [hval] at this
+  exact hzf_min_ne this
+
+theorem rscZCutMap_ker_eq_bot : LinearMap.ker (rscZCutMap L) = ⊥ := by
+  rw [LinearMap.ker_eq_bot]; exact rscZCutMap_injective
+
+/-- `rank(rscZCutMap) = |ZFaceIdx L|`. -/
+theorem rsc_rank_zCutMap :
+    Module.finrank (ZMod 2) (LinearMap.range (rscZCutMap L)) =
+      Fintype.card (ZFaceIdx L) := by
+  have hrn := LinearMap.finrank_range_add_finrank_ker (rscZCutMap L)
+  rw [show Module.finrank (ZMod 2) (LinearMap.ker (rscZCutMap L)) = 0 from ?_] at hrn
+  · rw [rsc_finrank_C0] at hrn
+    omega
+  · rw [rscZCutMap_ker_eq_bot]
+    exact finrank_bot (ZMod 2) (ZFaceIdx L → ZMod 2)
+
+/-! ## Transpose pairing of `rscBoundary1` and `rscZCutMap`
+
+The standard pairing `⟨∂₁ c, s⟩ = ⟨c, rscZCutMap s⟩` identifies the two
+maps as mutual transposes, so they share the same rank. -/
+
+theorem rscBoundary1_rscZCutMap_transpose
+    (c : VtxIdx L → ZMod 2) (s : ZFaceIdx L → ZMod 2) :
+    ∑ zf : ZFaceIdx L, rscBoundary1 L c zf * s zf =
+      ∑ v : VtxIdx L, c v * rscZCutMap L s v := by
+  simp only [rscBoundary1_apply, rscZCutMap_apply]
+  -- Helper: ∑ v ∈ zSupport zf, c v * s zf = ∑ v, if v ∈ zSupport zf then c v * s zf else 0.
+  have hsplit : ∀ zf : ZFaceIdx L,
+      (∑ v ∈ zSupport zf, c v * s zf) =
+        ∑ v : VtxIdx L, (if v ∈ zSupport zf then c v * s zf else 0) := by
+    intro zf
+    rw [← Finset.sum_filter]
+    apply Finset.sum_congr _ (fun _ _ => rfl)
+    ext v
+    simp
+  -- Convert both to a common form: ∑ v, ∑ zf, (if v ∈ zSupport zf then c v * s zf else 0).
+  trans (∑ v : VtxIdx L, ∑ zf : ZFaceIdx L,
+      (if v ∈ zSupport zf then c v * s zf else (0 : ZMod 2)))
+  · rw [Finset.sum_comm]
+    refine Finset.sum_congr rfl ?_
+    intro zf _
+    rw [Finset.sum_mul, hsplit]
+  · refine Finset.sum_congr rfl ?_
+    intro v _
+    rw [Finset.mul_sum]
+    refine Finset.sum_congr rfl ?_
+    intro zf _
+    split_ifs <;> ring
+
+/-! ## Rank equality via the Z-stab incidence matrix
+
+`rscBoundary1` and `rscZCutMap` are mutual transposes (the indicator
+matrix of Z-stabs).  Using `Matrix.rank_transpose` we get the rank
+equality `rank ∂₁ = rank rscZCutMap`. -/
+
+/-- The Z-stab incidence matrix: entry `(zf, v)` is `1` iff `v ∈ zSupport zf`. -/
+def stabZMatrix (L : ℕ) : Matrix (ZFaceIdx L) (VtxIdx L) (ZMod 2) :=
+  fun zf v => if v ∈ zSupport zf then 1 else 0
+
+lemma rscBoundary1_eq_mulVecLin :
+    rscBoundary1 L = (stabZMatrix L).mulVecLin := by
+  apply LinearMap.ext
+  intro c
+  funext zf
+  rw [rscBoundary1_apply, Matrix.mulVecLin_apply, Matrix.mulVec, dotProduct]
+  simp only [stabZMatrix]
+  -- Goal: ∑ v ∈ zSupport zf, c v = ∑ v, (if v ∈ zSupport zf then 1 else 0) * c v
+  rw [show (fun v : VtxIdx L => (if v ∈ zSupport zf then (1 : ZMod 2) else 0) * c v) =
+        (fun v => if v ∈ zSupport zf then c v else 0) from
+    funext fun v => by split_ifs <;> simp]
+  rw [← Finset.sum_filter]
+  apply Finset.sum_congr _ (fun _ _ => rfl)
+  ext v; simp
+
+lemma rscZCutMap_eq_transpose_mulVecLin :
+    rscZCutMap L = (stabZMatrix L).transpose.mulVecLin := by
+  apply LinearMap.ext
+  intro s
+  funext v
+  rw [rscZCutMap_apply, Matrix.mulVecLin_apply, Matrix.mulVec, dotProduct]
+  simp only [stabZMatrix, Matrix.transpose_apply]
+  apply Finset.sum_congr rfl
+  intro zf _
+  ring
+
+/-- `rank(∂₁) = rank(rscZCutMap)` via matrix transpose-rank. -/
+theorem rsc_rank_boundary1_eq_rank_zCutMap :
+    Module.finrank (ZMod 2) (LinearMap.range (rscBoundary1 L)) =
+      Module.finrank (ZMod 2) (LinearMap.range (rscZCutMap L)) := by
+  rw [rscBoundary1_eq_mulVecLin, rscZCutMap_eq_transpose_mulVecLin]
+  show Matrix.rank (stabZMatrix L) = Matrix.rank (stabZMatrix L).transpose
+  rw [Matrix.rank_transpose]
+
+/-- `rank(∂₁) = |ZFaceIdx L|`. -/
+theorem rsc_rank_boundary1 :
+    Module.finrank (ZMod 2) (LinearMap.range (rscBoundary1 L)) =
+      Fintype.card (ZFaceIdx L) := by
+  rw [rsc_rank_boundary1_eq_rank_zCutMap, rsc_rank_zCutMap]
+
+/-! ## The dim H₁ = 1 theorem -/
+
+/-- `dim(cycles) = L * L − |ZFaceIdx L|`. -/
+theorem rsc_finrank_cycles :
+    Module.finrank (ZMod 2) (rscCycles L) =
+      L * L - Fintype.card (ZFaceIdx L) := by
+  have hrn := LinearMap.finrank_range_add_finrank_ker (rscBoundary1 L)
+  rw [rsc_finrank_C1, rsc_rank_boundary1] at hrn
+  -- finrank C1 (= L*L) = rank(∂₁) + dim ker = |ZFaceIdx| + dim ker
+  -- dim Z₁ = dim ker (rscBoundary1) = L*L - |ZFaceIdx|
+  have hrange_le : Fintype.card (ZFaceIdx L) ≤ L * L := by
+    have := card_ZFaceIdx_add_card_XFaceIdx (L := L)
+    have hLpos : 1 ≤ L := by
+      rcases (Fact.out : Odd L) with ⟨m, hm⟩
+      omega
+    have hLL : 1 ≤ L * L := by nlinarith
+    omega
+  -- rscCycles = ker rscBoundary1
+  show Module.finrank (ZMod 2) (LinearMap.ker (rscBoundary1 L)) = _
+  omega
+
+/-- `dim(boundaries) = |XFaceIdx L|`. -/
+theorem rsc_finrank_boundaries :
+    Module.finrank (ZMod 2) (rscBoundaries L) = Fintype.card (XFaceIdx L) := by
+  show Module.finrank (ZMod 2) (LinearMap.range (rscBoundary2 L)) = _
+  exact rsc_rank_boundary2
+
+/-- `dim(H₁) = 1` for the rotated surface code. -/
+theorem rsc_finrank_H1_eq_one :
+    Module.finrank (ZMod 2) (rscH1 L) = 1 := by
+  -- The generic quotient-dimension formula on the HomologicalCode side.
+  have hquot := (rotatedSurfaceHomologicalCode L).finrank_H1_eq_cycles_sub_boundaries
+  -- Convert from generic cycles/boundaries to lattice-specific via the rfl-bridges.
+  have hC : Module.finrank (ZMod 2) ((rotatedSurfaceHomologicalCode L).cycles) =
+      L * L - Fintype.card (ZFaceIdx L) := by
+    show Module.finrank (ZMod 2) (rscCycles L) = _
+    exact rsc_finrank_cycles
+  have hB : Module.finrank (ZMod 2) ((rotatedSurfaceHomologicalCode L).boundaries) =
+      Fintype.card (XFaceIdx L) := by
+    show Module.finrank (ZMod 2) (rscBoundaries L) = _
+    exact rsc_finrank_boundaries
+  rw [hC, hB] at hquot
+  -- The two finrank forms (lattice vs generic) agree by defeq.
+  have h_targ : Module.finrank (ZMod 2) (rscH1 L) =
+      @Module.finrank (ZMod 2) (rotatedSurfaceHomologicalCode L).H1 _
+        (Submodule.Quotient.addCommGroup
+          (rotatedSurfaceHomologicalCode L).boundarySubmoduleInCycles).toAddCommMonoid
+        (Submodule.Quotient.module
+          (rotatedSurfaceHomologicalCode L).boundarySubmoduleInCycles) := rfl
+  rw [h_targ, hquot]
+  have hcard := card_ZFaceIdx_add_card_XFaceIdx (L := L)
+  have hLpos : 1 ≤ L := by
+    rcases (Fact.out : Odd L) with ⟨m, hm⟩
+    omega
+  have hLL : 1 ≤ L * L := by nlinarith
+  omega
+
+end RotatedSurface
+end Lattice
+end Stabilizer
+end Quantum


### PR DESCRIPTION
## Summary
- Adds a parametric `RotatedSurfaceCodeN` formalization for odd `L ≥ 3`, realizing the `[[L², 1, L]]` CSS code as `StabilizerCode (L*L) 1` with proven code distance exactly `L`.
- Builds the rotated-surface chain complex `XFaceIdx →∂₂ VtxIdx →∂₁ ZFaceIdx` over `ZMod 2`, packages it as a `HomologicalCode`, proves `dim H₁ = 1` (single logical qubit), and proves the X- and Z-distance bounds plus the CSS combined-distance bridge.
- **Lifts the CSS-bridge machinery (centralizer→cycle, weight↔chainWeight, qubit-wise anticommutation pattern matching) to the abstract `HomologicalCode` framework**, then refactors *both* toric and RSC distance files to delegate to it.  Result: net **−525 lines** across the two distance files, with the framework gaining the reusable bridge.

## What's the "abstraction does real work" evidence

Before this PR, the toric distance file (`ToricCodeNDistance.lean`) contained ~14 local helpers that re-derived the CSS bridge (centralizer ⇒ cycles, weight ↔ chainWeight, qubit-wise anticommutation match, "not both boundary").  Adding the RSC required either duplicating those helpers or lifting them.

This PR does the latter.  The four new generic lemma groups in `QEC/Stabilizer/Homological/Distance.lean`:
* `weight_chainXOperator` / `weight_chainZOperator` — weight of pure-X / pure-Z encoding equals chain weight.
* `anticommutesAt_vertexStabOf_iff_xChainOf` / `anticommutesAt_faceStabOf_iff_zChainOf` — anticommutation against Z- (resp. X-) type generators is determined by `g`'s X- (resp. Z-)content.
* `xChainOf_mem_cycles_of_centralizer` / `zChainOf_mem_dualCycles_of_centralizer` — `g ∈ centralizer` lifts to cycle / dual-cycle membership for the chain encodings.

After the refactor, both per-code distance files become thin instance plumbing:
* `ToricCodeNDistance.lean`: **609 → 207 lines**.
* `RotatedSurfaceCodeNDistance.lean`: **467 → 138 lines** (no local helpers — pure delegation).

## Structure (commits)
1. **0768c7f** — `cell complex types and boundary maps`
2. **3e2b6b6** — `chain complex bridge to HomologicalCode`
3. **5c4d93a** — `dim H₁ = 1`
4. **4f24159** — `StabilizerCode (L*L, 1) packaging`
5. **aa8a338** — `Stage 5 foundations — row-parity invariant`
6. **163f94a** — `Stage 5 — X-distance ≥ L`
7. **0403a7d** — `Stage 6 partial — colParity invariant + dualBoundary vanishing`
8. **903b475** — `Stage 6 — Z-distance ≥ L`
9. **bf5aaf0** — `Stage 7 — combined distance = L`
10. **19c93c3** — `refactor(homological): lift CSS-bridge helpers to abstract framework`

## Key theorems exposed
- `rotatedSurfaceStabilizerCode L : StabilizerCode (L*L) 1` — the packaged code.
- `rotatedSurfaceCodeN_distance_eq_L : HasCodeDistance (rotatedSurfaceStabilizerCode L) L` — the `[[L², 1, L]]` distance.
- `toricCodeN_distance_eq_L : HasCodeDistance (toricStabilizerCode L) L` — same theorem for the toric code, now proved via the same framework.
- `Stabilizer.Homological.HomologicalCode.{xChainOf_mem_cycles_of_centralizer, weight_chainXOperator, anticommutesAt_vertexStabOf_iff_xChainOf, …}` — reusable for any future homological CSS code.

## Test plan
- [x] `lake build` succeeds on the whole repo (3405/3405 jobs)
- [x] No `sorry` markers in any new file
- [x] No linter warnings introduced
- [x] Both `toricCodeN_distance_eq_L` and `rotatedSurfaceCodeN_distance_eq_L` proved via the *same* abstract argument
- [x] All new modules wired into the `QEC/Stabilizer/Codes.lean` / `QEC/Stabilizer/Lattice.lean` umbrellas

🤖 Generated with [Claude Code](https://claude.com/claude-code)