### PR TITLE
refactor(CSSDistance): lift hasCodeDistance_two_of_anticommute_witness helper

### DIFF
--- a/QEC/Stabilizer/Codes/Small/CSS_4_1_2.lean
+++ b/QEC/Stabilizer/Codes/Small/CSS_4_1_2.lean
@@ -484,16 +484,10 @@ private lemma weight_one_anticomm_witness :
 /-- The [[4, 1, 2]] LNCY code has distance 2: every weight-1 single-qubit Pauli
 anticommutes with at least one stabilizer generator, and `X̄ = XXII` is a
 nontrivial logical operator of weight exactly 2. -/
-theorem code_has_distance_two : HasCodeDistance stabilizerCode 2 := by
-  refine hasCodeDistance_of stabilizerCode 2 (by decide)
-    ⟨logicalX, (logicalOpsCSS_4_1_2 0).xOp_nontrivial, by decide⟩ ?_
-  intro w hw_pos hw_lt g hg_weight h_nontrivial
-  interval_cases w
-  -- w = 1: g has weight 1; show g is not in the centralizer.
-  rcases (IsNontrivialLogicalOperator_iff g stabilizerCode.toStabilizerGroup).mp h_nontrivial
-    with ⟨h_cent, _, _⟩
-  exact no_weight_one_mem_centralizer_of_anticommute_witness stabilizerCode.toStabilizerGroup
-    generators stabilizerCode_toSubgroup_eq weight_one_anticomm_witness g hg_weight h_cent
+theorem code_has_distance_two : HasCodeDistance stabilizerCode 2 :=
+  hasCodeDistance_two_of_anticommute_witness stabilizerCode generators
+    stabilizerCode_toSubgroup_eq weight_one_anticomm_witness
+    ⟨logicalX, (logicalOpsCSS_4_1_2 0).xOp_nontrivial, by decide⟩
 
 /-- The [[4, 1, 2]] LNCY code packaged with its distance. -/
 noncomputable def stabilizerCodeWithDistance : StabilizerCodeWithDistance 4 1 2 where

--- a/QEC/Stabilizer/Codes/Small/FourQubit_4_2_2.lean
+++ b/QEC/Stabilizer/Codes/Small/FourQubit_4_2_2.lean
@@ -531,16 +531,10 @@ private lemma weight_one_anticomm_witness :
 /-- The [[4, 2, 2]] code has distance 2: every weight-1 single-qubit Pauli
 anticommutes with at least one of `ZZZZ` or `XXXX`, and `X̄₁ = IXIX` is a
 nontrivial logical operator of weight exactly 2. -/
-theorem code_has_distance_two : HasCodeDistance stabilizerCode 2 := by
-  refine hasCodeDistance_of stabilizerCode 2 (by decide)
-    ⟨logicalX_1, (logicalOps4_2_2 0).xOp_nontrivial, by decide⟩ ?_
-  intro w hw_pos hw_lt g hg_weight h_nontrivial
-  interval_cases w
-  -- w = 1: g has weight 1; we show g is not in the centralizer.
-  rcases (IsNontrivialLogicalOperator_iff g stabilizerCode.toStabilizerGroup).mp h_nontrivial
-    with ⟨h_cent, _, _⟩
-  exact no_weight_one_mem_centralizer_of_anticommute_witness stabilizerCode.toStabilizerGroup
-    generators stabilizerCode_toSubgroup_eq weight_one_anticomm_witness g hg_weight h_cent
+theorem code_has_distance_two : HasCodeDistance stabilizerCode 2 :=
+  hasCodeDistance_two_of_anticommute_witness stabilizerCode generators
+    stabilizerCode_toSubgroup_eq weight_one_anticomm_witness
+    ⟨logicalX_1, (logicalOps4_2_2 0).xOp_nontrivial, by decide⟩
 
 /-- The [[4, 2, 2]] code packaged with its distance. -/
 noncomputable def stabilizerCodeWithDistance : StabilizerCodeWithDistance 4 2 2 where

--- a/QEC/Stabilizer/Framework/Core/CSS/CSSDistance.lean
+++ b/QEC/Stabilizer/Framework/Core/CSS/CSSDistance.lean
@@ -1,5 +1,6 @@
 import QEC.Stabilizer.Framework.Core.Stabilizer.StabilizerGroup
 import QEC.Stabilizer.Framework.Core.Stabilizer.Centralizer
+import QEC.Stabilizer.Framework.Core.Logical.CodeDistance
 import QEC.Stabilizer.Foundations.PauliGroup.NQubitOperator
 import QEC.Stabilizer.Foundations.PauliGroup.NQubitElement
 import QEC.Stabilizer.Foundations.PauliGroup.Commutation
@@ -138,6 +139,44 @@ theorem no_weight_two_mem_centralizer_of_anticommute_witness (S : StabilizerGrou
       _ = (s * g) * (s * g)⁻¹ := by rw [← H]
       _ = 1 := by rw [mul_inv_cancel]
   exact negIdentity_ne_one n h_neg
+
+/-! ## Distance-2 packaging
+
+Combines `hasCodeDistance_of` (the general "prove distance by witness + min-weight"
+schema in `Framework/Core/Logical/CodeDistance.lean`) with the weight-1 anticommute
+helper above, specialized to `d = 2`. The only positive weight strictly less than 2
+is `w = 1`, so a single anticommute-witness function suffices to rule out the
+nontrivial-low-weight side, and a single explicit weight-2 logical handles the
+realizer side.
+
+Saves the `interval_cases w; rcases (IsNontrivialLogicalOperator_iff …).mp …; exact`
+boilerplate that every distance-2 CSS code instantiates verbatim.
+
+Use sites: `Codes/Small/FourQubit_4_2_2.lean` ([[4,2,2]]),
+`Codes/Small/CSS_4_1_2.lean` ([[4,1,2]] LNCY), and any future small CSS
+detection code (the iceberg family `[[2m, 2m-2, 2]]` is next in the engineering
+queue). -/
+
+/-- Distance-2 from an anticommute witness. Given a CSS-style stabilizer code
+`C`, a generating set `genSet` whose closure is `C.toStabilizerGroup`, a witness
+function ruling out weight-1 elements in the centralizer (the `h_anticomm`
+predicate, same as for `no_weight_one_mem_centralizer_of_anticommute_witness`),
+and an explicit weight-2 nontrivial logical, conclude `HasCodeDistance C 2`. -/
+theorem hasCodeDistance_two_of_anticommute_witness {k : ℕ} (C : StabilizerCode n k)
+    (genSet : Set (NQubitPauliGroupElement n))
+    (h_closure : C.toStabilizerGroup.toSubgroup = Subgroup.closure genSet)
+    (h_anticomm : ∀ i : Fin n, ∀ P : PauliOperator, P ≠ .I →
+      ∃ g ∈ genSet, Anticommute (weightOneAt i P) g)
+    (h_witness : ∃ g, IsNontrivialLogicalOperator g C.toStabilizerGroup ∧ weight g = 2) :
+    HasCodeDistance C 2 := by
+  refine hasCodeDistance_of C 2 (by decide) h_witness ?_
+  intro w hw_pos hw_lt g hg_weight h_nontrivial
+  interval_cases w
+  -- w = 1: g has weight 1; show g cannot lie in the centralizer.
+  rcases (IsNontrivialLogicalOperator_iff g C.toStabilizerGroup).mp h_nontrivial
+    with ⟨h_cent, _, _⟩
+  exact no_weight_one_mem_centralizer_of_anticommute_witness C.toStabilizerGroup
+    genSet h_closure h_anticomm g hg_weight h_cent
 
 end StabilizerGroup
 end Quantum


### PR DESCRIPTION
## Summary

Resolves the suggested follow-up #1 in [pipeline/attempts/css_4_1_2/result.md](https://github.com/Stavan-Jain/QECLean/blob/main/pipeline/attempts/css_4_1_2/result.md) (added by PR #32).

The "prove distance 2 from a weight-1 anticommute witness" closing pattern was duplicated verbatim between [[4,2,2]] (`FourQubit_4_2_2.lean`) and [[4,1,2]] LNCY (`CSS_4_1_2.lean`) — the same 8-line ritual in both. This PR factors it into a single theorem in `Framework/Core/CSS/CSSDistance.lean` and collapses each call site to a one-call closure.

## Diff

| File | Change | Notes |
|---|---|---|
| `Framework/Core/CSS/CSSDistance.lean` | +39 LoC | New helper `hasCodeDistance_two_of_anticommute_witness` + section comment + docstring. New import: `Framework.Core.Logical.CodeDistance`. |
| `Codes/Small/FourQubit_4_2_2.lean` | −7 LoC | `code_has_distance_two` reduced to a single function application |
| `Codes/Small/CSS_4_1_2.lean` | −6 LoC | Same |

Net: +26 lines today; from the next distance-2 CSS code onward, saves ~5 lines per code, and (more importantly) keeps the ritual in one place rather than copy-pasted.

## What the helper provides

```lean
theorem hasCodeDistance_two_of_anticommute_witness {k : ℕ} (C : StabilizerCode n k)
    (genSet : Set (NQubitPauliGroupElement n))
    (h_closure : C.toStabilizerGroup.toSubgroup = Subgroup.closure genSet)
    (h_anticomm : ∀ i : Fin n, ∀ P : PauliOperator, P ≠ .I →
      ∃ g ∈ genSet, Anticommute (weightOneAt i P) g)
    (h_witness : ∃ g, IsNontrivialLogicalOperator g C.toStabilizerGroup ∧ weight g = 2) :
    HasCodeDistance C 2
```

Specialized to `d = 2` because the only positive `w < 2` is `w = 1`, which `no_weight_one_mem_centralizer_of_anticommute_witness` already handles. A `d = 3` analog would need to additionally chain the weight-2 helper.

## Import / layering check

- New import in `CSSDistance.lean`: `Framework.Core.Logical.CodeDistance` (transitively pulls in `StabilizerCode` and `LogicalOperators` — both needed for `HasCodeDistance` and `IsNontrivialLogicalOperator_iff`)
- No cycle: `grep -l "CSSDistance" Framework/Core/{Logical,Stabilizer}/*.lean` returns nothing (only the `Framework/Core/CSS.lean` umbrella imports `CSSDistance`)

## Test plan

- [x] `lake build` clean repo-wide (3422 jobs)
- [x] No new linter warnings (the two pre-existing flexible-tactic warnings in `Logical/LogicalGateGroup.lean` and `Logical/LogicalOperators.lean` are unrelated)
- [x] Both refactored call sites verified compile independently:
      `lake build QEC.Stabilizer.Codes.Small.{FourQubit_4_2_2,CSS_4_1_2}` clean
- [x] No `set_option linter.* false` suppressions introduced
- [x] Helper uses only existing primitives (no new axioms / sorries)

## Future beneficiaries

- **`iceberg`** ([[2m, 2m−2, 2]]) — rank 2 in the engineering queue, ~5 parameterized instances each saving ~5 lines
- Any future small CSS detection code (several remain in the queue: `stab_6_2_2`, `stab_6_4_2`, `stab_8_1_2`, `stab_8_2_2`, `stab_8_3_2`, `stab_10_1_2`, `stab_12_2_2`)

🤖 Generated as a follow-up to PR #32 (LNCY end-to-end formalization)