### PR TITLE
refactor(homological): lift CSS-bridge helpers to abstract framework

### DIFF
--- a/QEC/Stabilizer/Codes/RotatedSurfaceCodeNDistance.lean
+++ b/QEC/Stabilizer/Codes/RotatedSurfaceCodeNDistance.lean
@@ -9,23 +9,13 @@ import QEC.Stabilizer.Core.CodeDistance
 # Stage 7 — Combined rotated-surface-code distance = `L`
 
 Combines the X-distance ≥ L (`RotatedSurfaceCodeNDistanceX`) and the
-Z-distance ≥ L (`RotatedSurfaceCodeNDistanceZ`) via the CSS bridge
-`HomologicalCode.not_both_boundary_of_nontrivial` to obtain
-`HasCodeDistance (rotatedSurfaceStabilizerCode L) L`.
+Z-distance ≥ L (`RotatedSurfaceCodeNDistanceZ`) via the generic CSS bridge
+on `HomologicalCode` to obtain `HasCodeDistance (rotatedSurfaceStabilizerCode L) L`.
 
-The argument mirrors `ToricCodeNDistance`:
-
-* For a non-trivial logical `g`, its X-chain `xChainOf g` is always a
-  cycle and its Z-chain `zChainOf g` is always a dual cycle (because `g`
-  commutes with every stabilizer generator).
-* The CSS bridge guarantees that the two chains cannot **both** be
-  boundaries.
-* Whichever side is *not* a boundary gives a non-trivial X-type
-  (resp. Z-type) logical via `chainXOperator` (resp. `chainZOperator`),
-  whose weight is ≥ L by Stage 5 (resp. Stage 6).
-* The qubit-wise inclusion `weight g ≥ chainWeight (xChainOf g)`
-  (`HomologicalCode.weight_ge_chainWeight_xChainOf`) then transfers the
-  bound to `weight g`.
+The entire CSS-bridge machinery — centralizer ⇒ cycles, weight bridges, and the
+"not both boundary" lemma — lives in `Stabilizer.Homological.Distance`.  This
+file just plugs the rotated-surface `HomologicalCode` instance into that
+machinery and combines the result with the Stage 5/6 weight bounds.
 -/
 
 namespace Quantum
@@ -37,317 +27,6 @@ open NQubitPauliGroupElement Stabilizer.Lattice.RotatedSurface
   Quantum.Stabilizer.Homological.HomologicalCode
 
 variable (L : ℕ) [Fact (Odd L)] [Fact (3 ≤ L)]
-
-/-! ### Qubit-wise anticommutation bridges
-
-For any qubit `i`, the anticommutation pattern of `g` against a
-Z-type (resp. X-type) stabilizer generator depends only on `g`'s
-X-content (resp. Z-content) at `i`.  These are the rotated-surface
-analogues of `ToricCodeNDistance.anticommutesAt_vertexStab_g_iff_xChain`
-/ `anticommutesAt_faceStab_g_iff_zChain`. -/
-
-/-- Against the Z-type vertex stabilizer, qubit-wise anticommutation of
-`g` matches that of `chainXOperator (xChainOf g)` (the "X-only encoding"
-of `g`). -/
-private lemma anticommutesAt_vertexStabOf_iff_xChainOf
-    (g : NQubitPauliGroupElement (rotatedSurfaceHomologicalCode L).numQubits)
-    (v : (rotatedSurfaceHomologicalCode L).C0)
-    (i : Fin (rotatedSurfaceHomologicalCode L).numQubits) :
-    NQubitPauliGroupElement.anticommutesAt
-        ((rotatedSurfaceHomologicalCode L).vertexStabOf v).operators
-        g.operators i ↔
-      NQubitPauliGroupElement.anticommutesAt
-        ((rotatedSurfaceHomologicalCode L).vertexStabOf v).operators
-        ((rotatedSurfaceHomologicalCode L).chainXOperator
-          ((rotatedSurfaceHomologicalCode L).xChainOf g)).operators i := by
-  have hZ :
-      ((rotatedSurfaceHomologicalCode L).vertexStabOf v).operators i =
-        PauliOperator.I ∨
-      ((rotatedSurfaceHomologicalCode L).vertexStabOf v).operators i =
-        PauliOperator.Z :=
-    (Quantum.Stabilizer.Homological.HomologicalCode.vertexStabOf_isZType
-      (X := rotatedSurfaceHomologicalCode L) v).2 i
-  have heq :=
-    Quantum.Stabilizer.Homological.HomologicalCode.chainXOperator_xChainOf_op_at
-      (X := rotatedSurfaceHomologicalCode L) g i
-  rcases hZ with hI | hZ
-  · simp only [NQubitPauliGroupElement.anticommutesAt, hI]
-    cases hgi : g.operators i <;>
-      cases hxi :
-        ((rotatedSurfaceHomologicalCode L).chainXOperator
-          ((rotatedSurfaceHomologicalCode L).xChainOf g)).operators i <;>
-      simp [PauliOperator.mulOp]
-  · simp only [NQubitPauliGroupElement.anticommutesAt, hZ, heq]
-    cases hgi : g.operators i <;>
-      simp [PauliOperator.mulOp]
-
-/-- Against the X-type face stabilizer, qubit-wise anticommutation of `g`
-matches that of `chainZOperator (zChainOf g)` (the "Z-only encoding"
-of `g`). -/
-private lemma anticommutesAt_faceStabOf_iff_zChainOf
-    (g : NQubitPauliGroupElement (rotatedSurfaceHomologicalCode L).numQubits)
-    (f : (rotatedSurfaceHomologicalCode L).C2)
-    (i : Fin (rotatedSurfaceHomologicalCode L).numQubits) :
-    NQubitPauliGroupElement.anticommutesAt
-        ((rotatedSurfaceHomologicalCode L).faceStabOf f).operators
-        g.operators i ↔
-      NQubitPauliGroupElement.anticommutesAt
-        ((rotatedSurfaceHomologicalCode L).faceStabOf f).operators
-        ((rotatedSurfaceHomologicalCode L).chainZOperator
-          ((rotatedSurfaceHomologicalCode L).zChainOf g)).operators i := by
-  have hX :
-      ((rotatedSurfaceHomologicalCode L).faceStabOf f).operators i =
-        PauliOperator.I ∨
-      ((rotatedSurfaceHomologicalCode L).faceStabOf f).operators i =
-        PauliOperator.X :=
-    (Quantum.Stabilizer.Homological.HomologicalCode.faceStabOf_isXType
-      (X := rotatedSurfaceHomologicalCode L) f).2 i
-  have heq :=
-    Quantum.Stabilizer.Homological.HomologicalCode.chainZOperator_zChainOf_op_at
-      (X := rotatedSurfaceHomologicalCode L) g i
-  rcases hX with hI | hX
-  · simp only [NQubitPauliGroupElement.anticommutesAt, hI]
-    cases hgi : g.operators i <;>
-      cases hzi :
-        ((rotatedSurfaceHomologicalCode L).chainZOperator
-          ((rotatedSurfaceHomologicalCode L).zChainOf g)).operators i <;>
-      simp [PauliOperator.mulOp]
-  · simp only [NQubitPauliGroupElement.anticommutesAt, hX, heq]
-    cases hgi : g.operators i <;>
-      simp [PauliOperator.mulOp]
-
-/-! ### Centralizer → cycle bridges -/
-
-/-- For `g ∈ centralizer`, `xChainOf g` is a 1-cycle. -/
-private lemma xChainOf_mem_cycles_of_centralizer
-    (g : NQubitPauliGroupElement (rotatedSurfaceHomologicalCode L).numQubits)
-    (hg : g ∈ StabilizerGroup.centralizer
-            (rotatedSurfaceHomologicalCode L).homologicalStabilizerGroup) :
-    (rotatedSurfaceHomologicalCode L).xChainOf g ∈
-      (rotatedSurfaceHomologicalCode L).cycles := by
-  apply (chainXOperator_mem_centralizer_iff_mem_cycles
-      (X := rotatedSurfaceHomologicalCode L)
-      ((rotatedSurfaceHomologicalCode L).xChainOf g)).mp
-  intro s hs
-  refine Subgroup.closure_induction
-    (p := fun y _ => y *
-        (rotatedSurfaceHomologicalCode L).chainXOperator
-          ((rotatedSurfaceHomologicalCode L).xChainOf g) =
-      (rotatedSurfaceHomologicalCode L).chainXOperator
-        ((rotatedSurfaceHomologicalCode L).xChainOf g) * y) ?_ ?_ ?_ ?_ hs
-  · rintro y (⟨v, rfl⟩ | ⟨f, rfl⟩)
-    · -- y = vertexStabOf v (Z-type generator)
-      have hmem : (rotatedSurfaceHomologicalCode L).vertexStabOf v ∈
-          (rotatedSurfaceHomologicalCode L).homologicalStabilizerGroup.toSubgroup :=
-        Subgroup.subset_closure (Or.inl ⟨v, rfl⟩)
-      have hcomm_g :
-          (rotatedSurfaceHomologicalCode L).vertexStabOf v * g =
-            g * (rotatedSurfaceHomologicalCode L).vertexStabOf v :=
-        (Quantum.StabilizerGroup.mem_centralizer_iff g _).mp hg _ hmem
-      rw [NQubitPauliGroupElement.commutes_iff_even_anticommutes] at hcomm_g ⊢
-      classical
-      have hfilter_eq :
-          Finset.univ.filter (NQubitPauliGroupElement.anticommutesAt
-              ((rotatedSurfaceHomologicalCode L).vertexStabOf v).operators
-              ((rotatedSurfaceHomologicalCode L).chainXOperator
-                ((rotatedSurfaceHomologicalCode L).xChainOf g)).operators) =
-            Finset.univ.filter (NQubitPauliGroupElement.anticommutesAt
-              ((rotatedSurfaceHomologicalCode L).vertexStabOf v).operators
-              g.operators) := by
-        ext i
-        simp only [Finset.mem_filter, Finset.mem_univ, true_and]
-        exact (anticommutesAt_vertexStabOf_iff_xChainOf L g v i).symm
-      rw [hfilter_eq]
-      exact hcomm_g
-    · -- y = faceStabOf f (X-type generator) — X-type / X-type commute trivially
-      exact Quantum.Stabilizer.Homological.HomologicalCode.chainXOperator_commutes_faceStabOf
-        (X := rotatedSurfaceHomologicalCode L)
-        ((rotatedSurfaceHomologicalCode L).xChainOf g) f
-  · -- one
-    change (1 : NQubitPauliGroupElement (rotatedSurfaceHomologicalCode L).numQubits) *
-        (rotatedSurfaceHomologicalCode L).chainXOperator
-          ((rotatedSurfaceHomologicalCode L).xChainOf g) =
-        (rotatedSurfaceHomologicalCode L).chainXOperator
-          ((rotatedSurfaceHomologicalCode L).xChainOf g) * 1
-    rw [_root_.one_mul, _root_.mul_one]
-  · -- mul
-    intros y₁ y₂ _ _ hy₁ hy₂
-    calc (y₁ * y₂) *
-            (rotatedSurfaceHomologicalCode L).chainXOperator
-              ((rotatedSurfaceHomologicalCode L).xChainOf g)
-        = y₁ * (y₂ *
-            (rotatedSurfaceHomologicalCode L).chainXOperator
-              ((rotatedSurfaceHomologicalCode L).xChainOf g)) := _root_.mul_assoc _ _ _
-      _ = y₁ * ((rotatedSurfaceHomologicalCode L).chainXOperator
-              ((rotatedSurfaceHomologicalCode L).xChainOf g) * y₂) := by rw [hy₂]
-      _ = (y₁ * (rotatedSurfaceHomologicalCode L).chainXOperator
-              ((rotatedSurfaceHomologicalCode L).xChainOf g)) * y₂ :=
-        (_root_.mul_assoc _ _ _).symm
-      _ = ((rotatedSurfaceHomologicalCode L).chainXOperator
-              ((rotatedSurfaceHomologicalCode L).xChainOf g) * y₁) * y₂ := by rw [hy₁]
-      _ = (rotatedSurfaceHomologicalCode L).chainXOperator
-              ((rotatedSurfaceHomologicalCode L).xChainOf g) * (y₁ * y₂) :=
-        _root_.mul_assoc _ _ _
-  · -- inv
-    intros y _ hy
-    exact (show Commute y _ from hy).inv_left.eq
-
-/-- For `g ∈ centralizer`, `zChainOf g` is a dual cycle. -/
-private lemma zChainOf_mem_dualCycles_of_centralizer
-    (g : NQubitPauliGroupElement (rotatedSurfaceHomologicalCode L).numQubits)
-    (hg : g ∈ StabilizerGroup.centralizer
-            (rotatedSurfaceHomologicalCode L).homologicalStabilizerGroup) :
-    (rotatedSurfaceHomologicalCode L).zChainOf g ∈
-      (rotatedSurfaceHomologicalCode L).dualCycles := by
-  apply (chainZOperator_mem_centralizer_iff_mem_dualCycles
-      (X := rotatedSurfaceHomologicalCode L)
-      ((rotatedSurfaceHomologicalCode L).zChainOf g)).mp
-  intro s hs
-  refine Subgroup.closure_induction
-    (p := fun y _ => y *
-        (rotatedSurfaceHomologicalCode L).chainZOperator
-          ((rotatedSurfaceHomologicalCode L).zChainOf g) =
-      (rotatedSurfaceHomologicalCode L).chainZOperator
-        ((rotatedSurfaceHomologicalCode L).zChainOf g) * y) ?_ ?_ ?_ ?_ hs
-  · rintro y (⟨v, rfl⟩ | ⟨f, rfl⟩)
-    · -- y = vertexStabOf v (Z-type generator) — Z-type / Z-type commute trivially
-      exact Quantum.Stabilizer.Homological.HomologicalCode.chainZOperator_commutes_vertexStabOf
-        (X := rotatedSurfaceHomologicalCode L)
-        ((rotatedSurfaceHomologicalCode L).zChainOf g) v
-    · -- y = faceStabOf f (X-type generator)
-      have hmem : (rotatedSurfaceHomologicalCode L).faceStabOf f ∈
-          (rotatedSurfaceHomologicalCode L).homologicalStabilizerGroup.toSubgroup :=
-        Subgroup.subset_closure (Or.inr ⟨f, rfl⟩)
-      have hcomm_g :
-          (rotatedSurfaceHomologicalCode L).faceStabOf f * g =
-            g * (rotatedSurfaceHomologicalCode L).faceStabOf f :=
-        (Quantum.StabilizerGroup.mem_centralizer_iff g _).mp hg _ hmem
-      rw [NQubitPauliGroupElement.commutes_iff_even_anticommutes] at hcomm_g ⊢
-      classical
-      have hfilter_eq :
-          Finset.univ.filter (NQubitPauliGroupElement.anticommutesAt
-              ((rotatedSurfaceHomologicalCode L).faceStabOf f).operators
-              ((rotatedSurfaceHomologicalCode L).chainZOperator
-                ((rotatedSurfaceHomologicalCode L).zChainOf g)).operators) =
-            Finset.univ.filter (NQubitPauliGroupElement.anticommutesAt
-              ((rotatedSurfaceHomologicalCode L).faceStabOf f).operators
-              g.operators) := by
-        ext i
-        simp only [Finset.mem_filter, Finset.mem_univ, true_and]
-        exact (anticommutesAt_faceStabOf_iff_zChainOf L g f i).symm
-      rw [hfilter_eq]
-      exact hcomm_g
-  · -- one
-    change (1 : NQubitPauliGroupElement (rotatedSurfaceHomologicalCode L).numQubits) *
-        (rotatedSurfaceHomologicalCode L).chainZOperator
-          ((rotatedSurfaceHomologicalCode L).zChainOf g) =
-        (rotatedSurfaceHomologicalCode L).chainZOperator
-          ((rotatedSurfaceHomologicalCode L).zChainOf g) * 1
-    rw [_root_.one_mul, _root_.mul_one]
-  · -- mul
-    intros y₁ y₂ _ _ hy₁ hy₂
-    calc (y₁ * y₂) *
-            (rotatedSurfaceHomologicalCode L).chainZOperator
-              ((rotatedSurfaceHomologicalCode L).zChainOf g)
-        = y₁ * (y₂ *
-            (rotatedSurfaceHomologicalCode L).chainZOperator
-              ((rotatedSurfaceHomologicalCode L).zChainOf g)) := _root_.mul_assoc _ _ _
-      _ = y₁ * ((rotatedSurfaceHomologicalCode L).chainZOperator
-              ((rotatedSurfaceHomologicalCode L).zChainOf g) * y₂) := by rw [hy₂]
-      _ = (y₁ * (rotatedSurfaceHomologicalCode L).chainZOperator
-              ((rotatedSurfaceHomologicalCode L).zChainOf g)) * y₂ :=
-        (_root_.mul_assoc _ _ _).symm
-      _ = ((rotatedSurfaceHomologicalCode L).chainZOperator
-              ((rotatedSurfaceHomologicalCode L).zChainOf g) * y₁) * y₂ := by rw [hy₁]
-      _ = (rotatedSurfaceHomologicalCode L).chainZOperator
-              ((rotatedSurfaceHomologicalCode L).zChainOf g) * (y₁ * y₂) :=
-        _root_.mul_assoc _ _ _
-  · -- inv
-    intros y _ hy
-    exact (show Commute y _ from hy).inv_left.eq
-
-/-! ### Weight bridge: `weight (chain*Operator c) = chainWeight c`
-
-Local versions of the equalities `weight (chainXOperator c) = chainWeight c`
-and `weight (chainZOperator c) = chainWeight c`, proved via the same
-`rscQubitEquiv` bijection used in
-`RotatedSurfaceCodeNDistanceX.weight_chainXOperator_eq_chainSupport_card`. -/
-
-private lemma weight_chainXOperator_eq_chainWeight
-    (c : (rotatedSurfaceHomologicalCode L).C1 → ZMod 2) :
-    NQubitPauliGroupElement.weight
-        ((rotatedSurfaceHomologicalCode L).chainXOperator c) =
-      (rotatedSurfaceHomologicalCode L).chainWeight c := by
-  classical
-  unfold NQubitPauliGroupElement.weight NQubitPauliOperator.weight
-    Quantum.Stabilizer.Homological.HomologicalCode.chainWeight
-    Quantum.Stabilizer.Homological.HomologicalCode.chainSupport
-  symm
-  apply Finset.card_bij
-    (fun v _ => (rotatedSurfaceHomologicalCode L).edgeEquiv v)
-  · intro v hv
-    rw [Finset.mem_filter] at hv
-    have h_ne : c v ≠ 0 := hv.2
-    have h1 : c v = 1 := by
-      rcases Fin.exists_fin_two.mp ⟨c v, rfl⟩ with h0 | h1
-      · exact absurd h0 h_ne
-      · exact h1
-    exact (Quantum.Stabilizer.Homological.HomologicalCode.mem_support_chainXOperator_iff
-      (X := rotatedSurfaceHomologicalCode L) c v).mpr h1
-  · intros v₁ _ v₂ _ heq
-    exact (rotatedSurfaceHomologicalCode L).edgeEquiv.injective heq
-  · intros q hq
-    set v := (rotatedSurfaceHomologicalCode L).edgeEquiv.symm q with hv_def
-    have h_q : (rotatedSurfaceHomologicalCode L).edgeEquiv v = q :=
-      Equiv.apply_symm_apply _ _
-    refine ⟨v, ?_, h_q⟩
-    rw [Finset.mem_filter]
-    refine ⟨Finset.mem_univ _, ?_⟩
-    have h_iff :=
-      Quantum.Stabilizer.Homological.HomologicalCode.mem_support_chainXOperator_iff
-        (X := rotatedSurfaceHomologicalCode L) c v
-    rw [h_q] at h_iff
-    have hcv : c v = 1 := h_iff.mp hq
-    rw [hcv]; decide
-
-private lemma weight_chainZOperator_eq_chainWeight
-    (c : (rotatedSurfaceHomologicalCode L).C1 → ZMod 2) :
-    NQubitPauliGroupElement.weight
-        ((rotatedSurfaceHomologicalCode L).chainZOperator c) =
-      (rotatedSurfaceHomologicalCode L).chainWeight c := by
-  classical
-  unfold NQubitPauliGroupElement.weight NQubitPauliOperator.weight
-    Quantum.Stabilizer.Homological.HomologicalCode.chainWeight
-    Quantum.Stabilizer.Homological.HomologicalCode.chainSupport
-  symm
-  apply Finset.card_bij
-    (fun v _ => (rotatedSurfaceHomologicalCode L).edgeEquiv v)
-  · intro v hv
-    rw [Finset.mem_filter] at hv
-    have h_ne : c v ≠ 0 := hv.2
-    have h1 : c v = 1 := by
-      rcases Fin.exists_fin_two.mp ⟨c v, rfl⟩ with h0 | h1
-      · exact absurd h0 h_ne
-      · exact h1
-    exact (Quantum.Stabilizer.Homological.HomologicalCode.mem_support_chainZOperator_iff
-      (X := rotatedSurfaceHomologicalCode L) c v).mpr h1
-  · intros v₁ _ v₂ _ heq
-    exact (rotatedSurfaceHomologicalCode L).edgeEquiv.injective heq
-  · intros q hq
-    set v := (rotatedSurfaceHomologicalCode L).edgeEquiv.symm q with hv_def
-    have h_q : (rotatedSurfaceHomologicalCode L).edgeEquiv v = q :=
-      Equiv.apply_symm_apply _ _
-    refine ⟨v, ?_, h_q⟩
-    rw [Finset.mem_filter]
-    refine ⟨Finset.mem_univ _, ?_⟩
-    have h_iff :=
-      Quantum.Stabilizer.Homological.HomologicalCode.mem_support_chainZOperator_iff
-        (X := rotatedSurfaceHomologicalCode L) c v
-    rw [h_q] at h_iff
-    have hcv : c v = 1 := h_iff.mp hq
-    rw [hcv]; decide
-
-/-! ### Main theorem -/
 
 /-- **Stage 7 endpoint.**  The rotated surface code on an `L × L` lattice
 has code distance exactly `L`. -/
@@ -373,11 +52,12 @@ theorem rotatedSurfaceCodeN_distance_eq_L :
       ((Quantum.StabilizerGroup.IsNontrivialLogicalOperator_iff g _).mp hg_hom).1
     -- Apply the abstract CSS bridge: not both boundary.
     have h_not_both :=
-      Quantum.Stabilizer.Homological.HomologicalCode.not_both_boundary_of_nontrivial
-        (X := rotatedSurfaceHomologicalCode L) g hg_hom
-    -- xChainOf g ∈ cycles, zChainOf g ∈ dualCycles
-    have hxCyc := xChainOf_mem_cycles_of_centralizer L g hg_cent_hom
-    have hzCyc := zChainOf_mem_dualCycles_of_centralizer L g hg_cent_hom
+      not_both_boundary_of_nontrivial (X := rotatedSurfaceHomologicalCode L) g hg_hom
+    -- xChainOf g ∈ cycles, zChainOf g ∈ dualCycles — generic.
+    have hxCyc := xChainOf_mem_cycles_of_centralizer
+      (X := rotatedSurfaceHomologicalCode L) g hg_cent_hom
+    have hzCyc := zChainOf_mem_dualCycles_of_centralizer
+      (X := rotatedSurfaceHomologicalCode L) g hg_cent_hom
     -- Case on whether xChainOf g is a boundary.
     by_cases hxBnd : (rotatedSurfaceHomologicalCode L).xChainOf g ∈
         (rotatedSurfaceHomologicalCode L).boundaries
@@ -390,12 +70,11 @@ theorem rotatedSurfaceCodeN_distance_eq_L :
         (rotatedSurfaceHomologicalCode L).chainZOperator
           ((rotatedSurfaceHomologicalCode L).zChainOf g) with hgZ_def
       have hgZ_isZType : NQubitPauliGroupElement.IsZTypeElement gZ :=
-        Quantum.Stabilizer.Homological.HomologicalCode.chainZOperator_isZType
-          (X := rotatedSurfaceHomologicalCode L) _
+        chainZOperator_isZType (X := rotatedSurfaceHomologicalCode L) _
       have hgZ_nl_hom :
           Quantum.StabilizerGroup.IsNontrivialLogicalOperator gZ
             (rotatedSurfaceHomologicalCode L).homologicalStabilizerGroup :=
-        (Quantum.Stabilizer.Homological.HomologicalCode.chainZOperator_isNontrivialLogical_iff
+        (chainZOperator_isNontrivialLogical_iff
           (X := rotatedSurfaceHomologicalCode L)
           ((rotatedSurfaceHomologicalCode L).zChainOf g)).mpr ⟨hzCyc, hzBnd⟩
       have hgZ_nl :
@@ -404,30 +83,27 @@ theorem rotatedSurfaceCodeN_distance_eq_L :
         (h_iff_NL gZ).mpr hgZ_nl_hom
       have hwZ : L ≤ NQubitPauliGroupElement.weight gZ :=
         weight_ge_L_of_nontrivial_Z_logical L hgZ_isZType hgZ_nl
-      -- weight g ≥ chainWeight (zChainOf g) = weight gZ ≥ L.
       have h_step1 :
           (rotatedSurfaceHomologicalCode L).chainWeight
               ((rotatedSurfaceHomologicalCode L).zChainOf g) ≤
             NQubitPauliGroupElement.weight g :=
-        Quantum.Stabilizer.Homological.HomologicalCode.weight_ge_chainWeight_zChainOf
-          (X := rotatedSurfaceHomologicalCode L) g
+        weight_ge_chainWeight_zChainOf (X := rotatedSurfaceHomologicalCode L) g
       have h_step2 :
           NQubitPauliGroupElement.weight gZ =
             (rotatedSurfaceHomologicalCode L).chainWeight
               ((rotatedSurfaceHomologicalCode L).zChainOf g) :=
-        weight_chainZOperator_eq_chainWeight L _
+        weight_chainZOperator (X := rotatedSurfaceHomologicalCode L) _
       omega
     · -- xChainOf g ∉ boundaries — use X-distance bound.
       set gX : NQubitPauliGroupElement (numQubits L) :=
         (rotatedSurfaceHomologicalCode L).chainXOperator
           ((rotatedSurfaceHomologicalCode L).xChainOf g) with hgX_def
       have hgX_isXType : NQubitPauliGroupElement.IsXTypeElement gX :=
-        Quantum.Stabilizer.Homological.HomologicalCode.chainXOperator_isXType
-          (X := rotatedSurfaceHomologicalCode L) _
+        chainXOperator_isXType (X := rotatedSurfaceHomologicalCode L) _
       have hgX_nl_hom :
           Quantum.StabilizerGroup.IsNontrivialLogicalOperator gX
             (rotatedSurfaceHomologicalCode L).homologicalStabilizerGroup :=
-        (Quantum.Stabilizer.Homological.HomologicalCode.chainXOperator_isNontrivialLogical_iff
+        (chainXOperator_isNontrivialLogical_iff
           (X := rotatedSurfaceHomologicalCode L)
           ((rotatedSurfaceHomologicalCode L).xChainOf g)).mpr ⟨hxCyc, hxBnd⟩
       have hgX_nl :
@@ -440,23 +116,21 @@ theorem rotatedSurfaceCodeN_distance_eq_L :
           (rotatedSurfaceHomologicalCode L).chainWeight
               ((rotatedSurfaceHomologicalCode L).xChainOf g) ≤
             NQubitPauliGroupElement.weight g :=
-        Quantum.Stabilizer.Homological.HomologicalCode.weight_ge_chainWeight_xChainOf
-          (X := rotatedSurfaceHomologicalCode L) g
+        weight_ge_chainWeight_xChainOf (X := rotatedSurfaceHomologicalCode L) g
       have h_step2 :
           NQubitPauliGroupElement.weight gX =
             (rotatedSurfaceHomologicalCode L).chainWeight
               ((rotatedSurfaceHomologicalCode L).xChainOf g) :=
-        weight_chainXOperator_eq_chainWeight L _
+        weight_chainXOperator (X := rotatedSurfaceHomologicalCode L) _
       omega
   · -- Witness: `logicalX L` has weight exactly L.
     refine ⟨logicalX L, ?_, ?_⟩
-    · -- IsNontrivialLogicalOperator (logicalX L) (rotatedSurfaceStabilizerCode L).toStabilizerGroup
-      have hlogX_nl_hom :
+    · have hlogX_nl_hom :
           Quantum.StabilizerGroup.IsNontrivialLogicalOperator (logicalX L)
             (rotatedSurfaceHomologicalCode L).homologicalStabilizerGroup := by
         change Quantum.StabilizerGroup.IsNontrivialLogicalOperator
           ((rotatedSurfaceHomologicalCode L).chainXOperator (middleColChain L)) _
-        exact (Quantum.Stabilizer.Homological.HomologicalCode.chainXOperator_isNontrivialLogical_iff
+        exact (chainXOperator_isNontrivialLogical_iff
           (X := rotatedSurfaceHomologicalCode L) (middleColChain L)).mpr
           ⟨middleColChain_mem_cycles L, middleColChain_not_mem_boundaries L⟩
       exact (h_iff_NL (logicalX L)).mpr hlogX_nl_hom

--- a/QEC/Stabilizer/Codes/ToricCodeNDistance.lean
+++ b/QEC/Stabilizer/Codes/ToricCodeNDistance.lean
@@ -14,452 +14,27 @@ namespace ToricCodeN
 
 open scoped BigOperators
 open NQubitPauliGroupElement
+  Quantum.Stabilizer.Homological.HomologicalCode
 
 /-!
 # Full toric-code distance = L
 
 Combines the X-distance (from `ToricCodeNDistanceX`) and Z-distance
-(from `ToricCodeNDistanceZ`) via the CSS bridge to obtain the full distance.
+(from `ToricCodeNDistanceZ`) via the abstract CSS bridge on
+`HomologicalCode` to obtain the full distance.
+
+The entire CSS-bridge machinery — centralizer ⇒ cycles, weight bridges, and
+"not both boundary" — lives in `Stabilizer.Homological.Distance`.  This file
+just plugs the toric `HomologicalCode` instance into that machinery and
+combines the result with the toric X- / Z-distance witnesses.
 -/
 
--- ---------------------------------------------------------------------------
--- 1.  CSS bridge: full distance = min(dX, dZ)
--- ---------------------------------------------------------------------------
+variable (L : ℕ) [Fact (2 ≤ L)]
 
-/-
-Helper definitions for the CSS bridge proof.
-
-For a general Pauli `g`, the X-chain and Z-chain are:
-  xChainOf g e = 1  iff  g.operators (edgeToQubitIdx e) ∈ {X, Y}
-  zChainOf g e = 1  iff  g.operators (edgeToQubitIdx e) ∈ {Z, Y}
-
-Key facts:
-  * weight g ≥ edgeWeight (xChainOf g)   (support inclusion)
-  * weight g ≥ edgeWeight (zChainOf g)
-  * g commutes with all Z-vertex stabs  ↔  xChainOf g ∈ toricCycles
-  * g commutes with all X-face stabs    ↔  zChainOf g ∈ toricDualCycles
-  * g nontrivial  →  ¬(xChainOf g ∈ toricBoundaries ∧ zChainOf g ∈ toricDualBoundaries)
--/
-
-/-- X-part chain of a general Pauli (1 where the operator is X or Y). -/
-private noncomputable def xChainOf (L : ℕ) (g : NQubitPauliGroupElement (numQubits L)) :
-    Stabilizer.Lattice.C1 L :=
-  fun e =>
-    if g.operators (Stabilizer.Lattice.edgeToQubitIdx L e) = PauliOperator.X ∨
-       g.operators (Stabilizer.Lattice.edgeToQubitIdx L e) = PauliOperator.Y
-    then 1 else 0
-
-/-- Z-part chain of a general Pauli (1 where the operator is Z or Y). -/
-private noncomputable def zChainOf (L : ℕ) (g : NQubitPauliGroupElement (numQubits L)) :
-    Stabilizer.Lattice.C1 L :=
-  fun e =>
-    if g.operators (Stabilizer.Lattice.edgeToQubitIdx L e) = PauliOperator.Z ∨
-       g.operators (Stabilizer.Lattice.edgeToQubitIdx L e) = PauliOperator.Y
-    then 1 else 0
-
-/-- Weight of `g` is at least the edge-weight of its X-chain. -/
-private lemma weight_ge_edgeWeight_xChain (L : ℕ) [Fact (2 ≤ L)]
-    (g : NQubitPauliGroupElement (numQubits L)) :
-    weight g ≥ Stabilizer.Lattice.edgeWeight (L := L) (xChainOf L g) := by
-  have hL0 : 0 < L := Nat.lt_of_lt_of_le (by decide : 0 < 2) (Fact.out : 2 ≤ L)
-  haveI : Fact (0 < L) := ⟨hL0⟩
-  unfold weight Stabilizer.Lattice.edgeWeight
-  classical
-  have himg :
-      (Stabilizer.Lattice.edgeSupport (L := L) (xChainOf L g)).image
-        (Stabilizer.Lattice.edgeToQubitIdx L) ⊆
-        NQubitPauliOperator.support g.operators := by
-    intro q hq
-    rcases Finset.mem_image.mp hq with ⟨e, he, rfl⟩
-    have hne : xChainOf L g e ≠ 0 := (Stabilizer.Lattice.mem_edgeSupport _ _).mp he
-    have : g.operators (Stabilizer.Lattice.edgeToQubitIdx L e) = PauliOperator.X ∨
-        g.operators (Stabilizer.Lattice.edgeToQubitIdx L e) = PauliOperator.Y := by
-      by_contra h
-      push Not at h
-      simp [xChainOf, h.1, h.2] at hne
-    rcases this with hX | hY
-    · simp [NQubitPauliOperator.support, hX]
-    · simp [NQubitPauliOperator.support, hY]
-  calc (NQubitPauliOperator.support g.operators).card
-      ≥ ((Stabilizer.Lattice.edgeSupport (L := L) (xChainOf L g)).image
-          (Stabilizer.Lattice.edgeToQubitIdx L)).card :=
-        Finset.card_le_card himg
-    _ = (Stabilizer.Lattice.edgeSupport (L := L) (xChainOf L g)).card := by
-        rw [Finset.card_image_of_injective _ (Stabilizer.Lattice.edgeToQubitIdx_injective L)]
-
-/-- Weight of `g` is at least the edge-weight of its Z-chain. -/
-private lemma weight_ge_edgeWeight_zChain (L : ℕ) [Fact (2 ≤ L)]
-    (g : NQubitPauliGroupElement (numQubits L)) :
-    weight g ≥ Stabilizer.Lattice.edgeWeight (L := L) (zChainOf L g) := by
-  have hL0 : 0 < L := Nat.lt_of_lt_of_le (by decide : 0 < 2) (Fact.out : 2 ≤ L)
-  haveI : Fact (0 < L) := ⟨hL0⟩
-  unfold weight Stabilizer.Lattice.edgeWeight
-  classical
-  have himg :
-      (Stabilizer.Lattice.edgeSupport (L := L) (zChainOf L g)).image
-        (Stabilizer.Lattice.edgeToQubitIdx L) ⊆
-        NQubitPauliOperator.support g.operators := by
-    intro q hq
-    rcases Finset.mem_image.mp hq with ⟨e, he, rfl⟩
-    have hne : zChainOf L g e ≠ 0 := (Stabilizer.Lattice.mem_edgeSupport _ _).mp he
-    have : g.operators (Stabilizer.Lattice.edgeToQubitIdx L e) = PauliOperator.Z ∨
-        g.operators (Stabilizer.Lattice.edgeToQubitIdx L e) = PauliOperator.Y := by
-      by_contra h
-      push Not at h
-      simp [zChainOf, h.1, h.2] at hne
-    rcases this with hZ | hY
-    · simp [NQubitPauliOperator.support, hZ]
-    · simp [NQubitPauliOperator.support, hY]
-  calc (NQubitPauliOperator.support g.operators).card
-      ≥ ((Stabilizer.Lattice.edgeSupport (L := L) (zChainOf L g)).image
-          (Stabilizer.Lattice.edgeToQubitIdx L)).card :=
-        Finset.card_le_card himg
-    _ = (Stabilizer.Lattice.edgeSupport (L := L) (zChainOf L g)).card := by
-        rw [Finset.card_image_of_injective _ (Stabilizer.Lattice.edgeToQubitIdx_injective L)]
-
-/-- `edgeToQubitIdx` is surjective (since it is injective between equinumerous types). -/
-private lemma edgeToQubitIdx_surjective (L : ℕ) [Fact (0 < L)] :
-    Function.Surjective (Stabilizer.Lattice.edgeToQubitIdx L) := by
-  classical
-  have hcard_edge : Fintype.card (Stabilizer.Lattice.EdgeIdx L) =
-      Fintype.card (Fin (Stabilizer.Lattice.toricNumQubits L)) := by
-    simp [Stabilizer.Lattice.toricNumQubits, mul_comm]
-  exact (Fintype.bijective_iff_injective_and_card _).mpr
-    ⟨Stabilizer.Lattice.edgeToQubitIdx_injective L, hcard_edge⟩ |>.2
-
-/-- The X-only encoding `toricXOperatorOfChain (xChainOf g)` has, at each qubit, an X
-exactly when `g` has X or Y. -/
-private lemma toricXOf_xChain_operators_eq (L : ℕ) [Fact (0 < L)]
-    (g : NQubitPauliGroupElement (numQubits L)) (i : Fin (numQubits L)) :
-    (Stabilizer.Lattice.toricXOperatorOfChain L (xChainOf L g)).operators i =
-      (if g.operators i = PauliOperator.X ∨ g.operators i = PauliOperator.Y
-       then PauliOperator.X else PauliOperator.I) := by
-  classical
-  by_cases hxy : g.operators i = PauliOperator.X ∨ g.operators i = PauliOperator.Y
-  · obtain ⟨e, hei⟩ := edgeToQubitIdx_surjective L i
-    have he1 : xChainOf L g e = 1 := by
-      rcases hxy with hX | hY
-      · simp [xChainOf, hei, hX]
-      · simp [xChainOf, hei, hY]
-    have hex : ∃ e : Stabilizer.Lattice.EdgeIdx L,
-        Stabilizer.Lattice.edgeToQubitIdx L e = i ∧ xChainOf L g e = 1 := ⟨e, hei, he1⟩
-    simp [Stabilizer.Lattice.toricXOperatorOfChain, hex, hxy]
-  · push Not at hxy
-    have hex : ¬ ∃ e : Stabilizer.Lattice.EdgeIdx L,
-        Stabilizer.Lattice.edgeToQubitIdx L e = i ∧ xChainOf L g e = 1 := by
-      rintro ⟨e, hei, he1⟩
-      have h_xchain_zero : xChainOf L g e = 0 := by
-        subst hei; simp [xChainOf, hxy.1, hxy.2]
-      rw [h_xchain_zero] at he1
-      exact absurd he1 (by decide)
-    simp [Stabilizer.Lattice.toricXOperatorOfChain, hex, hxy]
-
-/-- For each qubit, anticommutation between `vertexStab` (Z-type) and a general `g` is
-equivalent to anticommutation between `vertexStab` and the X-only encoding of `xChainOf g`. -/
-private lemma anticommutesAt_vertexStab_g_iff_xChain
-    (L : ℕ) [Fact (2 ≤ L)] (g : NQubitPauliGroupElement (numQubits L))
-    (xv yv : Fin L) (i : Fin (numQubits L)) :
-    NQubitPauliGroupElement.anticommutesAt
-        (vertexStab L xv yv).operators g.operators i ↔
-      NQubitPauliGroupElement.anticommutesAt
-        (vertexStab L xv yv).operators
-        (Stabilizer.Lattice.toricXOperatorOfChain L (xChainOf L g)).operators i := by
-  have hL0 : 0 < L := Nat.lt_of_lt_of_le (by decide : 0 < 2) (Fact.out : 2 ≤ L)
-  haveI : Fact (0 < L) := ⟨hL0⟩
-  have hZ : (vertexStab L xv yv).operators i = PauliOperator.I ∨
-      (vertexStab L xv yv).operators i = PauliOperator.Z :=
-    (vertexStab_is_ZType L xv yv).2 i
-  have heq := toricXOf_xChain_operators_eq L g i
-  rcases hZ with hI | hZ
-  · simp only [NQubitPauliGroupElement.anticommutesAt, hI]
-    cases hgi : g.operators i <;>
-      cases hxi : (Stabilizer.Lattice.toricXOperatorOfChain L (xChainOf L g)).operators i <;>
-      simp [PauliOperator.mulOp]
-  · simp only [NQubitPauliGroupElement.anticommutesAt, hZ, heq]
-    cases hgi : g.operators i <;>
-      simp [PauliOperator.mulOp]
-
-/-- The Z-only encoding `toricZOperatorOfChain (zChainOf g)` has, at each qubit, a Z
-exactly when `g` has Z or Y. -/
-private lemma toricZOf_zChain_operators_eq (L : ℕ) [Fact (0 < L)]
-    (g : NQubitPauliGroupElement (numQubits L)) (i : Fin (numQubits L)) :
-    (Stabilizer.Lattice.toricZOperatorOfChain L (zChainOf L g)).operators i =
-      (if g.operators i = PauliOperator.Z ∨ g.operators i = PauliOperator.Y
-       then PauliOperator.Z else PauliOperator.I) := by
-  classical
-  by_cases hzy : g.operators i = PauliOperator.Z ∨ g.operators i = PauliOperator.Y
-  · obtain ⟨e, hei⟩ := edgeToQubitIdx_surjective L i
-    have he1 : zChainOf L g e = 1 := by
-      rcases hzy with hZ | hY
-      · simp [zChainOf, hei, hZ]
-      · simp [zChainOf, hei, hY]
-    have hex : ∃ e : Stabilizer.Lattice.EdgeIdx L,
-        Stabilizer.Lattice.edgeToQubitIdx L e = i ∧ zChainOf L g e = 1 := ⟨e, hei, he1⟩
-    simp [Stabilizer.Lattice.toricZOperatorOfChain, hex, hzy]
-  · push Not at hzy
-    have hex : ¬ ∃ e : Stabilizer.Lattice.EdgeIdx L,
-        Stabilizer.Lattice.edgeToQubitIdx L e = i ∧ zChainOf L g e = 1 := by
-      rintro ⟨e, hei, he1⟩
-      have h_zchain_zero : zChainOf L g e = 0 := by
-        subst hei; simp [zChainOf, hzy.1, hzy.2]
-      rw [h_zchain_zero] at he1
-      exact absurd he1 (by decide)
-    simp [Stabilizer.Lattice.toricZOperatorOfChain, hex, hzy]
-
-/-- For each qubit, anticommutation between `faceStab` (X-type) and a general `g` is
-equivalent to anticommutation between `faceStab` and the Z-only encoding of `zChainOf g`. -/
-private lemma anticommutesAt_faceStab_g_iff_zChain
-    (L : ℕ) [Fact (2 ≤ L)] (g : NQubitPauliGroupElement (numQubits L))
-    (xf yf : Fin L) (i : Fin (numQubits L)) :
-    NQubitPauliGroupElement.anticommutesAt
-        (faceStab L xf yf).operators g.operators i ↔
-      NQubitPauliGroupElement.anticommutesAt
-        (faceStab L xf yf).operators
-        (Stabilizer.Lattice.toricZOperatorOfChain L (zChainOf L g)).operators i := by
-  have hL0 : 0 < L := Nat.lt_of_lt_of_le (by decide : 0 < 2) (Fact.out : 2 ≤ L)
-  haveI : Fact (0 < L) := ⟨hL0⟩
-  have hX : (faceStab L xf yf).operators i = PauliOperator.I ∨
-      (faceStab L xf yf).operators i = PauliOperator.X :=
-    (faceStab_is_XType L xf yf).2 i
-  have heq := toricZOf_zChain_operators_eq L g i
-  rcases hX with hI | hX
-  · simp only [NQubitPauliGroupElement.anticommutesAt, hI]
-    cases hgi : g.operators i <;>
-      cases hzi : (Stabilizer.Lattice.toricZOperatorOfChain L (zChainOf L g)).operators i <;>
-      simp [PauliOperator.mulOp]
-  · simp only [NQubitPauliGroupElement.anticommutesAt, hX, heq]
-    cases hgi : g.operators i <;>
-      simp [PauliOperator.mulOp]
-
-/-- If `g` is in the centralizer, its X-chain is a primal cycle. -/
-private lemma xChain_mem_toricCycles_of_centralizer (L : ℕ) [Fact (2 ≤ L)]
-    (g : NQubitPauliGroupElement (numQubits L))
-    (hg : g ∈ centralizer (stabilizerGroup L)) :
-    xChainOf L g ∈ Stabilizer.Lattice.toricCycles (L := L) := by
-  apply (Stabilizer.Lattice.xCommutesWithZChecks_iff_mem_toricCycles L (xChainOf L g)).mp
-  intro z hz
-  rcases hz with ⟨⟨xv, yv⟩, rfl⟩
-  have hmem : vertexStab L xv yv ∈ (stabilizerGroup L).toSubgroup := by
-    rw [stabilizerGroup_toSubgroup_eq]
-    apply Subgroup.subset_closure
-    left; exact ⟨(xv, yv), rfl⟩
-  have hcomm_g : vertexStab L xv yv * g = g * vertexStab L xv yv := by
-    rw [mem_centralizer_iff] at hg
-    exact hg (vertexStab L xv yv) hmem
-  rw [NQubitPauliGroupElement.commutes_iff_even_anticommutes] at hcomm_g ⊢
-  classical
-  have hfilter_eq :
-      Finset.univ.filter (NQubitPauliGroupElement.anticommutesAt
-        (vertexStab L xv yv).operators
-        (Stabilizer.Lattice.toricXOperatorOfChain L (xChainOf L g)).operators) =
-      Finset.univ.filter (NQubitPauliGroupElement.anticommutesAt
-        (vertexStab L xv yv).operators g.operators) := by
-    ext i
-    simp only [Finset.mem_filter, Finset.mem_univ, true_and]
-    exact (anticommutesAt_vertexStab_g_iff_xChain L g xv yv i).symm
-  rw [hfilter_eq]
-  exact hcomm_g
-
-/-- If `g` is in the centralizer, its Z-chain is a dual cycle. -/
-private lemma zChain_mem_toricDualCycles_of_centralizer (L : ℕ) [Fact (2 ≤ L)]
-    (g : NQubitPauliGroupElement (numQubits L))
-    (hg : g ∈ centralizer (stabilizerGroup L)) :
-    zChainOf L g ∈ Stabilizer.Lattice.toricDualCycles (L := L) := by
-  apply (Stabilizer.Lattice.zCommutesWithXChecks_iff_mem_toricDualCycles L (zChainOf L g)).mp
-  intro x hx
-  rcases hx with ⟨⟨xf, yf⟩, rfl⟩
-  have hmem : faceStab L xf yf ∈ (stabilizerGroup L).toSubgroup := by
-    rw [stabilizerGroup_toSubgroup_eq]
-    apply Subgroup.subset_closure
-    right; exact ⟨(xf, yf), rfl⟩
-  have hcomm_g : faceStab L xf yf * g = g * faceStab L xf yf := by
-    rw [mem_centralizer_iff] at hg
-    exact hg (faceStab L xf yf) hmem
-  rw [NQubitPauliGroupElement.commutes_iff_even_anticommutes] at hcomm_g ⊢
-  classical
-  have hfilter_eq :
-      Finset.univ.filter (NQubitPauliGroupElement.anticommutesAt
-        (faceStab L xf yf).operators
-        (Stabilizer.Lattice.toricZOperatorOfChain L (zChainOf L g)).operators) =
-      Finset.univ.filter (NQubitPauliGroupElement.anticommutesAt
-        (faceStab L xf yf).operators g.operators) := by
-    ext i
-    simp only [Finset.mem_filter, Finset.mem_univ, true_and]
-    exact (anticommutesAt_faceStab_g_iff_zChain L g xf yf i).symm
-  rw [hfilter_eq]
-  exact hcomm_g
-
-/-- Weight of `toricXOperatorOfChain c` equals `edgeWeight c`. -/
-private lemma weight_toricXOperatorOfChain_eq (L : ℕ) [Fact (0 < L)]
-    (c : Stabilizer.Lattice.C1 L) :
-    NQubitPauliGroupElement.weight (Stabilizer.Lattice.toricXOperatorOfChain L c) =
-      Stabilizer.Lattice.edgeWeight (L := L) c := by
-  classical
-  unfold NQubitPauliGroupElement.weight Stabilizer.Lattice.edgeWeight
-  refine Finset.card_bij
-    (fun q (hq : q ∈ NQubitPauliOperator.support _) =>
-      Classical.choose
-        (show ∃ e, Stabilizer.Lattice.edgeToQubitIdx L e = q ∧ c e = 1 from by
-          simp only [NQubitPauliOperator.mem_support, ne_eq,
-            Stabilizer.Lattice.toricXOperatorOfChain] at hq
-          by_cases h : ∃ e, Stabilizer.Lattice.edgeToQubitIdx L e = q ∧ c e = 1
-          · exact h
-          · simp [h] at hq))
-    ?hmem ?hinj ?hsurj
-  · intro a ha
-    have hex : ∃ e, Stabilizer.Lattice.edgeToQubitIdx L e = a ∧ c e = 1 := by
-      simp only [NQubitPauliOperator.mem_support, ne_eq,
-        Stabilizer.Lattice.toricXOperatorOfChain] at ha
-      by_cases h : ∃ e, Stabilizer.Lattice.edgeToQubitIdx L e = a ∧ c e = 1
-      · exact h
-      · simp [h] at ha
-    have hspec := Classical.choose_spec hex
-    simp [Stabilizer.Lattice.mem_edgeSupport, hspec.2]
-  · intro a₁ ha₁ a₂ ha₂ heq
-    have hex1 : ∃ e, Stabilizer.Lattice.edgeToQubitIdx L e = a₁ ∧ c e = 1 := by
-      simp only [NQubitPauliOperator.mem_support, ne_eq,
-        Stabilizer.Lattice.toricXOperatorOfChain] at ha₁
-      by_cases h : ∃ e, Stabilizer.Lattice.edgeToQubitIdx L e = a₁ ∧ c e = 1
-      · exact h
-      · simp [h] at ha₁
-    have hex2 : ∃ e, Stabilizer.Lattice.edgeToQubitIdx L e = a₂ ∧ c e = 1 := by
-      simp only [NQubitPauliOperator.mem_support, ne_eq,
-        Stabilizer.Lattice.toricXOperatorOfChain] at ha₂
-      by_cases h : ∃ e, Stabilizer.Lattice.edgeToQubitIdx L e = a₂ ∧ c e = 1
-      · exact h
-      · simp [h] at ha₂
-    have hspec1 := Classical.choose_spec hex1
-    have hspec2 := Classical.choose_spec hex2
-    calc a₁ = Stabilizer.Lattice.edgeToQubitIdx L (Classical.choose hex1) := hspec1.1.symm
-      _ = Stabilizer.Lattice.edgeToQubitIdx L (Classical.choose hex2) := congrArg _ heq
-      _ = a₂ := hspec2.1
-  · intro b hb
-    refine ⟨Stabilizer.Lattice.edgeToQubitIdx L b, ?_, ?_⟩
-    · have hb1 : c b = 1 := by
-        have hbne : c b ≠ 0 := (Stabilizer.Lattice.mem_edgeSupport _ _).mp hb
-        rcases Fin.exists_fin_two.mp ⟨c b, rfl⟩ with h | h
-        · exfalso; exact hbne h
-        · exact h
-      have hex : ∃ e, Stabilizer.Lattice.edgeToQubitIdx L e =
-          Stabilizer.Lattice.edgeToQubitIdx L b ∧ c e = 1 := ⟨b, rfl, hb1⟩
-      simp only [NQubitPauliOperator.mem_support, ne_eq,
-        Stabilizer.Lattice.toricXOperatorOfChain, hex, ↓reduceIte]
-      decide
-    · have hb1 : c b = 1 := by
-        have hbne : c b ≠ 0 := (Stabilizer.Lattice.mem_edgeSupport _ _).mp hb
-        rcases Fin.exists_fin_two.mp ⟨c b, rfl⟩ with h | h
-        · exfalso; exact hbne h
-        · exact h
-      have hex : ∃ x, Stabilizer.Lattice.edgeToQubitIdx L x =
-          Stabilizer.Lattice.edgeToQubitIdx L b ∧ c x = 1 := ⟨b, rfl, hb1⟩
-      have hspec := Classical.choose_spec hex
-      exact Stabilizer.Lattice.edgeToQubitIdx_injective L hspec.1
-
-/-- Weight of `toricZOperatorOfChain c` equals `edgeWeight c`. -/
-private lemma weight_toricZOperatorOfChain_eq (L : ℕ) [Fact (0 < L)]
-    (c : Stabilizer.Lattice.C1 L) :
-    NQubitPauliGroupElement.weight (Stabilizer.Lattice.toricZOperatorOfChain L c) =
-      Stabilizer.Lattice.edgeWeight (L := L) c := by
-  classical
-  unfold NQubitPauliGroupElement.weight Stabilizer.Lattice.edgeWeight
-  refine Finset.card_bij
-    (fun q (hq : q ∈ NQubitPauliOperator.support _) =>
-      Classical.choose
-        (show ∃ e, Stabilizer.Lattice.edgeToQubitIdx L e = q ∧ c e = 1 from by
-          simp only [NQubitPauliOperator.mem_support, ne_eq,
-            Stabilizer.Lattice.toricZOperatorOfChain] at hq
-          by_cases h : ∃ e, Stabilizer.Lattice.edgeToQubitIdx L e = q ∧ c e = 1
-          · exact h
-          · simp [h] at hq))
-    ?hmem ?hinj ?hsurj
-  · intro a ha
-    have hex : ∃ e, Stabilizer.Lattice.edgeToQubitIdx L e = a ∧ c e = 1 := by
-      simp only [NQubitPauliOperator.mem_support, ne_eq,
-        Stabilizer.Lattice.toricZOperatorOfChain] at ha
-      by_cases h : ∃ e, Stabilizer.Lattice.edgeToQubitIdx L e = a ∧ c e = 1
-      · exact h
-      · simp [h] at ha
-    have hspec := Classical.choose_spec hex
-    simp [Stabilizer.Lattice.mem_edgeSupport, hspec.2]
-  · intro a₁ ha₁ a₂ ha₂ heq
-    have hex1 : ∃ e, Stabilizer.Lattice.edgeToQubitIdx L e = a₁ ∧ c e = 1 := by
-      simp only [NQubitPauliOperator.mem_support, ne_eq,
-        Stabilizer.Lattice.toricZOperatorOfChain] at ha₁
-      by_cases h : ∃ e, Stabilizer.Lattice.edgeToQubitIdx L e = a₁ ∧ c e = 1
-      · exact h
-      · simp [h] at ha₁
-    have hex2 : ∃ e, Stabilizer.Lattice.edgeToQubitIdx L e = a₂ ∧ c e = 1 := by
-      simp only [NQubitPauliOperator.mem_support, ne_eq,
-        Stabilizer.Lattice.toricZOperatorOfChain] at ha₂
-      by_cases h : ∃ e, Stabilizer.Lattice.edgeToQubitIdx L e = a₂ ∧ c e = 1
-      · exact h
-      · simp [h] at ha₂
-    have hspec1 := Classical.choose_spec hex1
-    have hspec2 := Classical.choose_spec hex2
-    calc a₁ = Stabilizer.Lattice.edgeToQubitIdx L (Classical.choose hex1) := hspec1.1.symm
-      _ = Stabilizer.Lattice.edgeToQubitIdx L (Classical.choose hex2) := congrArg _ heq
-      _ = a₂ := hspec2.1
-  · intro b hb
-    refine ⟨Stabilizer.Lattice.edgeToQubitIdx L b, ?_, ?_⟩
-    · have hb1 : c b = 1 := by
-        have hbne : c b ≠ 0 := (Stabilizer.Lattice.mem_edgeSupport _ _).mp hb
-        rcases Fin.exists_fin_two.mp ⟨c b, rfl⟩ with h | h
-        · exfalso; exact hbne h
-        · exact h
-      have hex : ∃ e, Stabilizer.Lattice.edgeToQubitIdx L e =
-          Stabilizer.Lattice.edgeToQubitIdx L b ∧ c e = 1 := ⟨b, rfl, hb1⟩
-      simp only [NQubitPauliOperator.mem_support, ne_eq,
-        Stabilizer.Lattice.toricZOperatorOfChain, hex, ↓reduceIte]
-      decide
-    · have hb1 : c b = 1 := by
-        have hbne : c b ≠ 0 := (Stabilizer.Lattice.mem_edgeSupport _ _).mp hb
-        rcases Fin.exists_fin_two.mp ⟨c b, rfl⟩ with h | h
-        · exfalso; exact hbne h
-        · exact h
-      have hex : ∃ x, Stabilizer.Lattice.edgeToQubitIdx L x =
-          Stabilizer.Lattice.edgeToQubitIdx L b ∧ c x = 1 := ⟨b, rfl, hb1⟩
-      have hspec := Classical.choose_spec hex
-      exact Stabilizer.Lattice.edgeToQubitIdx_injective L hspec.1
-
-/-- For a nontrivial logical `g`, the X-chain and Z-chain cannot both be boundaries.
-
-Delegates to the generic CSS bridge
-`Homological.HomologicalCode.not_both_boundary_of_nontrivial` on `toricHomologicalCode L`,
-via the subgroup bridge (`toricHomologicalCode_homologicalStabilizerGroup_toSubgroup_eq`)
-and the `dualBoundaries` bridge (`toricHomologicalCode_dualBoundaries_eq`).  The
-`xChainOf`/`zChainOf`-side bridges are `rfl` since both definitions share
-`edgeToQubitIdx` as their qubit-indexing equivalence. -/
-private lemma not_both_boundary_of_nontrivial (L : ℕ) [Fact (2 ≤ L)]
-    (g : NQubitPauliGroupElement (numQubits L))
-    (hg : IsNontrivialLogicalOperator g (stabilizerGroup L)) :
-    ¬(xChainOf L g ∈ Stabilizer.Lattice.toricBoundaries (L := L) ∧
-      zChainOf L g ∈ Stabilizer.Lattice.toricDualBoundaries (L := L)) := by
-  have hL0 : 0 < L := Nat.lt_of_lt_of_le (by decide : 0 < 2) (Fact.out : 2 ≤ L)
-  haveI : Fact (0 < L) := ⟨hL0⟩
-  -- Translate the lattice `IsNontrivialLogicalOperator` to the abstract one
-  -- via the subgroup bridge.
-  have h_sub_eq :
-      (stabilizerGroup L).toSubgroup =
-        (Stabilizer.Lattice.toricHomologicalCode L).homologicalStabilizerGroup.toSubgroup :=
-    (Stabilizer.Lattice.toricHomologicalCode_homologicalStabilizerGroup_toSubgroup_eq L).symm
-  have hg_abs :
-      IsNontrivialLogicalOperator g
-        (Stabilizer.Lattice.toricHomologicalCode L).homologicalStabilizerGroup :=
-    (IsNontrivialLogicalOperator_of_toSubgroup_eq g h_sub_eq).mp hg
-  -- Now invoke the generic `not_both_boundary_of_nontrivial`.
-  -- The toric `xChainOf` matches `(toricHomologicalCode L).xChainOf` by definition
-  -- (both use `edgeToQubitIdx L` via the `edgeEquiv` field).
-  -- Same for `zChainOf` and `toricBoundaries = (toricHomologicalCode L).boundaries` (rfl).
-  -- `toricDualBoundaries` matches via `toricHomologicalCode_dualBoundaries_eq`.
-  rintro ⟨hxBnd, hzBnd⟩
-  apply (Stabilizer.Lattice.toricHomologicalCode L).not_both_boundary_of_nontrivial g hg_abs
-  refine ⟨?_, ?_⟩
-  · exact hxBnd
-  · rw [← Stabilizer.Lattice.toricHomologicalCode_dualBoundaries_eq L] at hzBnd
-    exact hzBnd
+/-! ## CSS bridge: full distance = min(dX, dZ) -/
 
 /-- CSS bridge: full distance = min(dX, dZ). -/
-theorem toricCodeN_distance_eq_min_dX_dZ (L dX dZ : ℕ) [Fact (2 ≤ L)]
+theorem toricCodeN_distance_eq_min_dX_dZ (dX dZ : ℕ)
     (hx : HasToricXDistance L dX) (hz : HasToricZDistance L dZ) :
     HasCodeDistance (toricStabilizerCode L) (Nat.min dX dZ) := by
   have hL0 : 0 < L := Nat.lt_of_lt_of_le (by decide : 0 < 2) (Fact.out : 2 ≤ L)
@@ -472,111 +47,136 @@ theorem toricCodeN_distance_eq_min_dX_dZ (L dX dZ : ℕ) [Fact (2 ≤ L)]
   have h_iff : ∀ g, IsNontrivialLogicalOperator g (toricStabilizerCode L).toStabilizerGroup ↔
       IsNontrivialLogicalOperator g (stabilizerGroup L) :=
     fun g => IsNontrivialLogicalOperator_of_toSubgroup_eq g h_subgroup_eq
+  -- Bridge to the abstract homological stabilizer group.
+  have h_sub_eq_hom :
+      (stabilizerGroup L).toSubgroup =
+        (Stabilizer.Lattice.toricHomologicalCode L).homologicalStabilizerGroup.toSubgroup :=
+    (Stabilizer.Lattice.toricHomologicalCode_homologicalStabilizerGroup_toSubgroup_eq L).symm
+  have h_iff_hom : ∀ g, IsNontrivialLogicalOperator g (stabilizerGroup L) ↔
+      IsNontrivialLogicalOperator g
+        (Stabilizer.Lattice.toricHomologicalCode L).homologicalStabilizerGroup :=
+    fun g => IsNontrivialLogicalOperator_of_toSubgroup_eq g h_sub_eq_hom
+  have h_cent_eq :
+      centralizer (Stabilizer.Lattice.toricHomologicalCode L).homologicalStabilizerGroup =
+        centralizer (stabilizerGroup L) :=
+    centralizer_eq_of_toSubgroup_eq _ _ h_sub_eq_hom.symm
   refine ⟨le_min hdXpos hdZpos, ?_, ?_⟩
-  · intro g hgLogical' hgwpos
+  · -- Lower bound
+    intro g hgLogical' _hgwpos
     have hgLogical := (h_iff g).mp hgLogical'
-    have h_not_both := not_both_boundary_of_nontrivial L g hgLogical
+    have hgLogical_hom := (h_iff_hom g).mp hgLogical
     have hg_cent : g ∈ centralizer (stabilizerGroup L) :=
       (IsNontrivialLogicalOperator_iff g (stabilizerGroup L)).mp hgLogical |>.1
-    have hxCyc : xChainOf L g ∈ Stabilizer.Lattice.toricCycles (L := L) :=
-      xChain_mem_toricCycles_of_centralizer L g hg_cent
-    have hzCyc : zChainOf L g ∈ Stabilizer.Lattice.toricDualCycles (L := L) :=
-      zChain_mem_toricDualCycles_of_centralizer L g hg_cent
-    by_cases hxBnd : xChainOf L g ∈ Stabilizer.Lattice.toricBoundaries (L := L)
-    · by_cases hzBnd : zChainOf L g ∈ Stabilizer.Lattice.toricDualBoundaries (L := L)
-      · exact absurd ⟨hxBnd, hzBnd⟩ h_not_both
-      · -- Use Z-distance bound
-        have hzNontrivial :
-            IsNontrivialLogicalOperator
-              (Stabilizer.Lattice.toricZOperatorOfChain L (zChainOf L g))
-              (stabilizerGroup L) :=
-          (Stabilizer.Lattice.zNontrivialLogical_iff_dualCycle_not_dualBoundary L
-            (zChainOf L g)).mpr ⟨hzCyc, hzBnd⟩
-        have hzType :
-            NQubitPauliGroupElement.IsZTypeElement
-              (Stabilizer.Lattice.toricZOperatorOfChain L (zChainOf L g)) := by
-          refine ⟨rfl, ?_⟩
-          intro q
-          simp only [Stabilizer.Lattice.toricZOperatorOfChain]
-          by_cases h : ∃ e, Stabilizer.Lattice.edgeToQubitIdx L e = q ∧ zChainOf L g e = 1
-          · simp [h]; exact PauliOperator.IsZType_Z
-          · simp [h]; exact PauliOperator.IsZType_I
-        have h_zChain_pos : 0 < Stabilizer.Lattice.edgeWeight (L := L) (zChainOf L g) := by
-          rcases Nat.eq_zero_or_pos
-            (Stabilizer.Lattice.edgeWeight (L := L) (zChainOf L g)) with h0 | hpos
-          · exfalso
-            have hzero : Stabilizer.Lattice.edgeSupport (L := L) (zChainOf L g) = ∅ := by
-              rw [show Stabilizer.Lattice.edgeWeight (L := L) (zChainOf L g) =
-                  (Stabilizer.Lattice.edgeSupport (L := L) (zChainOf L g)).card from rfl,
-                Finset.card_eq_zero] at h0
-              exact h0
-            have hzChain_zero : zChainOf L g = 0 := by
-              funext e
-              change zChainOf L g e = 0
-              by_contra hne
-              have hmem : e ∈ Stabilizer.Lattice.edgeSupport (L := L) (zChainOf L g) := by
-                simp [Stabilizer.Lattice.mem_edgeSupport, hne]
-              rw [hzero] at hmem
-              exact (Finset.notMem_empty _ hmem)
-            have : zChainOf L g ∈ Stabilizer.Lattice.toricDualBoundaries (L := L) := by
-              rw [hzChain_zero]; exact Submodule.zero_mem _
-            exact hzBnd this
-          · exact hpos
-        have hwz : weight g ≥ dZ := by
-          calc weight g
-              ≥ Stabilizer.Lattice.edgeWeight (L := L) (zChainOf L g) :=
-                weight_ge_edgeWeight_zChain L g
-            _ = NQubitPauliGroupElement.weight
-                  (Stabilizer.Lattice.toricZOperatorOfChain L (zChainOf L g)) :=
-                (weight_toricZOperatorOfChain_eq L _).symm
-            _ ≥ dZ := hzLB _ hzType hzNontrivial
-                (by rw [weight_toricZOperatorOfChain_eq]; exact h_zChain_pos)
-        exact le_trans (Nat.min_le_right _ _) hwz
-    · have hxNontrivial :
-          IsNontrivialLogicalOperator
-            (Stabilizer.Lattice.toricXOperatorOfChain L (xChainOf L g))
-            (stabilizerGroup L) :=
-        (Stabilizer.Lattice.xNontrivialLogical_iff_cycle_not_boundary L
-          (xChainOf L g)).mpr ⟨hxCyc, hxBnd⟩
-      have hxType :
-          NQubitPauliGroupElement.IsXTypeElement
-            (Stabilizer.Lattice.toricXOperatorOfChain L (xChainOf L g)) := by
-        refine ⟨rfl, ?_⟩
-        intro q
-        simp only [Stabilizer.Lattice.toricXOperatorOfChain]
-        by_cases h : ∃ e, Stabilizer.Lattice.edgeToQubitIdx L e = q ∧ xChainOf L g e = 1
-        · simp [h]; exact PauliOperator.IsXType_X
-        · simp [h]; exact PauliOperator.IsXType_I
-      have h_xChain_pos : 0 < Stabilizer.Lattice.edgeWeight (L := L) (xChainOf L g) := by
-        rcases Nat.eq_zero_or_pos
-          (Stabilizer.Lattice.edgeWeight (L := L) (xChainOf L g)) with h0 | hpos
-        · exfalso
-          have hzero : Stabilizer.Lattice.edgeSupport (L := L) (xChainOf L g) = ∅ := by
-            rw [show Stabilizer.Lattice.edgeWeight (L := L) (xChainOf L g) =
-                (Stabilizer.Lattice.edgeSupport (L := L) (xChainOf L g)).card from rfl,
-              Finset.card_eq_zero] at h0
-            exact h0
-          have hxChain_zero : xChainOf L g = 0 := by
-            funext e
-            change xChainOf L g e = 0
-            by_contra hne
-            have hmem : e ∈ Stabilizer.Lattice.edgeSupport (L := L) (xChainOf L g) := by
-              simp [Stabilizer.Lattice.mem_edgeSupport, hne]
-            rw [hzero] at hmem
-            exact (Finset.notMem_empty _ hmem)
-          have : xChainOf L g ∈ Stabilizer.Lattice.toricBoundaries (L := L) := by
-            rw [hxChain_zero]; exact Submodule.zero_mem _
-          exact hxBnd this
-        · exact hpos
+    have hg_cent_hom :
+        g ∈ centralizer
+          (Stabilizer.Lattice.toricHomologicalCode L).homologicalStabilizerGroup := by
+      rw [h_cent_eq]; exact hg_cent
+    -- Apply the abstract CSS bridge.
+    have h_not_both := not_both_boundary_of_nontrivial
+      (X := Stabilizer.Lattice.toricHomologicalCode L) g hgLogical_hom
+    -- xChainOf g ∈ cycles, zChainOf g ∈ dualCycles
+    have hxCyc := xChainOf_mem_cycles_of_centralizer
+      (X := Stabilizer.Lattice.toricHomologicalCode L) g hg_cent_hom
+    have hzCyc := zChainOf_mem_dualCycles_of_centralizer
+      (X := Stabilizer.Lattice.toricHomologicalCode L) g hg_cent_hom
+    by_cases hxBnd : (Stabilizer.Lattice.toricHomologicalCode L).xChainOf g ∈
+        (Stabilizer.Lattice.toricHomologicalCode L).boundaries
+    · -- Then zChainOf g ∉ dualBoundaries — use Z-distance bound.
+      have hzBnd : (Stabilizer.Lattice.toricHomologicalCode L).zChainOf g ∉
+          (Stabilizer.Lattice.toricHomologicalCode L).dualBoundaries := by
+        intro h; exact h_not_both ⟨hxBnd, h⟩
+      -- chainZOperator (zChainOf g) is a Z-type non-trivial logical.
+      set gZ : NQubitPauliGroupElement (numQubits L) :=
+        (Stabilizer.Lattice.toricHomologicalCode L).chainZOperator
+          ((Stabilizer.Lattice.toricHomologicalCode L).zChainOf g) with hgZ_def
+      have hgZ_isZType : NQubitPauliGroupElement.IsZTypeElement gZ :=
+        chainZOperator_isZType (X := Stabilizer.Lattice.toricHomologicalCode L) _
+      have hgZ_nl_hom :
+          IsNontrivialLogicalOperator gZ
+            (Stabilizer.Lattice.toricHomologicalCode L).homologicalStabilizerGroup :=
+        (chainZOperator_isNontrivialLogical_iff
+          (X := Stabilizer.Lattice.toricHomologicalCode L)
+          ((Stabilizer.Lattice.toricHomologicalCode L).zChainOf g)).mpr ⟨hzCyc, hzBnd⟩
+      have hgZ_nl : IsNontrivialLogicalOperator gZ (stabilizerGroup L) :=
+        (h_iff_hom gZ).mpr hgZ_nl_hom
+      -- Need 0 < weight gZ for the Z-distance lower bound to apply.
+      have h_gZ_pos : 0 < weight gZ := by
+        change 0 < NQubitPauliGroupElement.weight
+            ((Stabilizer.Lattice.toricHomologicalCode L).chainZOperator
+              ((Stabilizer.Lattice.toricHomologicalCode L).zChainOf g))
+        rw [weight_chainZOperator (X := Stabilizer.Lattice.toricHomologicalCode L)]
+        unfold chainWeight chainSupport
+        rw [Finset.card_pos]
+        by_contra hempty
+        rw [Finset.not_nonempty_iff_eq_empty] at hempty
+        apply hzBnd
+        have h_eq : (Stabilizer.Lattice.toricHomologicalCode L).zChainOf g = 0 := by
+          funext e
+          change (Stabilizer.Lattice.toricHomologicalCode L).zChainOf g e = (0 : ZMod 2)
+          by_contra hne
+          have hmem : e ∈
+              (Finset.univ : Finset (Stabilizer.Lattice.toricHomologicalCode L).C1).filter
+                (fun e => (Stabilizer.Lattice.toricHomologicalCode L).zChainOf g e ≠ 0) := by
+            simp [hne]
+          rw [hempty] at hmem
+          exact (Finset.notMem_empty _ hmem)
+        rw [h_eq]; exact Submodule.zero_mem _
+      have hwz : weight g ≥ dZ := by
+        calc weight g
+            ≥ (Stabilizer.Lattice.toricHomologicalCode L).chainWeight
+                ((Stabilizer.Lattice.toricHomologicalCode L).zChainOf g) :=
+              weight_ge_chainWeight_zChainOf
+                (X := Stabilizer.Lattice.toricHomologicalCode L) g
+          _ = weight gZ :=
+              (weight_chainZOperator
+                (X := Stabilizer.Lattice.toricHomologicalCode L) _).symm
+          _ ≥ dZ := hzLB _ hgZ_isZType hgZ_nl h_gZ_pos
+      exact le_trans (Nat.min_le_right _ _) hwz
+    · -- xChainOf g ∉ boundaries — use X-distance bound.
+      set gX : NQubitPauliGroupElement (numQubits L) :=
+        (Stabilizer.Lattice.toricHomologicalCode L).chainXOperator
+          ((Stabilizer.Lattice.toricHomologicalCode L).xChainOf g) with hgX_def
+      have hgX_isXType : NQubitPauliGroupElement.IsXTypeElement gX :=
+        chainXOperator_isXType (X := Stabilizer.Lattice.toricHomologicalCode L) _
+      have hgX_nl_hom :
+          IsNontrivialLogicalOperator gX
+            (Stabilizer.Lattice.toricHomologicalCode L).homologicalStabilizerGroup :=
+        (chainXOperator_isNontrivialLogical_iff
+          (X := Stabilizer.Lattice.toricHomologicalCode L)
+          ((Stabilizer.Lattice.toricHomologicalCode L).xChainOf g)).mpr ⟨hxCyc, hxBnd⟩
+      have hgX_nl : IsNontrivialLogicalOperator gX (stabilizerGroup L) :=
+        (h_iff_hom gX).mpr hgX_nl_hom
+      have h_gX_pos : 0 < weight gX := by
+        change 0 < NQubitPauliGroupElement.weight
+            ((Stabilizer.Lattice.toricHomologicalCode L).chainXOperator
+              ((Stabilizer.Lattice.toricHomologicalCode L).xChainOf g))
+        rw [weight_chainXOperator (X := Stabilizer.Lattice.toricHomologicalCode L)]
+        unfold chainWeight chainSupport
+        rw [Finset.card_pos]
+        by_contra hempty
+        rw [Finset.not_nonempty_iff_eq_empty] at hempty
+        apply hxBnd
+        have h_eq : (Stabilizer.Lattice.toricHomologicalCode L).xChainOf g = 0 := by
+          funext e
+          change (Stabilizer.Lattice.toricHomologicalCode L).xChainOf g e = (0 : ZMod 2)
+          by_contra hne
+          have hmem : e ∈
+              (Finset.univ : Finset (Stabilizer.Lattice.toricHomologicalCode L).C1).filter
+                (fun e => (Stabilizer.Lattice.toricHomologicalCode L).xChainOf g e ≠ 0) := by
+            simp [hne]
+          rw [hempty] at hmem
+          exact (Finset.notMem_empty _ hmem)
+        rw [h_eq]; exact Submodule.zero_mem _
       have hwx : weight g ≥ dX := by
         calc weight g
-            ≥ Stabilizer.Lattice.edgeWeight (L := L) (xChainOf L g) :=
-              weight_ge_edgeWeight_xChain L g
-          _ = NQubitPauliGroupElement.weight
-                (Stabilizer.Lattice.toricXOperatorOfChain L (xChainOf L g)) :=
-              (weight_toricXOperatorOfChain_eq L _).symm
-          _ ≥ dX := hxLB _ hxType hxNontrivial
-              (by rw [weight_toricXOperatorOfChain_eq]; exact h_xChain_pos)
+            ≥ (Stabilizer.Lattice.toricHomologicalCode L).chainWeight
+                ((Stabilizer.Lattice.toricHomologicalCode L).xChainOf g) :=
+              weight_ge_chainWeight_xChainOf
+                (X := Stabilizer.Lattice.toricHomologicalCode L) g
+          _ = weight gX :=
+              (weight_chainXOperator
+                (X := Stabilizer.Lattice.toricHomologicalCode L) _).symm
+          _ ≥ dX := hxLB _ hgX_isXType hgX_nl h_gX_pos
       exact le_trans (Nat.min_le_left _ _) hwx
   · -- Witness
     by_cases hle : dX ≤ dZ
@@ -588,12 +188,10 @@ theorem toricCodeN_distance_eq_min_dX_dZ (L dX dZ : ℕ) [Fact (2 ≤ L)]
       refine ⟨g, (h_iff g).mpr hg_logical, ?_⟩
       rw [hg_weight]; exact (Nat.min_eq_right (le_of_lt hle)).symm
 
--- ---------------------------------------------------------------------------
--- 3.  Full distance = L
--- ---------------------------------------------------------------------------
+/-! ## Full distance = L -/
 
 /-- Section 8.3 endpoint: the full toric-code distance is `L`. -/
-theorem toricCodeN_distance_eq_L (L : ℕ) [Fact (2 ≤ L)] :
+theorem toricCodeN_distance_eq_L :
     HasCodeDistance (toricStabilizerCode L) L := by
   have hx : HasToricXDistance L L := toricCodeN_dX_eq_L L
   have hz : HasToricZDistance L L := toricCodeN_dZ_eq_L L

--- a/QEC/Stabilizer/Homological/Distance.lean
+++ b/QEC/Stabilizer/Homological/Distance.lean
@@ -201,6 +201,209 @@ lemma chainZOperator_zChainOf_op_at
     push Not
     exact hzy
 
+/-! ## Weight of the X- / Z-only encodings
+
+The qubit support of `chainXOperator c` (resp. `chainZOperator c`) is in
+bijection with `chainSupport c` via `edgeEquiv`, hence the operator
+weight equals the chain weight. -/
+
+/-- `weight (chainXOperator c) = chainWeight c`. -/
+lemma weight_chainXOperator (c : X.C1 → ZMod 2) :
+    NQubitPauliGroupElement.weight (X.chainXOperator c) = X.chainWeight c := by
+  classical
+  unfold NQubitPauliGroupElement.weight NQubitPauliOperator.weight
+    chainWeight chainSupport
+  symm
+  apply Finset.card_bij (fun v _ => X.edgeEquiv v)
+  · intro v hv
+    rw [Finset.mem_filter] at hv
+    have h1 : c v = 1 :=
+      (zmod2_dichotomy_local (c v)).resolve_left hv.2
+    exact (mem_support_chainXOperator_iff c v).mpr h1
+  · intros v₁ _ v₂ _ heq
+    exact X.edgeEquiv.injective heq
+  · intros q hq
+    refine ⟨X.edgeEquiv.symm q, ?_, by simp⟩
+    rw [Finset.mem_filter]
+    refine ⟨Finset.mem_univ _, ?_⟩
+    have h_iff := mem_support_chainXOperator_iff (X := X) c (X.edgeEquiv.symm q)
+    rw [Equiv.apply_symm_apply] at h_iff
+    have : c (X.edgeEquiv.symm q) = 1 := h_iff.mp hq
+    rw [this]; decide
+
+/-- Mirror: `weight (chainZOperator c) = chainWeight c`. -/
+lemma weight_chainZOperator (c : X.C1 → ZMod 2) :
+    NQubitPauliGroupElement.weight (X.chainZOperator c) = X.chainWeight c := by
+  classical
+  unfold NQubitPauliGroupElement.weight NQubitPauliOperator.weight
+    chainWeight chainSupport
+  symm
+  apply Finset.card_bij (fun v _ => X.edgeEquiv v)
+  · intro v hv
+    rw [Finset.mem_filter] at hv
+    have h1 : c v = 1 :=
+      (zmod2_dichotomy_local (c v)).resolve_left hv.2
+    exact (mem_support_chainZOperator_iff c v).mpr h1
+  · intros v₁ _ v₂ _ heq
+    exact X.edgeEquiv.injective heq
+  · intros q hq
+    refine ⟨X.edgeEquiv.symm q, ?_, by simp⟩
+    rw [Finset.mem_filter]
+    refine ⟨Finset.mem_univ _, ?_⟩
+    have h_iff := mem_support_chainZOperator_iff (X := X) c (X.edgeEquiv.symm q)
+    rw [Equiv.apply_symm_apply] at h_iff
+    have : c (X.edgeEquiv.symm q) = 1 := h_iff.mp hq
+    rw [this]; decide
+
+/-! ## Qubit-wise anticommutation bridges
+
+For any qubit `i`, the qubit-wise anticommutation of `g` against a Z-type
+generator (`vertexStabOf v`) is determined entirely by `g`'s X-content at `i`,
+i.e. matches that of `chainXOperator (xChainOf g)`.  Mirror on the Z side.
+These let centralizer-style arguments on `g` transfer to its X-only / Z-only
+encoding without redoing the Pauli case analysis. -/
+
+/-- Anticommutation against the Z-type vertex stab matches between `g` and
+its X-only encoding `chainXOperator (xChainOf g)`. -/
+lemma anticommutesAt_vertexStabOf_iff_xChainOf
+    (g : NQubitPauliGroupElement X.numQubits) (v : X.C0)
+    (i : Fin X.numQubits) :
+    NQubitPauliGroupElement.anticommutesAt (X.vertexStabOf v).operators
+        g.operators i ↔
+      NQubitPauliGroupElement.anticommutesAt (X.vertexStabOf v).operators
+        (X.chainXOperator (X.xChainOf g)).operators i := by
+  have hZ : (X.vertexStabOf v).operators i = PauliOperator.I ∨
+      (X.vertexStabOf v).operators i = PauliOperator.Z :=
+    (vertexStabOf_isZType v).2 i
+  have heq := chainXOperator_xChainOf_op_at (X := X) g i
+  rcases hZ with hI | hZ
+  · simp only [NQubitPauliGroupElement.anticommutesAt, hI]
+    cases hgi : g.operators i <;>
+      cases hxi : (X.chainXOperator (X.xChainOf g)).operators i <;>
+      simp [PauliOperator.mulOp]
+  · simp only [NQubitPauliGroupElement.anticommutesAt, hZ, heq]
+    cases hgi : g.operators i <;>
+      simp [PauliOperator.mulOp]
+
+/-- Mirror: anticommutation against the X-type face stab matches between
+`g` and its Z-only encoding `chainZOperator (zChainOf g)`. -/
+lemma anticommutesAt_faceStabOf_iff_zChainOf
+    (g : NQubitPauliGroupElement X.numQubits) (f : X.C2)
+    (i : Fin X.numQubits) :
+    NQubitPauliGroupElement.anticommutesAt (X.faceStabOf f).operators
+        g.operators i ↔
+      NQubitPauliGroupElement.anticommutesAt (X.faceStabOf f).operators
+        (X.chainZOperator (X.zChainOf g)).operators i := by
+  have hX : (X.faceStabOf f).operators i = PauliOperator.I ∨
+      (X.faceStabOf f).operators i = PauliOperator.X :=
+    (faceStabOf_isXType f).2 i
+  have heq := chainZOperator_zChainOf_op_at (X := X) g i
+  rcases hX with hI | hX
+  · simp only [NQubitPauliGroupElement.anticommutesAt, hI]
+    cases hgi : g.operators i <;>
+      cases hzi : (X.chainZOperator (X.zChainOf g)).operators i <;>
+      simp [PauliOperator.mulOp]
+  · simp only [NQubitPauliGroupElement.anticommutesAt, hX, heq]
+    cases hgi : g.operators i <;>
+      simp [PauliOperator.mulOp]
+
+/-! ## Centralizer → cycle bridges
+
+These complete the qubit-level commutation story: if `g` commutes with every
+stabilizer, then its X-chain is a 1-cycle (resp. Z-chain is a dual 1-cycle).
+The bridge runs through `chainXOperator_mem_centralizer_iff_mem_cycles` from
+`LogicalCorrespondence.lean`. -/
+
+/-- For `g ∈ centralizer`, `xChainOf g` is a 1-cycle. -/
+lemma xChainOf_mem_cycles_of_centralizer
+    (g : NQubitPauliGroupElement X.numQubits)
+    (hg : g ∈ Quantum.StabilizerGroup.centralizer X.homologicalStabilizerGroup) :
+    X.xChainOf g ∈ X.cycles := by
+  apply (chainXOperator_mem_centralizer_iff_mem_cycles (X.xChainOf g)).mp
+  intro s hs
+  refine Subgroup.closure_induction
+    (p := fun y _ => y * X.chainXOperator (X.xChainOf g) =
+      X.chainXOperator (X.xChainOf g) * y) ?_ ?_ ?_ ?_ hs
+  · rintro y (⟨v, rfl⟩ | ⟨f, rfl⟩)
+    · -- y = vertexStabOf v (Z-type generator)
+      have hmem : X.vertexStabOf v ∈ X.homologicalStabilizerGroup.toSubgroup :=
+        Subgroup.subset_closure (Or.inl ⟨v, rfl⟩)
+      have hcomm_g : X.vertexStabOf v * g = g * X.vertexStabOf v :=
+        (Quantum.StabilizerGroup.mem_centralizer_iff g _).mp hg _ hmem
+      rw [NQubitPauliGroupElement.commutes_iff_even_anticommutes] at hcomm_g ⊢
+      classical
+      have hfilter_eq :
+          Finset.univ.filter (NQubitPauliGroupElement.anticommutesAt
+              (X.vertexStabOf v).operators
+              (X.chainXOperator (X.xChainOf g)).operators) =
+            Finset.univ.filter (NQubitPauliGroupElement.anticommutesAt
+              (X.vertexStabOf v).operators g.operators) := by
+        ext i
+        simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+        exact (anticommutesAt_vertexStabOf_iff_xChainOf (X := X) g v i).symm
+      rw [hfilter_eq]
+      exact hcomm_g
+    · -- y = faceStabOf f (X-type generator) — X-X commutes
+      exact chainXOperator_commutes_faceStabOf (X := X) (X.xChainOf g) f
+  · change (1 : NQubitPauliGroupElement X.numQubits) *
+        X.chainXOperator (X.xChainOf g) =
+        X.chainXOperator (X.xChainOf g) * 1
+    rw [_root_.one_mul, _root_.mul_one]
+  · intros y₁ y₂ _ _ hy₁ hy₂
+    calc (y₁ * y₂) * X.chainXOperator (X.xChainOf g)
+        = y₁ * (y₂ * X.chainXOperator (X.xChainOf g)) := _root_.mul_assoc _ _ _
+      _ = y₁ * (X.chainXOperator (X.xChainOf g) * y₂) := by rw [hy₂]
+      _ = (y₁ * X.chainXOperator (X.xChainOf g)) * y₂ := (_root_.mul_assoc _ _ _).symm
+      _ = (X.chainXOperator (X.xChainOf g) * y₁) * y₂ := by rw [hy₁]
+      _ = X.chainXOperator (X.xChainOf g) * (y₁ * y₂) := _root_.mul_assoc _ _ _
+  · intros y _ hy
+    exact (show Commute y _ from hy).inv_left.eq
+
+/-- Mirror: for `g ∈ centralizer`, `zChainOf g` is a dual 1-cycle. -/
+lemma zChainOf_mem_dualCycles_of_centralizer
+    (g : NQubitPauliGroupElement X.numQubits)
+    (hg : g ∈ Quantum.StabilizerGroup.centralizer X.homologicalStabilizerGroup) :
+    X.zChainOf g ∈ X.dualCycles := by
+  apply (chainZOperator_mem_centralizer_iff_mem_dualCycles (X.zChainOf g)).mp
+  intro s hs
+  refine Subgroup.closure_induction
+    (p := fun y _ => y * X.chainZOperator (X.zChainOf g) =
+      X.chainZOperator (X.zChainOf g) * y) ?_ ?_ ?_ ?_ hs
+  · rintro y (⟨v, rfl⟩ | ⟨f, rfl⟩)
+    · -- y = vertexStabOf v (Z-type generator) — Z-Z commutes
+      exact chainZOperator_commutes_vertexStabOf (X := X) (X.zChainOf g) v
+    · -- y = faceStabOf f (X-type generator)
+      have hmem : X.faceStabOf f ∈ X.homologicalStabilizerGroup.toSubgroup :=
+        Subgroup.subset_closure (Or.inr ⟨f, rfl⟩)
+      have hcomm_g : X.faceStabOf f * g = g * X.faceStabOf f :=
+        (Quantum.StabilizerGroup.mem_centralizer_iff g _).mp hg _ hmem
+      rw [NQubitPauliGroupElement.commutes_iff_even_anticommutes] at hcomm_g ⊢
+      classical
+      have hfilter_eq :
+          Finset.univ.filter (NQubitPauliGroupElement.anticommutesAt
+              (X.faceStabOf f).operators
+              (X.chainZOperator (X.zChainOf g)).operators) =
+            Finset.univ.filter (NQubitPauliGroupElement.anticommutesAt
+              (X.faceStabOf f).operators g.operators) := by
+        ext i
+        simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+        exact (anticommutesAt_faceStabOf_iff_zChainOf (X := X) g f i).symm
+      rw [hfilter_eq]
+      exact hcomm_g
+  · change (1 : NQubitPauliGroupElement X.numQubits) *
+        X.chainZOperator (X.zChainOf g) =
+        X.chainZOperator (X.zChainOf g) * 1
+    rw [_root_.one_mul, _root_.mul_one]
+  · intros y₁ y₂ _ _ hy₁ hy₂
+    calc (y₁ * y₂) * X.chainZOperator (X.zChainOf g)
+        = y₁ * (y₂ * X.chainZOperator (X.zChainOf g)) := _root_.mul_assoc _ _ _
+      _ = y₁ * (X.chainZOperator (X.zChainOf g) * y₂) := by rw [hy₂]
+      _ = (y₁ * X.chainZOperator (X.zChainOf g)) * y₂ := (_root_.mul_assoc _ _ _).symm
+      _ = (X.chainZOperator (X.zChainOf g) * y₁) * y₂ := by rw [hy₁]
+      _ = X.chainZOperator (X.zChainOf g) * (y₁ * y₂) := _root_.mul_assoc _ _ _
+  · intros y _ hy
+    exact (show Commute y _ from hy).inv_left.eq
+
 /-! ## not_both_boundary_of_nontrivial
 
 Note: the Z-side closure helpers (`chainZOperator_cutMap_mem_ZClosure`,


### PR DESCRIPTION
Moves the centralizer→cycle / centralizer→dualCycle bridges, the qubit-wise anticommutation pattern-matching lemmas, and the weight↔chainWeight bijections from the per-code distance files into `Stabilizer.Homological.Distance`.  This eliminates the duplication between the toric and rotated-surface distance proofs and demonstrates that the abstract `HomologicalCode` framework genuinely captures the CSS distance argument once-and-for-all.

New generic lemmas in `Distance.lean`:
* `weight_chainXOperator` / `weight_chainZOperator` — `weight (chainXOperator c) = chainWeight c` (and Z-side mirror).
* `anticommutesAt_vertexStabOf_iff_xChainOf` / `anticommutesAt_faceStabOf_iff_zChainOf` — anticommutation against a Z-type (resp. X-type) generator at qubit `i` depends only on `g`'s X- (resp. Z-)content at `i`, matching that of `chainXOperator (xChainOf g)` (resp. Z mirror).
* `xChainOf_mem_cycles_of_centralizer` / `zChainOf_mem_dualCycles_of_centralizer` — for `g ∈ centralizer`, `xChainOf g` is a cycle (resp. Z mirror).

Consumers:
* `ToricCodeNDistance.lean` shrinks 609 → 207 lines.  All 14 local helpers (`xChain_mem_toricCycles_of_centralizer`, `weight_toricXOperatorOfChain_eq`, local `not_both_boundary_of_nontrivial`, …) are deleted; the main `toricCodeN_distance_eq_min_dX_dZ` proof now delegates to the generic framework via the existing toric `HomologicalCode` bridge.
* `RotatedSurfaceCodeNDistance.lean` shrinks 467 → 138 lines.  Same pattern: only the main theorem `rotatedSurfaceCodeN_distance_eq_L` remains, with all centralizer/weight/anticommute logic delegated.

Net effect: +203 lines in the framework, −728 lines across the two distance files (−525 net).  Both codes now derive their full distance proof from a shared abstract argument.