### PR TITLE
docs: split CLAUDE.md into tiered docs (lean-patterns + mathlib-quirks) + iceberg Stage 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,12 +2,14 @@
 .gauss/
 .DS_Store
 
-# Docs (Aristotle prompts, evaluations, guides) — but keep the published proof
-# and the formalization pipeline docs.
+# Docs (Aristotle prompts, evaluations, guides) — but keep the published proof,
+# the formalization pipeline docs, and the agent-facing reference docs.
 docs/*
 !docs/distance_proof.md
 !docs/pipeline.md
 !docs/pipeline-usage.md
+!docs/lean-patterns.md
+!docs/mathlib-version-quirks.md
 
 # Cursor local state and continual-learning index
 .cursor/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,31 @@
 This is a Lean 4 / mathlib formalization of the stabilizer formalism for
 quantum error correction. The active math is in `QEC/`. Build with `lake build`.
 
+## Where to look for what
+
+CLAUDE.md is the small must-read on every invocation. It carries
+codebase-wide orientation, naming/style policy, layering rules, and
+build/MCP workflow. Volatile or topic-scoped knowledge lives elsewhere:
+
+- **[`docs/lean-patterns.md`](docs/lean-patterns.md)** — tactical
+  patterns by code shape (CSS distance, non-CSS distance, parametric
+  families, mechanical fixes). Reach for this when your current code
+  matches one of its sections; add new patterns here when they're
+  code-shape-specific rather than codebase-wide.
+- **[`docs/mathlib-version-quirks.md`](docs/mathlib-version-quirks.md)**
+  — mathlib API drift (deprecations, renames, signature changes),
+  grouped by version. Add new entries here when you work around a
+  mathlib version-specific quirk.
+- **[`docs/pipeline.md`](docs/pipeline.md)** and
+  **[`docs/pipeline-usage.md`](docs/pipeline-usage.md)** — the
+  formalization-pipeline architecture and recipes (weekly triage,
+  Stage 2/3/4/5/6 workflows).
+- **[`pipeline/attempts/<code_id>/result.md`](pipeline/attempts/)** —
+  per-code Stage-4 write-ups, including "Patterns discovered" sections.
+  Patterns that generalize get promoted to `lean-patterns.md` or
+  CLAUDE.md at Stage 6 (post-merge); see `pipeline-usage.md` § Recipe:
+  post-merge reflection.
+
 ## Project tour
 
 ```
@@ -80,105 +105,18 @@ release; new code should import the new paths directly.
   - `simp +decide` is preferred over hand-written `decide` (and avoids the
     "expected type must not contain free variables" trap).
   - `native_decide` is allowed (per user preference).
-  - When closing residual `if c then 1 else 0`-style goals after `simp`,
-    `split_ifs <;> simp_all (config := {decide := true}) <;> first | rfl |
-    exact absurd rfl ‹_›` is the common closer.
   - **Probing residual goals**: prefer the `lean_goal` MCP tool (see "Agent
     tooling" below) — it returns the live `goals_before` / `goals_after` at
     a position without any edit or rebuild. Fallback when the MCP isn't
     available: replace the failing tactic tail with `(try sorry)` and
     rebuild; the "declaration uses sorry" warning includes the residual
     goal state.
-  - **`Finset.card` of `{a, b, c, d}` with all-pairwise-distinct hypotheses**:
-    `simp_all +decide [Finset.filter_eq', Finset.filter_or,
-    Finset.card_insert_of_notMem, Finset.mem_insert, Finset.mem_singleton]`
-    — as of mathlib v4.30 `simp_all` picks up the `Ne` hypotheses (in both
-    directions) from context automatically. The older guidance to pass
-    `h₁, h₂.symm, …` explicitly is stale and now triggers
-    `linter.unusedSimpArgs`.
-  - **`simp_all` with bidirectional hypotheses can erase what you need**:
-    if a hypothesis is a `↔` like `hfilt_eq : P ↔ Q`, `simp_all` may rewrite
-    `Q` back to `P` in a subgoal you wanted to keep simplified. Workaround:
-    `clear hfilt_eq` (or rename to a one-shot `have`) before `simp_all`.
-  - **`Anticommute p q` via `by decide`** (for non-CSS distance proofs): a
-    computable `DecidableEq (NQubitPauliGroupElement n)` and a `noncomputable`
-    `Decidable Anticommute` instance let `decide` reduce `Anticommute p q` for
-    concrete Pauli group elements. **`native_decide` does NOT work** here
-    (because `Mul` on `NQubitPauliGroupElement` is `noncomputable`) — prefer
-    `decide`. These instances live as `local instance` in
-    `Codes/FiveQubit_5_1_3.lean` to avoid global synthesis pollution; copy them
-    into any new non-CSS code file that needs them.
-  - **Backtracking witness search for non-CSS distance proofs**: when proving
-    "for every weight-`k` Pauli, some generator anticommutes", the standard
-    pattern is
-
-    ```lean
-    fin_cases i <;>
-      (match P, hP with
-       | .X, _ => first
-         | exact ⟨g₁, by simp [generators], by decide⟩
-         | exact ⟨g₂, by simp [generators], by decide⟩
-         | …
-       | .Y, _ => …
-       | .I, hP => exact (hP rfl).elim)
-    ```
-
-    `first` backtracks across generators by `decide`. Trim unused generator
-    branches per `(P, …)` case (flagged by `linter.unusedTactic`) to keep
-    the file lint-clean. See `FiveQubit_5_1_3.lean`'s
-    `weight_one_anticomm_witness` and `weight_two_anticomm_witness` for the
-    canonical use sites.
-  - **CSS distance proofs with multiple Z-generators (or multiple X-generators)
-    covering disjoint qubit subsets**: factor the "which generator covers `i`"
-    dichotomy out once and reuse across the `P = X` and `P = Y` match arms
-    rather than re-doing `by_cases` in each:
-
-    ```lean
-    have hi_dichotomy : (i = 0 ∨ i = 1) ∨ (i = 2 ∨ i = 3) := by
-      fin_cases i <;> tauto
-    ```
-
-    In each per-generator filter-equality helper, dispatch `rcases hi <;>
-    rcases hP` *inside* the `ext` proof before `fin_cases j` — keeps the
-    helper universally quantified over `i` instead of forcing per-case
-    specializations:
-
-    ```lean
-    have hfilter :
-        (Finset.univ.filter (anticommutesAt (weightOneAt i P) S_Z1)) =
-          ({i} : Finset (Fin 4)) := by
-      ext j; rcases hi with rfl | rfl <;> rcases hP with rfl | rfl <;>
-        fin_cases j <;> simp [...]
-    ```
-
-    Canonical use site: `CSS_4_1_2.lean`'s `weight_one_anticomm_witness`
-    (T19). Generalizes to larger CSS codes; the iceberg family
-    `[[2m, 2m-2, 2]]` will exercise this at scale.
-  - **High-frequency mechanical fixes worth recognizing immediately**:
-    - **Ambiguous overloaded name** (e.g. `mul_assoc` between `_root_.mul_assoc`
-      and `NQubitPauliGroupElement.mul_assoc` when `open NQubitPauliGroupElement`
-      is in scope): qualify with `_root_.` (or the specific namespace).
-      Trigger: `open NQubitPauliGroupElement` near the top of a `Codes/*.lean`
-      file shadows several mathlib names. Same applies to `one_mul` / `mul_one`.
-    - **`rw [one_mul, mul_one]` (or any rewrite) fails after
-      `Subgroup.closure_induction`**: the goal is `(fun y _ => …) 1 ⋯`,
-      unreduced. Add a `change` step to beta-reduce first — see
-      `Homological/LogicalCorrespondence.lean:280-282` for the canonical
-      pattern:
-      ```lean
-      · change (1 : NQubitPauliGroupElement X.numQubits) * X.chainXOperator c =
-          X.chainXOperator c * 1
-        rw [one_mul, mul_one]
-      ```
-    - **`HMul` instance failure between two defeq Pauli types** (e.g.
-      `NQubitPauliGroupElement (numQubits L)` vs.
-      `NQubitPauliGroupElement (rotatedSurfaceHomologicalCode L).numQubits`):
-      `*` resolves by syntactic type match, not defeq through abbreviations.
-      Fix by typing the local lemma signature consistently with whichever form
-      the proof body uses more. When the proof body multiplies abstract
-      `vertexStabOf`/`faceStabOf` against a parameter `g`, declare `g` at
-      `(rotatedSurfaceHomologicalCode L).numQubits` — callers can pass
-      `NQubitPauliGroupElement (numQubits L)` (defeq).
+  - **For code-shape-specific tactical patterns** (CSS distance-2 closer,
+    multi-Z anti-witness, parametric `Fin n` workarounds, backtracking
+    witness search for non-CSS distance, `_root_` qualification, mechanical
+    fixes), see [`docs/lean-patterns.md`](docs/lean-patterns.md). Add new
+    patterns there, not here, unless they generalize across multiple
+    code shapes.
 - **Sorry markers**: `sorry  -- TODO(<short-tag>): <one-line note about goal shape>`.
   Always tag so the next session can grep for them.
 - **Global vs. `local instance` discipline**: by default, declare typeclass
@@ -238,15 +176,10 @@ mathlib linter; don't introduce new violations):
   `linter.style.maxHeartbeats`. The same ordering rule applies to
   `omit [Fact ...] in`: the doc-comment must come AFTER `... in`, or the
   parser rejects the intervening doc-comment.
-- **`NQubitPauliOperator.identity` in simp sets** for CSS generator
-  equality lemmas: drop `identity` from the simp set when a generator's
-  `.set` chain *fully covers* every `Fin n` position (e.g.
-  `S_X1 = ...set 0 X.set 1 X.set 2 X.set 3 X` on `Fin 4`). Keep
-  `identity` for partial-coverage generators (e.g.
-  `S_Z1 = ...set 0 Z.set 1 Z` on `Fin 4` — qubits 2 and 3 fall through
-  to `identity`). `linter.unusedSimpArgs` flags the wrong choice. First
-  hit: `CSS_4_1_2.lean`'s T1 (`ZGenerators_are_ZType`) vs. T2
-  (`XGenerators_are_XType`).
+
+For CSS-specific simp-set idioms (e.g. when to drop
+`NQubitPauliOperator.identity`), see
+[`docs/lean-patterns.md`](docs/lean-patterns.md) § CSS distance proofs.
 
 ## Project-specific helpers (NOT mathlib)
 
@@ -450,53 +383,20 @@ stale build artifacts that crash `lake serve`:
 If you're upgrading the toolchain, see `TOOLCHAIN_UPGRADE.md` (gitignored,
 local runbook).
 
-## Things that broke recently in v4.30 (be aware)
+## Mathlib version drift
 
-**Maintenance:** when you discover an idiom or workaround during proof work,
-add a one-line entry here. This is the single most-consulted section by the
-next session, so keeping it current pays compound interest.
+For workarounds to mathlib API drift (deprecations, renames, signature
+changes encountered during version bumps), see
+[`docs/mathlib-version-quirks.md`](docs/mathlib-version-quirks.md). Add new
+entries there when you hit a version-specific quirk; don't add them to
+this file (CLAUDE.md is the small must-read doc, the quirks file is the
+version-grouped reference).
 
-- `Subgroup.normalizer` takes `Set G`, not `Subgroup G` — no dot notation.
-  Write `Subgroup.normalizer S.toSubgroup` not `S.toSubgroup.normalizer`.
-- `simp [ZMod, ← even_iff_two_dvd]` no longer turns `(c : ZMod 2) = 0` into
-  `Even c`. Use `Finset.sum_boole` + `ZMod.natCast_eq_zero_iff_even` instead.
-- `Matrix.mulVec_smul` rewrites can fail to unify when scalar type and
-  matrix-entry type differ (`ℝ` vs `ℂ`). Workaround: wrap in an explicit
-  `show ∀ (M : Matrix _ _ ℂ) (b : ℝ) (w : NQubitVec n), M.mulVec (b • w) =
-  b • M.mulVec w from fun _ _ _ => Matrix.mulVec_smul _ _ _`.
-- `push_neg` is deprecated — prefer `push Not`.
-- mathlib's `Matrix.mul_eq_one_comm`, `Matrix.isUnit_of_right_inverse` are
-  deprecated; use `mul_eq_one_comm` and `IsUnit.of_mul_eq_one`.
-  **Signature gotcha**: `IsUnit.of_mul_eq_one` is `(b : M) (h : a * b = 1)`
-  — the right-hand operand is explicit. For a square `h_mul : M * M = 1`
-  write `IsUnit.of_mul_eq_one M h_mul`, not `IsUnit.of_mul_eq_one h_mul`.
-- `Finset.filter_union_filter_neg_eq` → `Finset.filter_union_filter_not_eq`
-  (`neg` → `not`). Same renaming on `Finset.disjoint_filter_filter_neg` →
-  `Finset.disjoint_filter_filter_not`.
-- `Nat.xor_cancel_left` / `Nat.xor_cancel_right` don't exist under those
-  names — they're in Batteries as `Nat.xor_xor_cancel_left` /
-  `Nat.xor_xor_cancel_right` (note the extra `xor_`). Used in
-  `QuantumHamming.lean`'s involution proof.
-- `Prod.mk.inj_iff` is gone — use `Prod.mk_inj`.
-- `((List.finRange L).product (List.finRange L)).length = L * L` doesn't
-  reduce by `simp` directly. Workaround: `unfold List.product; simp [List.length_flatMap]`.
-- The `List.countP_eq_count_of_decide_iff`, `List.countP_add_countP_eq_length`,
-  `List.length_filter_eq_countP` family doesn't exist (or moved). For
-  `(L.filter p).length` arithmetic, route through `List.toFinset_card_of_nodup`
-  (when the list is `Nodup`) and `Finset.card_erase_of_mem` —
-  see `coordsTrimmed_length` in `ToricCodeNStabilizerCode.lean` for the pattern.
-- **Adding a global typeclass instance can break unrelated `native_decide`
-  proofs.** In Stage 4 of `stab_5_1_3` we added global
-  `instDecidableEqNQubitPauliGroupElement` and `decidableAnticommute` to
-  `PauliGroup/Commutation.lean`, intending broad reuse. It silently broke
-  `RotatedSurfaceCode3.lean`'s `weight_2_pairs_span_coeffs` proof: the new
-  instance disrupted the `Decidable (∀-∃ proposition)` synthesis path the
-  `native_decide` was relying on, even though the proposition has no
-  `NQubitPauliGroupElement` equality in it. **Resolution**: scope the new
-  instances as `local instance` inside `Codes/FiveQubit_5_1_3.lean`. See the
-  "Global vs. `local instance` discipline" bullet in the naming-and-style
-  section above, and `pipeline/attempts/stab_5_1_3/result.md` § "Lessons
-  learned" for the worked diagnosis.
+The "global typeclass instance can break unrelated `native_decide` proofs"
+footgun is documented in the "Global vs. `local instance` discipline"
+bullet in the *Naming and style conventions* section above — that's the
+canonical location for the rule and its worked example
+(`pipeline/attempts/stab_5_1_3/result.md` § "Lessons learned").
 
 ## Formalization pipeline
 

--- a/docs/lean-patterns.md
+++ b/docs/lean-patterns.md
@@ -1,0 +1,276 @@
+# Lean tactic patterns by code shape
+
+Reference manual of tactical patterns useful when formalizing specific
+kinds of QEC codes in this repo. Each pattern has a canonical use site so
+you can see it in context.
+
+**Add patterns here**, not to `CLAUDE.md`, when:
+- the pattern is specific to a code shape (CSS distance, non-CSS, parametric, etc.)
+- it's a mechanical fix for a recurring gotcha
+- it's a workaround for a Lean / mathlib quirk that isn't strictly
+  version-specific (those go in `mathlib-version-quirks.md`)
+
+`CLAUDE.md` is the small "must-read on every invocation" doc. This file
+is the reference you reach for when your current code matches one of the
+sections below.
+
+## Index
+
+- [CSS distance proofs](#css-distance-proofs)
+- [Non-CSS distance proofs](#non-css-distance-proofs)
+- [Parametric code families](#parametric-code-families)
+- [Mechanical fixes for common gotchas](#mechanical-fixes-for-common-gotchas)
+
+---
+
+## CSS distance proofs
+
+### Distance-2 packaging via `hasCodeDistance_two_of_anticommute_witness`
+
+Single closer for "distance is exactly 2" given (a) a weight-1 anticommute
+witness function and (b) an explicit weight-2 nontrivial logical. Defined
+in `Framework/Core/CSS/CSSDistance.lean`; canonical signature:
+
+```lean
+theorem hasCodeDistance_two_of_anticommute_witness {k : ℕ} (C : StabilizerCode n k)
+    (genSet : Set (NQubitPauliGroupElement n))
+    (h_closure : C.toStabilizerGroup.toSubgroup = Subgroup.closure genSet)
+    (h_anticomm : ∀ i : Fin n, ∀ P : PauliOperator, P ≠ .I →
+      ∃ g ∈ genSet, Anticommute (weightOneAt i P) g)
+    (h_witness : ∃ g, IsNontrivialLogicalOperator g C.toStabilizerGroup ∧ weight g = 2) :
+    HasCodeDistance C 2
+```
+
+Replaces the 8-line `refine hasCodeDistance_of … ⟨…⟩ ?_ ; intro …;
+interval_cases w; rcases (IsNontrivialLogicalOperator_iff …).mp …; exact …`
+boilerplate. Use sites: `Codes/Small/FourQubit_4_2_2.lean`,
+`Codes/Small/CSS_4_1_2.lean`, `Codes/Iceberg/N.lean` (T18 in each).
+
+### Multiple Z-generators (or X-generators) covering disjoint qubit subsets
+
+When a CSS code has multiple Z-stabilizers whose supports partition (or
+sub-partition) the qubits, factor the "which generator covers `i`"
+dichotomy out once and reuse across the `P = X` and `P = Y` match arms
+rather than re-doing `by_cases` in each:
+
+```lean
+have hi_dichotomy : (i = 0 ∨ i = 1) ∨ (i = 2 ∨ i = 3) := by
+  fin_cases i <;> tauto
+```
+
+In each per-generator filter-equality helper, dispatch `rcases hi <;>
+rcases hP` *inside* the `ext` proof before `fin_cases j` — keeps the
+helper universally quantified over `i` instead of forcing per-case
+specializations:
+
+```lean
+have hfilter :
+    (Finset.univ.filter (anticommutesAt (weightOneAt i P) S_Z1)) =
+      ({i} : Finset (Fin 4)) := by
+  ext j; rcases hi with rfl | rfl <;> rcases hP with rfl | rfl <;>
+    fin_cases j <;> simp [...]
+```
+
+Canonical use site: `CSS_4_1_2.lean`'s `weight_one_anticomm_witness` (T19).
+
+### Anti-witness function when all generators have full support
+
+The counter-pattern to the multi-Z dichotomy above. When the all-X
+stabilizer covers every qubit AND the all-Z stabilizer covers every qubit
+(e.g. iceberg's `S_X m = XX…X`, `S_Z m = ZZ…Z`), **no `hi_dichotomy`
+is needed**. A plain 3-way `match P, hP` over `{X, Y, Z}` suffices —
+each branch picks the unique generator that anticommutes with `P` at
+qubit `i`:
+
+```lean
+intro i P hP
+match P, hP with
+| PauliOperator.X, _ => exact ⟨S_Z m, by simp [generators, ZGenerators], …⟩
+| PauliOperator.Y, _ => exact ⟨S_Z m, by simp [generators, ZGenerators], …⟩
+| PauliOperator.Z, _ => exact ⟨S_X m, by simp [generators, XGenerators], …⟩
+| PauliOperator.I, hP => exact (hP rfl).elim
+```
+
+Canonical use site: `Iceberg/N.lean`'s `weight_one_anticomm_witness` (T17).
+If you find yourself reaching for `hi_dichotomy` on a CSS code with
+full-support stabilizers, you're overcomplicating it.
+
+### `NQubitPauliOperator.identity` in simp sets for CSS generator equality
+
+For CSS generator-equality lemmas (e.g., `ZGenerators_are_ZType`,
+`XGenerators_are_XType`), drop `identity` from the simp set when a
+generator's `.set` chain *fully covers* every `Fin n` position (e.g.
+`S_X1 = ...set 0 X.set 1 X.set 2 X.set 3 X` on `Fin 4`). Keep
+`identity` for partial-coverage generators (e.g.
+`S_Z1 = ...set 0 Z.set 1 Z` on `Fin 4` — qubits 2 and 3 fall through to
+`identity`). `linter.unusedSimpArgs` flags the wrong choice. First hit:
+`CSS_4_1_2.lean`'s T1 (`ZGenerators_are_ZType`) vs. T2
+(`XGenerators_are_XType`).
+
+---
+
+## Non-CSS distance proofs
+
+### `Anticommute p q` via `by decide`
+
+A computable `DecidableEq (NQubitPauliGroupElement n)` and a
+`noncomputable` `Decidable Anticommute` instance let `decide` reduce
+`Anticommute p q` for concrete Pauli group elements. **`native_decide`
+does NOT work** here (because `Mul` on `NQubitPauliGroupElement` is
+`noncomputable`) — prefer `decide`.
+
+These instances live as `local instance` in
+`Codes/FiveQubit_5_1_3.lean` to avoid global synthesis pollution (see
+the global-vs-local discipline bullet in `CLAUDE.md`); copy them into
+any new non-CSS code file that needs them.
+
+### Backtracking witness search
+
+When proving "for every weight-`k` Pauli, some generator anticommutes",
+the standard pattern is:
+
+```lean
+fin_cases i <;>
+  (match P, hP with
+   | .X, _ => first
+     | exact ⟨g₁, by simp [generators], by decide⟩
+     | exact ⟨g₂, by simp [generators], by decide⟩
+     | …
+   | .Y, _ => …
+   | .I, hP => exact (hP rfl).elim)
+```
+
+`first` backtracks across generators by `decide`. Trim unused generator
+branches per `(P, …)` case (flagged by `linter.unusedTactic`) to keep
+the file lint-clean. See `FiveQubit_5_1_3.lean`'s
+`weight_one_anticomm_witness` and `weight_two_anticomm_witness` for
+canonical use sites.
+
+---
+
+## Parametric code families
+
+These patterns are specific to parametric formalizations (`Iceberg/N.lean`,
+`RotatedSurface/N.lean`, `Toric/CodeN.lean`, `Repetition/N.lean`). Most
+break when `Fin n` has parametric `n`.
+
+### Parametric column-evaluation for `rowsLinearIndependent`
+
+When the check-matrix dimension is parametric, the `by decide` approach
+used for concrete-`n` codes fails. The clean parametric pattern is to
+peel off each row of `f` by evaluating `hf` at carefully chosen columns:
+
+```lean
+-- T8 in Iceberg/N.lean:
+intro f hf
+have h0 : f 0 = 0 := by
+  have := congrFun hf (Sum.inl 0)  -- evaluate at the first Z-column
+  -- the row-sum reduces to f 0 * 1 + f 1 * 0 = f 0
+  simpa [...] using this
+have h1 : f 1 = 0 := by
+  have := congrFun hf (Sum.inr 0)  -- evaluate at the first X-column
+  simpa [...] using this
+ext i; fin_cases i <;> [exact h0; exact h1]
+```
+
+Generalizes to any small CSS code where the natural check matrix has
+"single-block" rows (a Z-row covering some columns + an X-row covering
+the complementary columns).
+
+### Bypassing `fin_cases ℓ <;> fin_cases ℓ'` for parametric `Fin n`
+
+The `pauli_comm_componentwise` tactic and the `logical_commute_cross`
+field of `StabilizerCode` both want to enumerate over `Fin (n - k)`,
+which `fin_cases` can't do when `n - k` is parametric. The workaround
+is to *structurally* decompose `∀ ℓ ℓ', …` via `refine ⟨_, _, _, _⟩`
+into the `i = j` and `i ≠ j` sub-cases, then dispatch each case to a
+previously-proved lemma:
+
+```lean
+refine ⟨?_, ?_, ?_, ?_⟩
+· intro ℓ ℓ'; exact logicalX_commutes_logicalX m ℓ ℓ'        -- both X-type
+· intro ℓ ℓ'; exact logicalZ_commutes_logicalZ m ℓ ℓ'        -- both Z-type
+· intro ℓ ℓ' hℓℓ'                                            -- cross, i ≠ j
+  by_cases hij : ℓ = ℓ'
+  · exact absurd hij hℓℓ'
+  · exact logicalX_commutes_logicalZ_offdiag m ℓ ℓ' hij
+· …
+```
+
+Canonical use site: `Iceberg/N.lean` (T15 = `stabilizerCode` structure
+literal).
+
+### `simp [foo]` → `simp only [foo]` for `@[inline] private def`
+
+When the `simp` is just unfolding an `@[inline] private def`, replace
+with `simp only [foo]`. The narrower form satisfies `linter.flexible`
+and (with `@[inline]`) reduces identically. Canonical hit:
+`Iceberg/N.lean`'s `logIdx_ne_xAnchor` lemma uses `simp only [logIdx]`
+not `simp [logIdx]`.
+
+---
+
+## Mechanical fixes for common gotchas
+
+These are quick-lookup items for failures that have a definite fix once
+recognized.
+
+### `if c then 1 else 0` residual goal closer
+
+When `simp` leaves a goal of the form `if c then 1 else 0 = …`, the
+common closer is:
+
+```lean
+split_ifs <;> simp_all (config := {decide := true}) <;>
+  first | rfl | exact absurd rfl ‹_›
+```
+
+### `Finset.card` of `{a, b, c, d}` with all-pairwise-distinct hypotheses
+
+```lean
+simp_all +decide [Finset.filter_eq', Finset.filter_or,
+  Finset.card_insert_of_notMem, Finset.mem_insert, Finset.mem_singleton]
+```
+
+As of mathlib v4.30 `simp_all` picks up the `Ne` hypotheses (in both
+directions) from context automatically. The older guidance to pass
+`h₁, h₂.symm, …` explicitly is stale and now triggers
+`linter.unusedSimpArgs`.
+
+### `simp_all` with bidirectional hypotheses can erase what you need
+
+If a hypothesis is a `↔` like `hfilt_eq : P ↔ Q`, `simp_all` may rewrite
+`Q` back to `P` in a subgoal you wanted to keep simplified. Workaround:
+`clear hfilt_eq` (or rename to a one-shot `have`) before `simp_all`.
+
+### Ambiguous overloaded name (`_root_` qualification)
+
+E.g. `mul_assoc` is ambiguous between `_root_.mul_assoc` and
+`NQubitPauliGroupElement.mul_assoc` when `open NQubitPauliGroupElement`
+is in scope. Qualify with `_root_.` (or the specific namespace). Trigger:
+`open NQubitPauliGroupElement` near the top of a `Codes/*.lean` file
+shadows several mathlib names. Same applies to `one_mul` / `mul_one`.
+
+### `rw [one_mul, mul_one]` fails after `Subgroup.closure_induction`
+
+The goal is `(fun y _ => …) 1 ⋯`, unreduced. Add a `change` step to
+beta-reduce first — see `Homological/LogicalCorrespondence.lean:280-282`
+for the canonical pattern:
+
+```lean
+· change (1 : NQubitPauliGroupElement X.numQubits) * X.chainXOperator c =
+    X.chainXOperator c * 1
+  rw [one_mul, mul_one]
+```
+
+### `HMul` instance failure between two defeq Pauli types
+
+E.g. `NQubitPauliGroupElement (numQubits L)` vs.
+`NQubitPauliGroupElement (rotatedSurfaceHomologicalCode L).numQubits`:
+`*` resolves by syntactic type match, not defeq through abbreviations.
+
+Fix by typing the local lemma signature consistently with whichever form
+the proof body uses more. When the proof body multiplies abstract
+`vertexStabOf` / `faceStabOf` against a parameter `g`, declare `g` at
+`(rotatedSurfaceHomologicalCode L).numQubits` — callers can pass
+`NQubitPauliGroupElement (numQubits L)` (defeq).

--- a/docs/mathlib-version-quirks.md
+++ b/docs/mathlib-version-quirks.md
@@ -1,0 +1,51 @@
+# Mathlib version drift quirks
+
+Workarounds and renamings encountered during mathlib version bumps in
+this repo. Entries are grouped by the mathlib version where the quirk
+was first observed.
+
+**Maintenance**: when you hit a mathlib API quirk during proof work, add
+a one-line entry to the appropriate version section (or create a new
+section if a fresh bump just landed). Date the entry by when you
+verified it. Once a quirk is no longer triggerable (e.g. you upgraded
+past the deprecation window and the legacy form is gone), move the
+entry to a `## Resolved` section at the bottom rather than deleting it
+— the historical record helps with future bisection.
+
+This file is intentionally less compact than `CLAUDE.md` because
+version-specific knowledge ages quickly and isn't worth the
+must-read-on-every-invocation cost.
+
+---
+
+## v4.30 (verified 2026-05-24)
+
+- `Subgroup.normalizer` takes `Set G`, not `Subgroup G` — no dot notation.
+  Write `Subgroup.normalizer S.toSubgroup` not `S.toSubgroup.normalizer`.
+- `simp [ZMod, ← even_iff_two_dvd]` no longer turns `(c : ZMod 2) = 0` into
+  `Even c`. Use `Finset.sum_boole` + `ZMod.natCast_eq_zero_iff_even` instead.
+- `Matrix.mulVec_smul` rewrites can fail to unify when scalar type and
+  matrix-entry type differ (`ℝ` vs `ℂ`). Workaround: wrap in an explicit
+  `show ∀ (M : Matrix _ _ ℂ) (b : ℝ) (w : NQubitVec n), M.mulVec (b • w) =
+  b • M.mulVec w from fun _ _ _ => Matrix.mulVec_smul _ _ _`.
+- `push_neg` is deprecated — prefer `push Not`.
+- mathlib's `Matrix.mul_eq_one_comm`, `Matrix.isUnit_of_right_inverse` are
+  deprecated; use `mul_eq_one_comm` and `IsUnit.of_mul_eq_one`.
+  **Signature gotcha**: `IsUnit.of_mul_eq_one` is `(b : M) (h : a * b = 1)`
+  — the right-hand operand is explicit. For a square `h_mul : M * M = 1`
+  write `IsUnit.of_mul_eq_one M h_mul`, not `IsUnit.of_mul_eq_one h_mul`.
+- `Finset.filter_union_filter_neg_eq` → `Finset.filter_union_filter_not_eq`
+  (`neg` → `not`). Same renaming on `Finset.disjoint_filter_filter_neg` →
+  `Finset.disjoint_filter_filter_not`.
+- `Nat.xor_cancel_left` / `Nat.xor_cancel_right` don't exist under those
+  names — they're in Batteries as `Nat.xor_xor_cancel_left` /
+  `Nat.xor_xor_cancel_right` (note the extra `xor_`). Used in
+  `QuantumHamming.lean`'s involution proof.
+- `Prod.mk.inj_iff` is gone — use `Prod.mk_inj`.
+- `((List.finRange L).product (List.finRange L)).length = L * L` doesn't
+  reduce by `simp` directly. Workaround: `unfold List.product; simp [List.length_flatMap]`.
+- The `List.countP_eq_count_of_decide_iff`, `List.countP_add_countP_eq_length`,
+  `List.length_filter_eq_countP` family doesn't exist (or moved). For
+  `(L.filter p).length` arithmetic, route through `List.toFinset_card_of_nodup`
+  (when the list is `Nodup`) and `Finset.card_erase_of_mem` — see
+  `coordsTrimmed_length` in `ToricCodeNStabilizerCode.lean` for the pattern.

--- a/docs/pipeline-usage.md
+++ b/docs/pipeline-usage.md
@@ -367,11 +367,31 @@ partially-closed file with structured BLOCKED markers + a detailed
 
 **Steps:**
 
-1. **Update CLAUDE.md** with any patterns from `result.md`'s "Patterns
-   discovered" section. This is the single most-consulted file by future
-   agent sessions — additions here compound.
+1. **Promote patterns from `result.md`'s "Patterns discovered" section.**
+   Use the tiered destination rule — most patterns are NOT CLAUDE.md
+   material:
+
+   - **`docs/lean-patterns.md`** (default destination): patterns
+     specific to a code shape (CSS distance, non-CSS distance,
+     parametric family, mechanical fixes). The vast majority of
+     promoted patterns end up here.
+   - **`docs/mathlib-version-quirks.md`**: mathlib API drift you worked
+     around during the formalization (deprecations, renames, signature
+     changes). Date the entry.
+   - **`CLAUDE.md`** (highest bar): only patterns that either generalize
+     across ≥ 2 different code shapes OR are pure codebase-wide
+     policy/style. If you're tempted to add to CLAUDE.md, ask whether
+     `lean-patterns.md` would be the better home — usually yes.
+   - **Stay in `result.md`** (no promotion): one-off observations,
+     patterns that haven't recurred yet, or notes too narrow to
+     generalize.
+
+   The rationale: CLAUDE.md is pulled by every agent on every
+   invocation. Each line costs tokens forever. Keep it small and
+   high-signal; let `docs/*.md` carry the long tail.
 
 2. **Update `pipeline/attempts/<code_id>/state.yaml`** to `status: done`.
+   Add `merged_at` and `merged_pr` fields.
 
 3. **Re-run the prioritizer** if the merge added a new abstraction that
    shifts `reuse` scores — see [#rescoring](#recipe-re-score-the-queue).
@@ -387,8 +407,14 @@ partially-closed file with structured BLOCKED markers + a detailed
    Or leave it — the disk space is small and an in-place worktree is
    sometimes useful for follow-ups.
 
-**Expected outcome:** Repo state updated; future skeleton-drafter runs
-benefit from any new patterns documented in `CLAUDE.md`.
+5. **(Periodic) Audit CLAUDE.md size.** Every ~5 merges, or when
+   CLAUDE.md crosses ~500 lines, scan for entries that haven't been
+   referenced in subsequent `result.md` files and consider moving them
+   to `lean-patterns.md` or pruning. The point of the split is to keep
+   CLAUDE.md sustainably small.
+
+**Expected outcome:** Repo state updated; new patterns landed in the
+appropriate tier; CLAUDE.md stayed small.
 
 ---
 

--- a/pipeline/attempts/iceberg/state.yaml
+++ b/pipeline/attempts/iceberg/state.yaml
@@ -4,7 +4,7 @@ parameters: {n: '2m', k: '2m-2', d: 2}
 parametric: true
 parameter: m
 parameter_constraint: 'm >= 2 (Fact (2 <= m))'
-status: pr-ready
+status: done
 track: engineering
 started_at: '2026-05-24'
 worktree_branch: worktree-agent-a87ccc1c921287d7a
@@ -12,9 +12,11 @@ estimated_loc: 500
 final_loc: 765
 sorries_closed: 24
 sorries_blocked: 0
-phase: stage-4-formalization
+phase: stage-6-reflection
 formalization_started_at: '2026-05-24'
 formalization_completed_at: '2026-05-24'
+merged_at: '2026-05-24'
+merged_pr: 36
 covering_lean_file: QEC/Stabilizer/Codes/Iceberg/N.lean
 umbrella_file: QEC/Stabilizer/Codes/Iceberg.lean
 specializes_to:


### PR DESCRIPTION
## Summary

Splits CLAUDE.md into a tiered structure to keep the "must-read on every agent invocation" doc sustainably small. Also closes Stage 6 for iceberg ([[2m, 2m-2, 2]], PR #36) by landing its 4 patterns in the new lean-patterns.md (not CLAUDE.md, per the new tier rule).

**No Lean code changes.** Pure docs restructure.

## The problem

CLAUDE.md was 602 lines and growing roughly linearly with each merge. Patterns and version-quirk entries accreted under sections that don't actually need to grow (orientation, layering, naming policy). Every agent pulls CLAUDE.md on every invocation, so the bloat costs tokens forever.

## The new structure

| File | Role | Now |
|---|---|---|
| `CLAUDE.md` | Stable codebase-wide orientation, naming/style policy, layering, build/MCP workflow. **Must-read every invocation.** | **502 lines** (down from 602) |
| `docs/lean-patterns.md` | **NEW.** Tactical patterns by code shape (CSS distance, non-CSS, parametric, mechanical fixes). Reach for it when your code matches a section. | 276 lines |
| `docs/mathlib-version-quirks.md` | **NEW.** Mathlib API drift grouped by version, dated. | 51 lines |
| `docs/pipeline-usage.md` | Updated Stage 6 recipe with tiered promotion rule. | +36 lines |

CLAUDE.md gets a new "Where to look for what" section at the top pointing to the other docs, so agents discover them on first read.

## Tier rule (in `docs/pipeline-usage.md` § Stage 6)

| Pattern type | Destination |
|---|---|
| Code-shape-specific (CSS distance, non-CSS, parametric, mechanical fix) | **`docs/lean-patterns.md`** (default — most patterns go here) |
| Mathlib API drift (deprecation, rename, signature change) | **`docs/mathlib-version-quirks.md`** (dated entry) |
| Generalizes ≥ 2 code shapes OR pure codebase-wide policy | **`CLAUDE.md`** (highest bar) |
| One-off observation, hasn't recurred | Stay in `result.md` (no promotion) |

Also adds a periodic CLAUDE.md size audit step (every ~5 merges or when CLAUDE.md crosses ~500 lines).

## What moved out of CLAUDE.md

**To `docs/lean-patterns.md`:**

From the "Tactics" subsection:
- `if c then 1 else 0` residual goal closer
- `Finset.card` of `{a, b, c, d}` recipe
- `simp_all` with bidirectional hypotheses workaround
- `Anticommute p q` via `by decide` (non-CSS distance)
- Backtracking witness search (non-CSS distance)
- CSS distance proofs with multiple Z-generators (multi-Z `hi_dichotomy`)
- High-frequency mechanical fixes trio (`_root_` qualification, `rw` after closure_induction, `HMul` defeq)

From "Linter-clean idioms":
- `NQubitPauliOperator.identity` in simp sets (CSS-specific)

Plus the **4 new iceberg patterns** from `pipeline/attempts/iceberg/result.md`:
- Parametric column-evaluation for `rowsLinearIndependent`
- Structural `refine` for `logical_commute_cross` when `Fin n` is parametric
- `simp [foo]` → `simp only [foo]` for `@[inline] private def`
- Counter-pattern (no `hi_dichotomy` needed when all generators have full support)

**To `docs/mathlib-version-quirks.md`:**

The entire "Things that broke recently in v4.30" section, verbatim, under a `## v4.30 (verified 2026-05-24)` header. Future mathlib bumps add new `## v4.31` etc. sections without touching CLAUDE.md.

Also removed: the duplicate "global typeclass instance can break unrelated `native_decide`" entry — the canonical version stays at the "Global vs. `local instance` discipline" bullet in *Naming and style* (no information loss).

## What stayed in CLAUDE.md

Everything that's genuinely stable codebase-wide:
- Project tour, layering, compatibility shims
- Naming policy (snake_case lemmas, camelCase defs, namespaces, noncomputable)
- General tactic preferences (`simp +decide`, `native_decide` allowed, `lean_goal` MCP)
- Sorry-marker convention
- Global vs. local instance discipline
- Linter policy + codebase-wide linter-clean idioms (`push Not`, `refine` with `?_`, `induction with`, `change` vs `show`, `set_option maxHeartbeats`)
- Project-specific helpers index (the helper-name list)
- Build & verification
- Worktrees: mathlib symlink recipe
- Agent tooling: lean-lsp MCP details
- Forbidden / require-permission actions
- LSP recovery
- Formalization pipeline overview
- Canonical CSS code structure / `_TEMPLATE.lean`
- Stabilizer-code packaging (trimmed generators)
- Umbrella files (orphan-module trap)
- Cleanup recipes

## Stage 6 for iceberg

This PR also closes Stage 6 for [[2m, 2m-2, 2]] iceberg (PR #36):
- `pipeline/attempts/iceberg/state.yaml`: `pr-ready → done`, `phase: stage-4-formalization → stage-6-reflection`, adds `merged_at` and `merged_pr: 36`
- Iceberg's 4 patterns landed in `docs/lean-patterns.md`

## Test plan

- [x] `lake build` clean repo-wide (3424 jobs) — no Lean code changed, but sanity-checked
- [x] CLAUDE.md still parses cleanly (visual scan; section structure verified via `grep "^## "`)
- [x] Cross-references in CLAUDE.md still resolve (removed sections that were referenced from elsewhere were checked; only one duplicate "global typeclass" entry was removed, with the canonical version preserved)
- [x] `.gitignore` whitelists the new doc files so they're tracked
- [x] No new linter warnings (no Lean changed)

## Future work

After this lands, the natural next iteration is to audit the existing entries in `docs/lean-patterns.md` once it's seen a few more codes — patterns added today might consolidate or recategorize as the repo grows. The "periodic CLAUDE.md audit" step in the new Stage 6 recipe is the trigger.

🤖 Generated as a CLAUDE.md sustainability refactor + iceberg Stage 6 closure