### PR TITLE
feat(dashboard): add /done/ view of completed formalizations

### DIFF
--- a/dashboard/build.py
+++ b/dashboard/build.py
@@ -38,6 +38,27 @@ QUEUE_MD_PATH = REPO_ROOT / "pipeline" / "queue.md"
 
 GITHUB_REPO = "Stavan-Jain/QECLean"
 
+# Manually curated map of done codes → their primary Lean file(s) in the
+# repo. Used to render reliable source links on the /done/ page. Some
+# rationales contain wildcards/braces (toric, repetition, RSC) that don't
+# parse as clean URLs, so we maintain this list by hand.
+DONE_LEAN_PATHS: dict[str, list[str]] = {
+    "stab_4_2_2":         ["QEC/Stabilizer/Codes/Small/FourQubit_4_2_2.lean"],
+    "stab_5_1_3":         ["QEC/Stabilizer/Codes/Small/FiveQubit_5_1_3.lean"],
+    "shor_nine":          ["QEC/Stabilizer/Codes/Small/Shor9.lean"],
+    "steane":             ["QEC/Stabilizer/Codes/Small/Steane7.lean"],
+    "quantum_hamming":    ["QEC/Stabilizer/Codes/Small/QuantumHamming.lean"],
+    "stab_15_7_3":        ["QEC/Stabilizer/Codes/Small/QuantumHamming.lean"],
+    "quantum_repetition": [
+        "QEC/Stabilizer/Codes/Repetition/Three.lean",
+        "QEC/Stabilizer/Codes/Repetition/N.lean",
+    ],
+    "toric":              ["QEC/Stabilizer/Codes/Toric/"],
+    "rotated_surface":    ["QEC/Stabilizer/Codes/RotatedSurface/"],
+    "surface-17":         ["QEC/Stabilizer/Codes/RotatedSurface/N.lean"],
+    "qubit_stabilizer":   ["QEC/Stabilizer/Core/"],
+}
+
 
 # ---------------------------------------------------------------------------
 # Data loading
@@ -233,6 +254,37 @@ def strip_math_delims(text: str) -> str:
     return text
 
 
+RATIONALE_PREFIX_RE = re.compile(
+    r"^(Audit override:\s*|Already formalized:\s*)", re.IGNORECASE,
+)
+
+
+def done_summary(rationale: str, max_len: int = 220) -> str:
+    """Extract a short summary from a done-code's rationale.
+
+    Strips the "Audit override:" / "Already formalized:" prefix and any
+    "Previous rationale: ..." trailer, then truncates to max_len.
+    """
+    if not rationale:
+        return ""
+    text = RATIONALE_PREFIX_RE.sub("", rationale.strip())
+    # Some rationales have a "Previous rationale:" trailer — drop it.
+    idx = text.find("Previous rationale:")
+    if idx != -1:
+        text = text[:idx].rstrip().rstrip(".")
+    text = " ".join(text.split())  # collapse newlines/whitespace
+    if len(text) > max_len:
+        text = text[: max_len - 1].rstrip() + "…"
+    return text
+
+
+def basename(path: str) -> str:
+    """Filename portion of a path, or the path itself if it ends with /."""
+    if path.endswith("/"):
+        return path
+    return path.rsplit("/", 1)[-1]
+
+
 def render_md(text: str | None) -> str:
     if not text:
         return ""
@@ -323,6 +375,9 @@ def build():
     env.filters["render_md"] = render_md
     env.filters["format_parameters"] = format_parameters
     env.filters["code_slug"] = code_slug
+    env.filters["done_summary"] = done_summary
+    env.filters["basename"] = basename
+    env.globals["done_lean_paths"] = DONE_LEAN_PATHS
 
     by_track: dict[str, list[CodeEntry]] = {"engineering": [], "moonshot": [], "defer": [], "skip": []}
     for e in entries:
@@ -375,6 +430,27 @@ def build():
         root_prefix="../",
         entries=entries,
         queue_json=json.dumps(queue_json),
+    ))
+
+    # --- Done ---
+    print("[build] rendering done")
+    done_tmpl = env.get_template("done.html")
+    # Split done into concrete (has parameters.n) and parametric/abstract; within each
+    # group, sort by n ascending (concrete) or alphabetically (parametric).
+    done_concrete = sorted(
+        [e for e in done if e.parameters.get("n")],
+        key=lambda e: (e.parameters.get("n"), e.parameters.get("k", 0), e.code_id),
+    )
+    done_parametric = sorted(
+        [e for e in done if not e.parameters.get("n")],
+        key=lambda e: e.code_id,
+    )
+    write(DIST_DIR / "done" / "index.html", done_tmpl.render(
+        title="Done",
+        active="done",
+        root_prefix="../",
+        done_concrete=done_concrete,
+        done_parametric=done_parametric,
     ))
 
     # --- Research log ---

--- a/dashboard/static/style.css
+++ b/dashboard/static/style.css
@@ -185,6 +185,96 @@ main {
 }
 .count-num { font-size: 22px; font-weight: 600; }
 .count-label { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; }
+a.count-link {
+  text-decoration: none;
+  color: var(--text);
+  display: block;
+  transition: border-color 120ms, background 120ms;
+}
+a.count-link:hover {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+a.count-link:hover .count-label { color: var(--accent); }
+
+/* ---- Done page ---- */
+.done-section-title {
+  font-size: 15px;
+  margin: 8px 0 2px;
+  color: var(--text);
+}
+
+.done-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 14px;
+  margin-top: 14px;
+}
+
+.done-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  transition: border-color 120ms, box-shadow 120ms;
+}
+.done-card:hover {
+  border-color: var(--accent);
+  box-shadow: 0 1px 2px rgba(42, 95, 165, 0.08);
+}
+
+.done-card-header {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.done-code-id {
+  font-family: var(--mono);
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--accent);
+  text-decoration: none;
+}
+.done-code-id:hover { text-decoration: underline; }
+.done-params {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--muted);
+}
+.done-name {
+  margin: 0;
+  font-weight: 500;
+  font-size: 14px;
+  color: var(--text);
+}
+.done-summary {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+.done-card-footer {
+  margin-top: auto;
+  padding-top: 8px;
+  border-top: 1px dashed var(--border);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 12px;
+  font-size: 12px;
+}
+.done-source code {
+  font-size: 11px;
+  background: #f0efea;
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+.done-source { color: var(--text); text-decoration: none; }
+.done-source:hover code { background: var(--accent-soft); color: var(--accent); }
+.done-attempt { font-weight: 500; }
 
 /* ---- Panels ---- */
 .panel {

--- a/dashboard/templates/base.html
+++ b/dashboard/templates/base.html
@@ -16,6 +16,7 @@
     <nav class="site-nav">
       <a href="{{ root_prefix }}index.html" class="{{ 'active' if active == 'overview' }}">Overview</a>
       <a href="{{ root_prefix }}queue/index.html" class="{{ 'active' if active == 'queue' }}">Queue</a>
+      <a href="{{ root_prefix }}done/index.html" class="{{ 'active' if active == 'done' }}">Done</a>
       <a href="{{ root_prefix }}research/index.html" class="{{ 'active' if active == 'research' }}">Research</a>
       <a href="https://github.com/{{ github_repo }}" class="external">GitHub</a>
     </nav>

--- a/dashboard/templates/done.html
+++ b/dashboard/templates/done.html
@@ -1,0 +1,55 @@
+{% extends "base.html" %}
+{% import "_macros.html" as m %}
+
+{% block content %}
+<h1 class="page-title">Done · {{ (done_concrete | length) + (done_parametric | length) }} codes formalized</h1>
+<p class="subtitle">
+  Stabilizer codes with end-to-end mechanized proofs in this repo. Pipeline-era
+  attempts link to their full write-ups (<code>result.md</code> and friends);
+  earlier codes link to their Lean source directly.
+</p>
+
+{% macro done_card(code) %}
+<div class="done-card">
+  <div class="done-card-header">
+    <a class="done-code-id" href="{{ root_prefix }}code/{{ code.code_id | code_slug }}/index.html">{{ code.code_id }}</a>
+    {% if code.parameters %}<span class="done-params">{{ code.parameters | format_parameters }}</span>{% endif %}
+  </div>
+  <p class="done-name">{{ code.name }}</p>
+  <p class="done-summary">{{ code.rationale | done_summary }}</p>
+  <div class="done-card-footer">
+    {% set paths = done_lean_paths.get(code.code_id, []) %}
+    {% for path in paths %}
+      <a class="done-source" href="https://github.com/{{ github_repo }}/blob/main/{{ path }}" title="{{ path }}"><code>{{ path | basename }}</code></a>
+    {% endfor %}
+    {% if code.attempt %}
+      <a class="done-attempt" href="{{ root_prefix }}code/{{ code.code_id | code_slug }}/index.html">attempt write-up →</a>
+    {% endif %}
+  </div>
+</div>
+{% endmacro %}
+
+<h2 class="done-section-title">Concrete codes</h2>
+<p class="note">Sorted by code length <code>n</code> ascending.</p>
+<div class="done-grid">
+  {% for code in done_concrete %}
+    {{ done_card(code) }}
+  {% endfor %}
+</div>
+
+<h2 class="done-section-title" style="margin-top: 36px;">Parametric families &amp; abstractions</h2>
+<p class="note">Codes that span a family (any <code>L</code>, any <code>r</code>) or capture an abstraction rather than a concrete code.</p>
+<div class="done-grid">
+  {% for code in done_parametric %}
+    {{ done_card(code) }}
+  {% endfor %}
+</div>
+
+<hr class="soft">
+
+<p class="note">
+  See <a href="{{ root_prefix }}queue/index.html">queue</a> for the rest
+  of the catalog, or <a href="{{ root_prefix }}research/index.html">research</a>
+  for moonshot attempts where the distance proof is the open problem.
+</p>
+{% endblock %}

--- a/dashboard/templates/overview.html
+++ b/dashboard/templates/overview.html
@@ -74,7 +74,9 @@
 
 <section class="counts">
   <div class="count"><div class="count-num">{{ total }}</div><div class="count-label">Total scored</div></div>
-  <div class="count"><div class="count-num">{{ done | length }}</div><div class="count-label">Done</div></div>
+  <a class="count count-link" href="done/index.html">
+    <div class="count-num">{{ done | length }}</div><div class="count-label">Done →</div>
+  </a>
   <div class="count"><div class="count-num">{{ in_flight | length }}</div><div class="count-label">In-flight</div></div>
   <div class="count"><div class="count-num">{{ by_track.engineering | length }}</div><div class="count-label">Engineering</div></div>
   <div class="count"><div class="count-num">{{ by_track.moonshot | length }}</div><div class="count-label">Moonshot</div></div>


### PR DESCRIPTION
## Summary

Adds a dedicated **Done** page to the dashboard showcasing all codes with `status: done` in `catalog/scoring.yaml`. Currently 11 codes — Steane, Shor, Toric, the rotated-surface family, quantum Hamming, repetition codes, the `qubit_stabilizer` abstraction, plus the two pipeline-era completions `[[4,2,2]]` and `[[5,1,3]]`.

## What's on the page

Each completed code renders as a card with:
- Code id + `[[n,k,d]]` parameters
- Display name
- One-paragraph summary (rationale with the boilerplate `"Audit override:"` / `"Already formalized:"` prefix stripped, and any `"Previous rationale:"` trailer dropped)
- Direct GitHub link(s) to the Lean source file(s)
- For pipeline-era attempts: a link to the full `result.md` write-up under `/code/<id>/`

Cards are split into two sections:
1. **Concrete codes** (7) — sorted by code length `n` ascending
2. **Parametric families & abstractions** (4) — alphabetical (`qubit_stabilizer`, `quantum_repetition`, `rotated_surface`, `toric`)

## Navigation

- New top-nav item **"Done"** between Queue and Research
- The "Done" count tile on the Overview page is now a clickable link to `/done/`

## Implementation notes

The Lean file paths for each done code are maintained as a small hand-curated `DONE_LEAN_PATHS` dict in `dashboard/build.py`. The rationale strings have wildcards (`Toric/CodeN*.lean`, `RotatedSurface/*.lean`) and brace expansions (`Repetition/{Three,N}.lean`) that don't parse cleanly as URLs, so hand-maintaining 11 entries was simpler than fighting the regex.

A new `done_summary` filter strips boilerplate prefixes from the rationale before truncating to ~220 chars — keeps the card text focused on what was proven, not on the audit-override metadata.

## Files

| File | Change |
|---|---|
| `dashboard/build.py` | +76 — `DONE_LEAN_PATHS`, `done_summary` / `basename` filters, `/done/` render route |
| `dashboard/templates/done.html` | new — 55 LoC |
| `dashboard/templates/base.html` | +1 — nav link |
| `dashboard/templates/overview.html` | +3 — count tile → link |
| `dashboard/static/style.css` | +90 — `.done-grid`, `.done-card`, `a.count-link` styles |

**+225 / -1 LoC total.**

## Test plan

- [x] `python3 dashboard/build.py` clean — produces 271 HTML files (was 270, +1 for `/done/`)
- [x] Rendered card count matches `status: done` entries in scoring (11 cards, 0 missing)
- [x] Both section headings present
- [x] Nav link appears on all 271 pages
- [x] `HTTP 200` on `/`, `/queue/`, `/done/`, `/research/`, `/code/stab_5_1_3/`, `/code/toric/`
- [ ] Deploy workflow runs on merge and produces the live `/done/` URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)