### PR TITLE
feat(core): add StabilizerCodeWithDistance wrapper

### DIFF
--- a/QEC/Stabilizer/Codes/FiveQubit_5_1_3.lean
+++ b/QEC/Stabilizer/Codes/FiveQubit_5_1_3.lean
@@ -763,6 +763,11 @@ theorem code_has_distance_three : HasCodeDistance stabilizerCode 3 := by
       stabilizerCode.toStabilizerGroup generators stabilizerCode_toSubgroup_eq
       weight_two_anticomm_witness g hg_weight h_cent
 
+/-- The [[5, 1, 3]] perfect code packaged with its distance. -/
+noncomputable def stabilizerCodeWithDistance : StabilizerCodeWithDistance 5 1 3 where
+  toStabilizerCode := stabilizerCode
+  hasDistance      := code_has_distance_three
+
 end FiveQubit_5_1_3
 end StabilizerGroup
 end Quantum

--- a/QEC/Stabilizer/Codes/FourQubit_4_2_2.lean
+++ b/QEC/Stabilizer/Codes/FourQubit_4_2_2.lean
@@ -542,6 +542,11 @@ theorem code_has_distance_two : HasCodeDistance stabilizerCode 2 := by
   exact no_weight_one_mem_centralizer_of_anticommute_witness stabilizerCode.toStabilizerGroup
     generators stabilizerCode_toSubgroup_eq weight_one_anticomm_witness g hg_weight h_cent
 
+/-- The [[4, 2, 2]] code packaged with its distance. -/
+noncomputable def stabilizerCodeWithDistance : StabilizerCodeWithDistance 4 2 2 where
+  toStabilizerCode := stabilizerCode
+  hasDistance      := code_has_distance_two
+
 end FourQubit_4_2_2
 end StabilizerGroup
 end Quantum

--- a/QEC/Stabilizer/Codes/RepetitionCode3.lean
+++ b/QEC/Stabilizer/Codes/RepetitionCode3.lean
@@ -327,6 +327,11 @@ theorem repetitionCode3_min_weight_nontrivial_logical (g : NQubitPauliGroupEleme
     NQubitPauliGroupElement.weight g ≥ 1 :=
   HasCodeDistance.min_weight stabilizerCode 1 repetitionCode3_has_distance_one g hg hw
 
+/-- The 3-qubit repetition code as a `[[3, 1, 1]]` stabilizer code with distance. -/
+noncomputable def stabilizerCodeWithDistance : StabilizerCodeWithDistance 3 1 1 where
+  toStabilizerCode := stabilizerCode
+  hasDistance      := repetitionCode3_has_distance_one
+
 end RepetitionCode3
 end StabilizerGroup
 

--- a/QEC/Stabilizer/Codes/RotatedSurfaceCode3.lean
+++ b/QEC/Stabilizer/Codes/RotatedSurfaceCode3.lean
@@ -556,6 +556,11 @@ theorem rotatedSurfaceCode3_has_distance_three : HasCodeDistance stabilizerCode 
       · exact (Iff.not (IsNontrivialLogicalOperator_of_toSubgroup_eq g h_subgroup_eq)).2
           (no_weight_2_logical g hw))
 
+/-- The 3×3 rotated surface code as a `[[9, 1, 3]]` stabilizer code with distance. -/
+noncomputable def stabilizerCodeWithDistance : StabilizerCodeWithDistance 9 1 3 where
+  toStabilizerCode := stabilizerCode
+  hasDistance      := rotatedSurfaceCode3_has_distance_three
+
 end RotatedSurfaceCode3
 end StabilizerGroup
 end Quantum

--- a/QEC/Stabilizer/Codes/RotatedSurfaceCodeNDistance.lean
+++ b/QEC/Stabilizer/Codes/RotatedSurfaceCodeNDistance.lean
@@ -136,6 +136,13 @@ theorem rotatedSurfaceCodeN_distance_eq_L :
       exact (h_iff_NL (logicalX L)).mpr hlogX_nl_hom
     · exact logicalX_weight_eq_L L
 
+/-- The rotated surface code on an `L × L` lattice packaged as a
+`[[L*L, 1, L]]` stabilizer code with distance. -/
+noncomputable def rotatedSurfaceStabilizerCodeWithDistance :
+    StabilizerCodeWithDistance (numQubits L) 1 L where
+  toStabilizerCode := rotatedSurfaceStabilizerCode L
+  hasDistance      := rotatedSurfaceCodeN_distance_eq_L L
+
 end RotatedSurfaceCodeN
 end StabilizerGroup
 end Quantum

--- a/QEC/Stabilizer/Codes/ToricCodeNDistance.lean
+++ b/QEC/Stabilizer/Codes/ToricCodeNDistance.lean
@@ -197,9 +197,12 @@ theorem toricCodeN_distance_eq_L :
   have hz : HasToricZDistance L L := toricCodeN_dZ_eq_L L
   simpa using toricCodeN_distance_eq_min_dX_dZ L L L hx hz
 
--- (Parameter packaging: `n = 2L²` is the unfolding of `numQubits L`,
--- `k = 2` is encoded in `toricStabilizerCode L : StabilizerCode _ 2`,
--- and `d = L` is `toricCodeN_distance_eq_L`. No separate alias needed.)
+/-- The toric code on an `L × L` lattice packaged as a `[[2L², 2, L]]`
+stabilizer code with distance. -/
+noncomputable def toricStabilizerCodeWithDistance :
+    StabilizerCodeWithDistance (numQubits L) 2 L where
+  toStabilizerCode := toricStabilizerCode L
+  hasDistance      := toricCodeN_distance_eq_L L
 
 end ToricCodeN
 end StabilizerGroup

--- a/QEC/Stabilizer/Core/CodeDistance.lean
+++ b/QEC/Stabilizer/Core/CodeDistance.lean
@@ -64,5 +64,47 @@ theorem hasCodeDistance_of (C : StabilizerCode n k) (d : ℕ)
     exact absurd hg_nontrivial (h_min (weight g) h1 h g rfl)
   · omega
 
+/-!
+## `StabilizerCodeWithDistance`: full `[[n, k, d]]` packaging
+
+`StabilizerCode n k` captures the first two parameters of the standard
+`[[n, k, d]]` notation. Distance is layered on as a separate `Prop`
+(`HasCodeDistance`) so that codes whose distance is not yet known (e.g.,
+research-track codes whose minimum-weight nontrivial logical is unproven)
+can still be formalized as stabilizer codes. This wrapper bundles the
+two for codes where distance *is* established, giving a single object
+that carries all three parameters in its type.
+-/
+
+/-- A stabilizer code together with a proof that its distance equals `d`.
+    Use this when a code's `[[n, k, d]]` parameters are all formalized. -/
+structure StabilizerCodeWithDistance (n k d : ℕ) extends StabilizerCode n k where
+  /-- Proof that the underlying stabilizer code has distance exactly `d`. -/
+  hasDistance : HasCodeDistance toStabilizerCode d
+
+namespace StabilizerCodeWithDistance
+
+variable {n k d : ℕ}
+
+/-- A code with distance `d` satisfies `d ≥ 1`. -/
+theorem one_le_d (C : StabilizerCodeWithDistance n k d) : 1 ≤ d :=
+  C.hasDistance.1
+
+/-- Every nontrivial logical operator with positive weight has weight ≥ d. -/
+theorem min_weight (C : StabilizerCodeWithDistance n k d)
+    (g : NQubitPauliGroupElement n)
+    (hg : IsNontrivialLogicalOperator g C.toStabilizerCode.toStabilizerGroup)
+    (hw : 0 < weight g) :
+    weight g ≥ d :=
+  C.hasDistance.2.1 g hg hw
+
+/-- There exists a nontrivial logical of weight exactly `d`. -/
+theorem exists_weight_eq (C : StabilizerCodeWithDistance n k d) :
+    ∃ g, IsNontrivialLogicalOperator g C.toStabilizerCode.toStabilizerGroup ∧
+         weight g = d :=
+  C.hasDistance.2.2
+
+end StabilizerCodeWithDistance
+
 end StabilizerGroup
 end Quantum


### PR DESCRIPTION
## Summary

- Adds `StabilizerCodeWithDistance n k d` in [Core/CodeDistance.lean](QEC/Stabilizer/Core/CodeDistance.lean), an `extends`-style wrapper around `StabilizerCode n k` that bundles a `HasCodeDistance` proof. Lifts the full `[[n, k, d]]` parameters into the type while leaving the bare `StabilizerCode` definition (and every existing proof against it) unchanged.
- Instantiates the wrapper for the 6 codes that currently have both a `StabilizerCode` packaging and a discharged `HasCodeDistance` proof.
- Codes without a distance proof yet (Steane7, RepetitionCodeN, gross/Floquet moonshot codes) stay on `StabilizerCode n k` until their distance is formalized — adoption is opt-in.

## What landed

Wrapper + three projection lemmas (`one_le_d`, `min_weight`, `exists_weight_eq`) in the `StabilizerCodeWithDistance` namespace.

| Code | `[[n, k, d]]` | New def |
|---|---|---|
| RepetitionCode3 | `[[3, 1, 1]]` | `stabilizerCodeWithDistance` |
| FourQubit_4_2_2 | `[[4, 2, 2]]` | `stabilizerCodeWithDistance` |
| FiveQubit_5_1_3 | `[[5, 1, 3]]` | `stabilizerCodeWithDistance` |
| RotatedSurfaceCode3 | `[[9, 1, 3]]` | `stabilizerCodeWithDistance` |
| RotatedSurfaceCodeN | `[[L*L, 1, L]]` (parametric, `[Fact (Odd L)] [Fact (3 ≤ L)]`) | `rotatedSurfaceStabilizerCodeWithDistance` |
| ToricCodeN | `[[2L², 2, L]]` (parametric, `[Fact (2 ≤ L)]`) | `toricStabilizerCodeWithDistance` |

## Design note

`d` lives in the type rather than as a `Nat` field on the structure. This is clean for the current 6 codes (where `d` is symbolic — a numeral or `L`); if a future family has an awkward distance expression (`⌊…⌋`, `Nat.find`, etc.) we may want a `d`-as-field variant. Not blocking that path — both can coexist if needed.

## Test plan

- [x] `lake build` — clean, 3410/3410 jobs, exit 0
- [x] All warnings in tail are pre-existing `linter.flexible` on `ToricCodeNDistanceZ.lean` / `ToricCodeNStabilizerCode.lean` (already noted as out-of-scope in CLAUDE.md). No new warnings introduced.
- [x] No file lives outside an umbrella — all edits are to files already in the build graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)