### PR TITLE
feat(bb_lab): adversarial Tier-3 falsifies R1+R4 on Z_3×Z_15

### DIFF
--- a/experiments/bb_lab/notes/Cv4_R4_falsified.md
+++ b/experiments/bb_lab/notes/Cv4_R4_falsified.md
@@ -1,0 +1,132 @@
+# C-v4 — R1+R4 conjecture FALSIFIED (clean in-hypothesis counterexample)
+
+Date: 2026-05-27. Follow-up to [`T3_CV3_R4_crossorbit.md`](T3_CV3_R4_crossorbit.md)
+and [`pipeline/attempts/bb_distance_conjecture_radical_weight_narrow_tier3/result.md`](../../../pipeline/attempts/bb_distance_conjecture_radical_weight_narrow_tier3/result.md).
+
+## Verdict
+
+The R1 + R4 conjecture (loose-but-correct candidate that survived Tier 3
+round on Bravyi-style codes) is **falsified** by a clean in-hypothesis
+counterexample on a non-Bravyi-style group structure.
+
+> **Counterexample**: `G = Z_3 × Z_15`, `A = 1 + x + x²`, `B = 1 + y + y² + y³ + y⁴`.
+>
+> - `|A| = 3, |B| = 5` both odd (R1 ✓)
+> - `G_odd = Z_3² × Z_5`, each prime-part elementary abelian (loose elem-ab ✓)
+> - `c = [G_a : G_a ∩ G_b] = 3` (✓)
+> - `n = 90, k = 16`
+> - **R4 bound = 4, d_X = 2 → CONJECTURE FALSIFIED, gap +2**
+
+## Reproduction
+
+```bash
+cd experiments/bb_lab
+uv run python scripts/adv_attack3_z3xz7.py
+uv run python scripts/adv_attack3_verify.py     # detailed verification
+uv run python scripts/adv_attack3_recheck.py    # comprehensive recheck
+```
+
+## Verification (multi-path)
+
+Every key quantity confirmed by ≥2 independent methods:
+
+| Quantity | Methods agreeing |
+|---|---|
+| `H_X · H_Z^T = 0` mod 2 | manual circulants + lab `bb_check_matrices` |
+| `n = 90, k = 16` | manual rank + lab `code_params` |
+| `d_X ≥ 2` | brute-force of all 90 weight-1 vectors (zero logicals found) |
+| `d_X = 2` | SAT cap=2 + **45 explicit weight-2 X-logical witnesses** |
+| 2 joint-vanishing orbits | lab + manual Frobenius analysis on Z_3 × Z_3 × Z_5 characters |
+| R4 raw = 12 | Gray-code + random sampling + **exhaustive enumeration of all 255 nonzero F₂-combinations** of the 8-dim basis |
+| Lin–Pryadko is satisfied | explicit `(1 + y + y⁵ + y⁶ + y¹⁰ + y¹¹) ∈ ker(M_B)` of weight 6 → `⌈6/3⌉ = 2 = d_X` |
+
+## Mechanism — the proof gap, realized
+
+The Lin–Pryadko (Statement 12, [arXiv:2306.16400](https://arxiv.org/abs/2306.16400)) bound uses
+`min weight in ker(M_A)` (which equals `d_A^⊥`). R1+R4 strengthens this to
+`min weight in W(A, B) = (⊕_{O ∈ JointVan(A,B)} R_O) ∩ ker(M_A)`. The
+strengthening assumes the minimum-weight kernel element of `M_A` can be
+chosen with support entirely on joint-vanishing orbits. **This assumption
+is false in general.**
+
+Concretely on the counterexample:
+
+- `(1 + x) ∈ ker(M_A)` of weight 2: `A · (1 + x) = (1+x+x²)(1+x) = 1 + x³ = 0`
+  in `F_2[Z_3 × Z_15]`. So `d_A^⊥ = 2`.
+- But `(1 + x)`'s Fourier support is on orbits with `χ_1` (first-`Z_3` character)
+  nontrivial — including the `B`-unit orbits, NOT just the joint-vanishing ones.
+  Hence `(1 + x) ∉ W(A, B)`, and R4 doesn't see it.
+- The minimum-weight element of `W(A, B)` has weight 12 (verified exhaustively).
+  R4 reports `ρ_A = 12`, giving bound `⌈12/3⌉ = 4`.
+- The weight-2 element `(1 + x)`, combined with the weight-6 element of
+  `ker(M_B)` above, produces a weight-2 X-logical `(0, β)` with
+  `β = δ_{(0,0)} + δ_{(1,0)}`, as verified by all 45 explicit witnesses.
+
+So R4's joint-vanishing restriction is structurally invalid.
+
+## Scope of the failure
+
+[`scripts/adv_attack3_scope.py`](../scripts/adv_attack3_scope.py) probed
+the structural scope:
+
+| `G` | `G_odd` | semisimple? | Verdict |
+|---|---|:---:|---|
+| `Z_3 × Z_15` | `Z_3² × Z_5` (multi-prime) | yes | **FALSIFIES** R4=4 > d=2 |
+| `Z_6 × Z_15` | `Z_3² × Z_5` (multi-prime) | no (`G_2 = Z_2`) | **FALSIFIES** R4=4 > d=2 |
+| `Z_3 × Z_30` | `Z_3² × Z_5` (multi-prime) | no (`G_2 = Z_2`) | **FALSIFIES** R4=4 > d=2 |
+| `Z_3 × Z_3` | `Z_3²` (single-prime) | yes | tight (R4 = d = 2) |
+| `Z_15 × Z_15` | `Z_3² × Z_5²` (multi-prime, rank≥2 each) | yes | loose-correct (R4 < d) |
+| `Z_12 × Z_12` (Bravyi domain) | `Z_3²` (single-prime) | no | satisfies (prior testing) |
+
+The failure mode requires:
+
+1. **Multi-prime `G_odd`** with at least one prime appearing at rank 1.
+2. Polynomial choices where `A` vanishes on one prime's nontrivial-character
+   orbits and `B` vanishes on the other prime's nontrivial-character orbits
+   — making `JointVan(A, B)` a tiny fraction of `ker(M_A)` and `ker(M_B)`.
+
+This regime includes BB code `[[90, 8, 10]]` (Bravyi) by group structure
+(`G_odd = Z_3² × Z_5`), though bb_90's specific polynomial choices avoid
+the failure mode and the code satisfies the conjecture.
+
+The other three Bravyi codes (`[[72,12,6]]`, gross `[[144,12,12]]`,
+`[[288,12,18]]`) all have single-prime `G_odd = Z_3²` and are NOT affected
+by this falsifier.
+
+## Implications
+
+1. **R1+R4 as stated is dead.** The clean in-hypothesis counterexample
+   removes it from the Lean formalization track. Recommendation in
+   [`pipeline/attempts/bb_distance_conjecture_radical_weight_narrow_tier3/result.md`](../../../pipeline/attempts/bb_distance_conjecture_radical_weight_narrow_tier3/result.md)
+   to pursue `HANDOFF_C4_R4.md` is withdrawn.
+
+2. **Lin–Pryadko Statement 12 remains the only correct formalization target**
+   in this space — the original (un-strengthened) bound `d_X ≥ ⌈d_A^⊥ / c⌉`,
+   which is satisfied (and tight at 2) on the counterexample.
+
+3. **Possible salvage: add single-prime `G_odd` hypothesis.** The scope
+   probe shows the falsifier requires multi-prime `G_odd`. Restricting
+   the conjecture domain to `G_odd = (Z_p)^k for some single prime p`
+   excludes the falsifier and bb_90, retaining the other 3 Bravyi codes.
+   Whether the R1+R4 bound provably holds on the single-prime subset is
+   open — the proof would still need to handle the joint-vanishing
+   restriction, and there is no proof-theoretic reason the single-prime
+   case avoids the proof gap demonstrated by the `(1+x)` mechanism.
+
+4. **The C-program (Cv1 → Cv2 → Cv3 → R1+R4) has now run its course**
+   with no surviving tight or loose-correct bound applicable to the
+   engineering target. The empirically-clean "0 violations on c ≥ 3"
+   finding from the corpus sweep ([`Cv3_restricted_sweep.md`](Cv3_restricted_sweep.md))
+   is now understood as a side effect of the corpus being dominated by
+   single-prime `G_odd`. The conjecture was overfit to that regime.
+
+## Side note: Lin–Pryadko's d_A^⊥ vs R4's ρ_A on this instance
+
+- `d_A^⊥ = 2` (achieved by `1 + x`)
+- `d_B^⊥ ≤ 6` (achieved by `1 + y + y⁵ + y⁶ + y¹⁰ + y¹¹`)
+- `ρ_A = ρ_B = 12` (cross-orbit min over joint-vanishing direct sum)
+
+So R4 strengthens `d_A^⊥` from 2 to 12 — a factor of 6 — and over-shoots
+`d_X` by a factor of 2 after dividing by `c = 3`. This is the cleanest
+numerical demonstration to date that the joint-vanishing restriction is
+NOT a sound strengthening of Lin–Pryadko.

--- a/experiments/bb_lab/scripts/adv_attack1_4_5.py
+++ b/experiments/bb_lab/scripts/adv_attack1_4_5.py
@@ -1,0 +1,87 @@
+"""Adversarial Attack 1: test R1+R4 conjecture on case (4, 5) over Z_12 × Z_12.
+
+The H_UNIT² investigation flagged this instance as a falsifier of the
+H_UNIT² tight refinement. Its R4 (cross-orbit) bound was never explicitly
+computed against d. This script does that test.
+
+Case: A = x^3 + y^4 + y^5, B = y^3 + x + x^2  over  Z_12 × Z_12.
+Hypothesis: |A|=|B|=3 odd, G_odd = Z_3 × Z_3 elem-ab, c = 3.
+Empirical d_X = 12 (per H_UNIT² note, from SAT).
+
+Conjecture: d_X >= ceil(min(R4_A, R4_B) / c).
+
+Outcomes:
+  - If R4 bound <= 12: conjecture survives on this instance.
+  - If R4 bound  > 12: conjecture FALSIFIED.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+
+# Make the parent script's imports work
+sys.path.insert(0, str(__import__("pathlib").Path(__file__).resolve().parent))
+
+from tier3_cv3_r4_crossorbit import test_case
+from bb_lab.group import ZmZn
+
+
+def main():
+    print("=== Adversarial Attack 1: case (4, 5) on Z_12 × Z_12 ===\n", flush=True)
+
+    # The H_UNIT² falsifier
+    G = ZmZn(12, 12)
+    A_str = "x^3 + y^4 + y^5"
+    B_str = "y^3 + x + x^2"
+
+    print(f"  G        = {G.label()}  (|G| = {G.cardinality})")
+    print(f"  A        = {A_str}")
+    print(f"  B        = {B_str}")
+    print(f"  Expected: d_X = 12 (per H_UNIT² note, from SAT)\n")
+    print("  Running test_case (SAT may take ~minutes for n=288)...\n", flush=True)
+
+    t0 = time.time()
+    r = test_case(
+        label="(4,5) on Z_12×Z_12 — H_UNIT² falsifier of per-orbit",
+        G=G, A_str=A_str, B_str=B_str,
+        max_d=13,           # bound R4 may overshoot; test up to 13
+        skip_sat=False,
+    )
+    elapsed = time.time() - t0
+
+    print(f"  --- RESULTS ---")
+    print(f"  n = {r.n}, k = {r.k}, c = {r.c}, elem_ab = {r.elem_ab}")
+    print(f"  d_X (from SAT) = {r.d}")
+    print(f"  C-v3 per-orbit bound = {r.bound_orig}")
+    print(f"  R4 cross-orbit bound = {r.bound_r4}")
+    print(f"  R4 info: {r.info}")
+    print(f"  Total elapsed: {elapsed:.1f}s\n")
+
+    # Verdict
+    d_used = r.d if r.d is not None else 12   # fall back to published if SAT failed
+    print(f"  --- VERDICT ---")
+    print(f"  Hypothesis domain: ", end="")
+    in_domain = (r.elem_ab and r.c >= 3)
+    print("YES" if in_domain else "NO")
+    if not in_domain:
+        print(f"    (elem_ab={r.elem_ab}, c={r.c})")
+        return
+    print(f"  weight(A) = {len(A_str.split('+'))} (odd ✓)")
+    print(f"  weight(B) = {len(B_str.split('+'))} (odd ✓)")
+
+    if r.bound_r4 is None:
+        print(f"  R4 evaluator returned None (basis dim too large)")
+        return
+    if r.bound_r4 > d_used:
+        print(f"\n  *** CONJECTURE FALSIFIED ***")
+        print(f"    R4 bound = {r.bound_r4} > d_X = {d_used}")
+        print(f"    Gap = +{r.bound_r4 - d_used}")
+    elif r.bound_r4 == d_used:
+        print(f"\n  tight: R4 bound = d_X = {d_used}")
+    else:
+        print(f"\n  loose-correct: R4 bound = {r.bound_r4} < d_X = {d_used} (gap {d_used - r.bound_r4})")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/bb_lab/scripts/adv_attack2_weight5.py
+++ b/experiments/bb_lab/scripts/adv_attack2_weight5.py
@@ -1,0 +1,182 @@
+"""Adversarial Attack 2: weight-5 BB codes over Z_6 × Z_6, c ≥ 3.
+
+The R1 (odd-weight) hypothesis was added to exclude 78 weight-4 violators
+on Z_6 × Z_6. Weight-3 codes are extensively tested (the corpus). Weight-5
+codes (also odd ✓ R1) have NEVER been tested.
+
+If the odd-weight hypothesis is doing "real work" (some augmentation-ideal
+mechanism), weight-5 should also satisfy. If it's anti-fit to weight-4
+violators specifically, weight-5 may produce new violators.
+
+Strategy:
+  - Enumerate weight-5 canonical BB pairs over Z_6 × Z_6 (k >= 1)
+  - Filter to in-hypothesis: c >= 3 (G_odd = Z_3 × Z_3 is automatic; elem-ab)
+  - For each in-scope case, compute R4 bound and SAT distance (max_d <= 8)
+  - Stop after ~30 minutes wall-clock or 30 in-scope cases tested
+  - Report any violator
+
+A single violation falsifies the conjecture.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from tier3_cv3_r4_crossorbit import r4_cross_orbit_bound
+from bb_lab.checks import bb_check_matrices
+from bb_lab.codeparams import code_params
+from bb_lab.degeneracy import is_g_odd_elementary_abelian
+from bb_lab.enumerate_bb import enumerate_canonical_pairs
+from bb_lab.group import ZmZn
+from bb_lab.poly import Poly
+from bb_lab.radical_weight import (
+    bb_radical_bound,
+    joint_support_subgroup_index,
+)
+from bb_lab.sat_distance import x_distance
+
+
+WALL_BUDGET_SECONDS = 1800   # 30 minutes
+MAX_IN_SCOPE_CASES = 50
+MAX_SAT_WEIGHT = 8           # cap SAT search to keep runtime sane
+
+
+def supports_to_poly_string(support, G):
+    """Convert a list of group-element tuples to a polynomial string."""
+    parts = []
+    for g in support:
+        if isinstance(g, tuple):
+            a, b = g
+        else:
+            a, b = g
+        terms = []
+        if a > 0:
+            terms.append("x" if a == 1 else f"x^{a}")
+        if b > 0:
+            terms.append("y" if b == 1 else f"y^{b}")
+        if not terms:
+            parts.append("1")
+        else:
+            parts.append("*".join(terms))
+    return " + ".join(parts)
+
+
+def main():
+    print("=== Adversarial Attack 2: weight-5 BB codes over Z_6 × Z_6 ===\n", flush=True)
+    G = ZmZn(6, 6)
+    print(f"  G = {G.label()},  G_odd = Z_3 × Z_3,  G_2 = Z_2 × Z_2")
+    print(f"  G_odd elem-ab: {is_g_odd_elementary_abelian(G)}")
+    print(f"  Weight = 5 (odd; R1 hypothesis satisfied trivially)")
+    print(f"  Filter: c >= 3 (in-hypothesis)")
+    print(f"  Budget: {WALL_BUDGET_SECONDS}s wall-clock, {MAX_IN_SCOPE_CASES} in-scope cases\n")
+    print("  Enumerating canonical pairs (k >= 1)...\n", flush=True)
+
+    t_start = time.time()
+    n_canonical = 0
+    n_inscope = 0
+    n_tested = 0
+    n_violations = 0
+    n_tight = 0
+    n_loose = 0
+    n_sat_failed = 0
+    n_r4_unable = 0
+
+    violators: list[dict] = []
+
+    for inst in enumerate_canonical_pairs(G, weight=5, only_k_geq=1, verbose=False):
+        n_canonical += 1
+        elapsed = time.time() - t_start
+        if elapsed > WALL_BUDGET_SECONDS:
+            print(f"\n  (wall-clock budget {WALL_BUDGET_SECONDS}s reached)", flush=True)
+            break
+        if n_inscope >= MAX_IN_SCOPE_CASES:
+            print(f"\n  (max in-scope cases {MAX_IN_SCOPE_CASES} reached)", flush=True)
+            break
+
+        # Materialize A, B as Polys
+        A_str = supports_to_poly_string(inst.canonical.A_support, G)
+        B_str = supports_to_poly_string(inst.canonical.B_support, G)
+        A = Poly.from_string(A_str, G)
+        B = Poly.from_string(B_str, G)
+        c = joint_support_subgroup_index(A, B, G)
+        if c < 3:
+            continue
+        n_inscope += 1
+
+        # Compute R4 bound
+        bound_r4, info = r4_cross_orbit_bound(A, B, G)
+        bound_orig = bb_radical_bound(A, B, G)
+        if bound_r4 is None:
+            n_r4_unable += 1
+            print(
+                f"  [{n_inscope:>2d}] (canon #{n_canonical}, t={elapsed:6.1f}s)  "
+                f"A={A_str!r}  B={B_str!r}  k={inst.k}  c={c}  "
+                f"R4 UNABLE (basis dim too large)",
+                flush=True,
+            )
+            continue
+
+        # Compute exact distance via SAT (cap at MAX_SAT_WEIGHT)
+        checks = bb_check_matrices(A, B)
+        try:
+            res = x_distance(checks, weight_upper_bound=MAX_SAT_WEIGHT)
+            d = res.distance
+        except Exception as exc:
+            d = None
+            n_sat_failed += 1
+            print(f"      SAT failed: {exc}", flush=True)
+            continue
+
+        n_tested += 1
+        if d is None:
+            n_sat_failed += 1
+            continue
+        if bound_r4 > d:
+            n_violations += 1
+            violators.append({
+                "A": A_str, "B": B_str, "c": c, "k": inst.k,
+                "bound_orig": bound_orig, "bound_r4": bound_r4, "d": d,
+                "info": info,
+            })
+            verdict = f"*** VIOLATION (R4 {bound_r4} > d {d}) ***"
+        elif bound_r4 == d:
+            n_tight += 1
+            verdict = f"tight (= {d})"
+        else:
+            n_loose += 1
+            verdict = f"loose ({bound_r4} < d={d}, gap {d - bound_r4})"
+
+        print(
+            f"  [{n_inscope:>2d}] (canon #{n_canonical}, t={elapsed:6.1f}s)  "
+            f"A={A_str:<22}  B={B_str:<22}  k={inst.k}  c={c}  "
+            f"orig={bound_orig}  R4={bound_r4}  d={d}  {verdict}",
+            flush=True,
+        )
+
+    elapsed_total = time.time() - t_start
+    print(f"\n=== Summary ===")
+    print(f"  Canonical pairs scanned: {n_canonical}")
+    print(f"  In-scope (c >= 3):       {n_inscope}")
+    print(f"  Successfully tested:     {n_tested}")
+    print(f"  Tight:                   {n_tight}")
+    print(f"  Loose-correct:           {n_loose}")
+    print(f"  **Violations:**          {n_violations}")
+    print(f"  SAT failures:            {n_sat_failed}")
+    print(f"  R4 unable (dim>22):      {n_r4_unable}")
+    print(f"  Wall-clock:              {elapsed_total:.1f}s")
+    if n_violations > 0:
+        print(f"\n  *** CONJECTURE FALSIFIED ***")
+        for v in violators:
+            print(f"    A={v['A']!r}, B={v['B']!r}, c={v['c']}, R4={v['bound_r4']}, d={v['d']}")
+    elif n_tested == 0:
+        print(f"\n  Inconclusive (no test completed).")
+    else:
+        print(f"\n  Conjecture SURVIVES this attack on weight-5 Z_6×Z_6 c>=3 ({n_tested} tested, 0 violations).")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/bb_lab/scripts/adv_attack3_recheck.py
+++ b/experiments/bb_lab/scripts/adv_attack3_recheck.py
@@ -1,0 +1,314 @@
+"""Comprehensive recheck of the Z_3 × Z_15 falsifier.
+
+What could be wrong?
+  (a) d_X = 2 is incorrect — SAT bug, or my code misreads result.
+  (b) R4 = 12 raw is incorrect — wrong joint-vanishing identification,
+      wrong constraint matrix, or wrong min-weight enumeration.
+  (c) c = 3 is incorrect — different convention.
+  (d) The weight-2 "witnesses" are actually stabilizers (not logicals).
+
+This script checks every one of these from an INDEPENDENT angle.
+"""
+
+from __future__ import annotations
+
+import sys
+from itertools import combinations, product
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from bb_lab.checks import bb_check_matrices, circulant
+from bb_lab.codeparams import code_params
+from bb_lab.group import ZmZn
+from bb_lab.linalg import nullspace_f2, rank_f2
+from bb_lab.poly import Poly
+
+
+def main():
+    print("=== COMPREHENSIVE RECHECK: Z_3 × Z_15 falsifier ===\n", flush=True)
+    G = ZmZn(3, 15)
+    A = Poly.from_string("1 + x + x^2", G)
+    B = Poly.from_string("1 + y + y^2 + y^3 + y^4", G)
+    nG = G.cardinality
+    assert nG == 45
+
+    # ---- Check (a): build H_X, H_Z manually and verify CSS commutation ----
+    print("--- Check A: CSS commutation H_X · H_Z^T = 0 (mod 2) ---")
+    M_A = circulant(A).astype(np.uint8)
+    M_B = circulant(B).astype(np.uint8)
+    H_X = np.hstack([M_A, M_B]).astype(np.uint8)
+    H_Z = np.hstack([M_B.T, M_A.T]).astype(np.uint8)
+    prod = (H_X @ H_Z.T) % 2
+    print(f"  H_X shape = {H_X.shape}, H_Z shape = {H_Z.shape}")
+    print(f"  max |H_X · H_Z^T mod 2| = {prod.max()}  (must be 0)")
+    assert prod.max() == 0, "CSS commutation FAILS — H_X, H_Z are wrong"
+    print(f"  ✓ CSS commutation holds\n")
+
+    # Also check via the lab's bb_check_matrices and confirm same matrices.
+    checks = bb_check_matrices(A, B)
+    print(f"  lab H_X identical: {np.array_equal(H_X, checks.H_X)}")
+    print(f"  lab H_Z identical: {np.array_equal(H_Z, checks.H_Z)}")
+
+    # ---- Check (b): n, k ----
+    print("\n--- Check B: n, k via independent rank computation ---")
+    rank_HX = rank_f2(H_X)
+    rank_HZ = rank_f2(H_Z)
+    # k = n - rank(H_X) - rank(H_Z) for a valid CSS code
+    n = 2 * nG
+    k = n - rank_HX - rank_HZ
+    print(f"  n = {n}, rank(H_X) = {rank_HX}, rank(H_Z) = {rank_HZ}, k = {k}")
+    params = code_params(checks)
+    print(f"  lab reports n = {params.n}, k = {params.k}")
+    assert params.n == n and params.k == k
+
+    # ---- Check (c): weight-1 has no logical (so d_X >= 2) ----
+    print("\n--- Check C: weight-1 enumeration (must find ZERO logicals) ---")
+    ker_HZ = nullspace_f2(H_Z)
+    print(f"  dim ker(H_Z) = {ker_HZ.shape[0]} (should equal n - rank(H_Z) = {n - rank_HZ})")
+    found_w1 = 0
+    for i in range(n):
+        v = np.zeros(n, dtype=np.uint8)
+        v[i] = 1
+        if ((H_Z @ v) % 2).any():
+            continue
+        # in ker(H_Z); check if stabilizer
+        stack = np.vstack([H_X, v.reshape(1, -1)])
+        if rank_f2(stack) == rank_HX:
+            continue   # stabilizer, not a logical
+        found_w1 += 1
+    print(f"  weight-1 X-logicals: {found_w1}")
+    assert found_w1 == 0, "Found a weight-1 X-logical — d_X = 1, not 2!"
+    print(f"  ✓ d_X >= 2\n")
+
+    # ---- Check (d): explicit weight-2 witness ----
+    print("--- Check D: explicit weight-2 X-logical witnesses ---")
+    witnesses = []
+    for i, j in combinations(range(n), 2):
+        v = np.zeros(n, dtype=np.uint8)
+        v[i] = v[j] = 1
+        if ((H_Z @ v) % 2).any():
+            continue
+        stack = np.vstack([H_X, v.reshape(1, -1)])
+        if rank_f2(stack) == rank_HX:
+            continue
+        witnesses.append((i, j))
+    print(f"  Number of weight-2 X-logicals found: {len(witnesses)}")
+    print(f"  First 5 witnesses (qubit indices): {witnesses[:5]}")
+    assert len(witnesses) > 0, "No weight-2 X-logical — d_X > 2, falsifier is wrong"
+    # Pick one and confirm its full structure
+    i, j = witnesses[0]
+    v = np.zeros(n, dtype=np.uint8)
+    v[i] = v[j] = 1
+    print(f"  --- Detailed check on witness 0: indices ({i}, {j}) ---")
+    print(f"    H_Z · v (should be all 0): max = {((H_Z @ v) % 2).max()}")
+    print(f"    rank([H_X; v]) = {rank_f2(np.vstack([H_X, v.reshape(1, -1)]))}")
+    print(f"    rank(H_X)      = {rank_HX}")
+    print(f"    → rank increases → v is NOT in rowspan(H_X), hence logical\n")
+
+    # ---- Check (e): independent SAT result via the CLI cadical backend ----
+    print("--- Check E: independent SAT distance verification ---")
+    from bb_lab.sat_distance import x_distance
+    # Use cadical CLI backend (NOT pysat) — different solver path entirely
+    try:
+        res_cli = x_distance(checks, weight_upper_bound=10, backend="cadical-cli")
+        print(f"  cadical-cli backend: d_X = {res_cli.distance}")
+    except (TypeError, Exception) as exc:
+        # Fall back to whatever default and try both cap = 1 and cap = 2
+        from bb_lab.sat_distance import x_distance
+        try:
+            x_distance(checks, weight_upper_bound=1)
+            print(f"  weight_upper_bound=1: SAT found a logical (d_X = 1) — would contradict Check C")
+        except Exception:
+            print(f"  weight_upper_bound=1: no logical (d_X > 1) ✓")
+        res2 = x_distance(checks, weight_upper_bound=2)
+        print(f"  weight_upper_bound=2: SAT result d_X = {res2.distance}")
+    print()
+
+    # ---- Check (f): joint-vanishing orbit identification ----
+    print("--- Check F: joint-vanishing orbits identified manually ---")
+    # G = Z_3 × Z_15 = Z_3 × Z_3 × Z_5.  G_odd = G.
+    # Characters χ = (a, b, c) with a ∈ Z_3 (first factor), b ∈ Z_3 (in Z_15), c ∈ Z_5.
+    # A vanishes iff Σ_{g∈Z_3} ω^{a·g} = 0 iff a ≠ 0.
+    # B vanishes iff Σ_{k=0..4} ζ_15^{(b+5c)·k}? Wait Z_15 → ω^b ζ^c via CRT.
+    # Actually B = sum y^k for k=0..4, y is the Z_15 generator. χ(y) = some 15th root.
+    # Sum_{k=0..4} χ(y)^k = 0 iff χ(y)^5 = 1 AND χ(y) ≠ 1.
+    # χ(y)^5 = 1 iff order of χ(y) divides 5 iff χ corresponds to (b, c) with b = 0 (trivial Z_3-of-Z_15).
+    # So B vanishes iff Z_3-of-Z_15 char trivial (b = 0) AND Z_5 char nontrivial (c ≠ 0).
+    nontrivial_count = 0
+    a_vanishes_count = 0
+    b_vanishes_count = 0
+    joint_count = 0
+    a_only_count = 0
+    b_only_count = 0
+    F4 = None  # placeholder; we work in arithmetic abstractly
+    for a in range(3):
+        for b in range(3):
+            for c in range(5):
+                a_vanish = (a != 0)
+                b_vanish = (b == 0 and c != 0)
+                if a_vanish and b_vanish:
+                    joint_count += 1
+                if a_vanish and not b_vanish:
+                    a_only_count += 1
+                if not a_vanish and b_vanish:
+                    b_only_count += 1
+                if a_vanish:
+                    a_vanishes_count += 1
+                if b_vanish:
+                    b_vanishes_count += 1
+                if not (a == 0 and b == 0 and c == 0):
+                    nontrivial_count += 1
+    print(f"  Total characters: {3 * 3 * 5} = 45")
+    print(f"  A vanishes on: {a_vanishes_count} characters (a ≠ 0)")
+    print(f"  B vanishes on: {b_vanishes_count} characters (b = 0 ∧ c ≠ 0)")
+    print(f"  Joint vanishing (both): {joint_count}")
+    print(f"  A-only vanishing: {a_only_count}")
+    print(f"  B-only vanishing: {b_only_count}")
+    # Joint = a ≠ 0 ∧ b = 0 ∧ c ≠ 0 → 2 · 1 · 4 = 8 characters.
+    # These 8 characters under Frobenius (χ → χ²) split into Galois orbits.
+    # Frobenius on (a, b, c) is (2a mod 3, 2b mod 3, 2c mod 5).
+    # For (a, b=0, c≠0): orbit is {(a, 0, c), (2a, 0, 2c), (a, 0, 4c), (2a, 0, 3c)}.
+    # Check orbit of (1, 0, 1): {(1,0,1), (2,0,2), (1,0,4), (2,0,3)}. Size 4.
+    # Check orbit of (1, 0, 2): {(1,0,2), (2,0,4), (1,0,3), (2,0,1)}. Size 4. Different orbit.
+    # Total: 8 chars in 2 orbits of size 4 each.  Matches script's joint_vanishing_count = 2. ✓
+    # And matches dim_A_subspace = 8 (size 4 + 4).
+    assert joint_count == 8
+
+    # ---- Check (g): re-derive R4 raw min weight via direct min-weight search ----
+    print("\n--- Check G: R4 raw min weight via Gray-code over an explicit basis ---")
+    # Build W(A, B) as the intersection of ker(M_A) with the joint-vanishing subspace.
+    # Joint-vanishing subspace = {v ∈ F_2[G] : v's Fourier support is in joint-vanishing orbits}
+    # Equivalently: v has zero Fourier coefficient on ALL non-joint chars.
+    #
+    # For each non-joint character χ, the constraint is: Σ_g v[g] · χ(g) = 0 over F_{2^|O|}.
+    # In F_2-terms, each F_{2^|O|}-equation gives |O| F_2-rows.
+    #
+    # Approach: use a direct Fourier approach. Build a 2|G| × |G| matrix R where
+    # each "block" is the F_2-coefficient extraction of v's image under χ.
+    # Stack with M_A and find nullspace.
+    #
+    # Easier: just call the lab function and inspect the result.
+    from bb_lab.radical_weight import _min_weight_in_basis
+    from tier3_cv3_r4_crossorbit import (
+        cross_orbit_constraint_rows,
+        joint_vanishing_orbit_indices,
+    )
+    joint_idx = joint_vanishing_orbit_indices(A, B, G)
+    print(f"  Lab joint-vanishing orbit indices: {joint_idx}")
+    cross_rows = cross_orbit_constraint_rows(G, joint_idx)
+    print(f"  cross-orbit constraint matrix: shape {cross_rows.shape}")
+
+    # Test: an element of ⊕_joint R_O should be in null(cross_rows). Check that
+    # adding cross_rows to M_A and finding null gives a subspace of dim 8.
+    stacked = np.vstack([M_A, cross_rows])
+    basis = nullspace_f2(stacked)
+    print(f"  dim null(stack[M_A, cross_rows]) = {basis.shape[0]}")
+    min_w = _min_weight_in_basis(basis)
+    print(f"  Gray-code min weight: {min_w}")
+    # Independent sanity: try a few random combinations and verify weight >= 12
+    rng = np.random.default_rng(42)
+    n_check = 200
+    min_random = float("inf")
+    for _ in range(n_check):
+        d = basis.shape[0]
+        mask = rng.integers(0, 2, size=d)
+        if mask.sum() == 0:
+            continue
+        v = np.zeros(45, dtype=np.uint8)
+        for ii, m in enumerate(mask):
+            if m:
+                v ^= basis[ii]
+        w = int(v.sum())
+        if w > 0:
+            min_random = min(min_random, w)
+    print(f"  Random {n_check} samples min weight: {min_random}")
+    # All 255 nonzero combinations
+    all_min = float("inf")
+    d = basis.shape[0]
+    for mask_int in range(1, 1 << d):
+        v = np.zeros(45, dtype=np.uint8)
+        for ii in range(d):
+            if (mask_int >> ii) & 1:
+                v ^= basis[ii]
+        w = int(v.sum())
+        if w > 0 and w < all_min:
+            all_min = w
+    print(f"  Exhaustive {(1 << d) - 1} = {(1 << d) - 1} combinations min weight: {all_min}")
+    assert all_min == min_w, "Gray-code disagrees with exhaustive search!"
+    print()
+
+    # ---- Check (h): Lin-Pryadko d_A^⊥ — find a low-weight kernel element ----
+    print("--- Check H: Lin-Pryadko d_A^⊥ sanity ---")
+    null_MA = nullspace_f2(M_A)
+    null_MB = nullspace_f2(M_B)
+    print(f"  dim ker(M_A) = {null_MA.shape[0]}")
+    print(f"  dim ker(M_B) = {null_MB.shape[0]}")
+    # Min weight by random sampling (dim too high for exact)
+    rng = np.random.default_rng(0)
+    best_A = float("inf")
+    for _ in range(50000):
+        d_ = null_MA.shape[0]
+        mask = rng.integers(0, 2, size=d_)
+        if mask.sum() == 0:
+            continue
+        v = np.zeros(45, dtype=np.uint8)
+        for ii, m in enumerate(mask):
+            if m:
+                v ^= null_MA[ii]
+        w = int(v.sum())
+        if 0 < w < best_A:
+            best_A = w
+    best_B = float("inf")
+    for _ in range(50000):
+        d_ = null_MB.shape[0]
+        mask = rng.integers(0, 2, size=d_)
+        if mask.sum() == 0:
+            continue
+        v = np.zeros(45, dtype=np.uint8)
+        for ii, m in enumerate(mask):
+            if m:
+                v ^= null_MB[ii]
+        w = int(v.sum())
+        if 0 < w < best_B:
+            best_B = w
+    print(f"  Random min weight in ker(M_A): {best_A}  (this is an UPPER bound on d_A^⊥)")
+    print(f"  Random min weight in ker(M_B): {best_B}")
+    # Specifically: (1 + y + y^5 + y^6 + y^{10} + y^{11}) should be in ker(M_B).
+    # Build this element explicitly.
+    def g_index(g_x, g_y):
+        return g_x * 15 + g_y
+    test_v = np.zeros(45, dtype=np.uint8)
+    for g_y in [0, 1, 5, 6, 10, 11]:
+        test_v[g_index(0, g_y)] = 1
+    # M_B applied to test_v: should be zero
+    print(f"  M_B · (test element of weight 6): max = {((M_B @ test_v) % 2).max()}")
+    print(f"  (Should be 0 since (1+y+y^5+y^6+y^10+y^11)·B = 0 by y^{{15}} - 1 factoring)")
+    # Note: test_v ∈ ker(M_B^T) or ker(M_B)? Let's check
+    if ((M_B @ test_v) % 2).max() == 0:
+        print(f"  test_v ∈ ker(M_B), weight = {test_v.sum()}")
+    test_v2 = np.zeros(45, dtype=np.uint8)
+    for g_y in [0, 1, 5, 6, 10, 11]:
+        test_v2[g_index(0, g_y)] = 1
+    if ((M_B.T @ test_v2) % 2).max() == 0:
+        print(f"  test_v2 ∈ ker(M_B^T), weight = {test_v2.sum()}")
+
+    # ---- VERDICT ----
+    print("\n=== FINAL VERDICT ===")
+    c = 3
+    print(f"  CSS commutation:      ✓")
+    print(f"  n = {n}, k = {k} (lab agrees): ✓")
+    print(f"  No weight-1 X-logical: ✓ (so d_X >= 2)")
+    print(f"  {len(witnesses)} weight-2 X-logical witnesses found: ✓ (so d_X = 2)")
+    print(f"  Joint-vanishing orbit count = {len(joint_idx)} ✓ (matches Frobenius analysis)")
+    print(f"  R4 raw min weight = {min_w} (Gray-code) = {all_min} (exhaustive 255 combos) ✓")
+    print(f"  R4 bound = ⌈{min_w}/{c}⌉ = {-(-min_w // c)}")
+    print(f"  Lin-Pryadko side: d_B^⊥ ≤ 6 (explicit weight-6 witness), so ⌈d_B^⊥/c⌉ ≤ 2 = d_X ✓")
+    print()
+    print(f"  *** R4 bound = {-(-min_w // c)} > d_X = 2: CONJECTURE FALSIFIED, VERIFIED ***")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/bb_lab/scripts/adv_attack3_scope.py
+++ b/experiments/bb_lab/scripts/adv_attack3_scope.py
@@ -1,0 +1,112 @@
+"""Probe the structural scope of the Z_3 × Z_15 falsifier.
+
+Found: A = 1+x+x², B = 1+y+y²+y³+y⁴ on Z_3 × Z_15 has R4=4 > d_X=2.
+
+Open questions about the failure mode:
+  Q1. Is the falsifier specific to SEMISIMPLE G (|G| odd, G_2 trivial)?
+      Test the same A, B on a non-semisimple variant.
+  Q2. Does single-prime G_odd save it? Restrict to G_odd = (Z_p)^k single prime.
+      The current falsifier has G_odd = Z_3² × Z_5 (multi-prime).
+  Q3. Lin-Pryadko's d_A^⊥ is satisfied; is it ALWAYS satisfied while R4 fails?
+      That is, can we engineer an instance where Lin-Pryadko itself fails?
+      (If yes, something is wrong in the setup — we'd be falsifying a proven
+      theorem.)
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from tier3_cv3_r4_crossorbit import test_case
+from bb_lab.checks import bb_check_matrices
+from bb_lab.codeparams import code_params
+from bb_lab.degeneracy import is_g_odd_elementary_abelian
+from bb_lab.group import ZmZn
+from bb_lab.poly import Poly
+from bb_lab.radical_weight import joint_support_subgroup_index
+
+
+CASES = [
+    # The original falsifier (semisimple G, multi-prime G_odd)
+    ("REFERENCE: Z_3xZ_15 (semisimple, multi-prime) — KNOWN FALSIFIER",
+        3, 15, "1 + x + x^2", "1 + y + y^2 + y^3 + y^4", 10),
+    # Variants with G_2 non-trivial (Z_3 × Z_15 → Z_6 × Z_15, etc.)
+    ("Z_6xZ_15: c?-version with A on Z_3-subgroup",
+        6, 15, "1 + x^2 + x^4", "1 + y + y^2 + y^3 + y^4", 10),
+    ("Z_3xZ_30: G_2=Z_2 on second factor only",
+        3, 30, "1 + x + x^2", "1 + y^2 + y^4 + y^6 + y^8", 10),
+    # Non-semisimple, but single-prime G_odd? — need G with G_odd a single (Z_p)^k.
+    # No 5 → just (Z_3)^k.  E.g. Z_6 × Z_6 (already in corpus, well-tested).
+    # The simplest test: Z_3 × Z_3 (semisimple, single-prime). Does the analog falsify?
+    # Need a polynomial on Z_3 with cube-root vanishing (A=1+x+x²) and one on Z_3 with
+    # cube-root vanishing in DIFFERENT direction (B=1+y+y²). What does R4 give?
+    ("Z_3xZ_3 (semisimple, single-prime) analog",
+        3, 3, "1 + x + x^2", "1 + y + y^2", 6),
+    # And Z_3 × Z_9 (semisimple, NON-elem-ab Z_9 part) — out of hypothesis
+    ("Z_3xZ_9 (semisimple, NON-elem-ab) — should be excluded",
+        3, 9, "1 + x + x^2", "1 + y + y^2 + y^3 + y^4 + y^5 + y^6 + y^7 + y^8", 8),
+    # Z_15 × Z_15 = Z_3 × Z_5 × Z_3 × Z_5 (semisimple, two-prime, rank-2 each)
+    ("Z_15xZ_15 (semisimple, multi-prime, higher rank)",
+        15, 15, "1 + x + x^2", "1 + y + y^2 + y^3 + y^4", 10),
+    # Test whether the Lin-Pryadko base bound (d_A^⊥/c) also exceeds d on the falsifier.
+    # If yes, we'd be falsifying a proven theorem — alarm bell. If no, R4 is the issue.
+    # (This is checked by `adv_attack3_verify.py` for the original falsifier.)
+]
+
+
+def main():
+    print("=== Adversarial Attack 3 SCOPE PROBE ===\n", flush=True)
+    print("  Question: does the Z_3 × Z_15 falsifier generalize, and to what?\n", flush=True)
+    print(f"{'Label':<60} {'c':>3} {'k':>4} {'orig':>5} {'R4':>5} {'d':>4} {'verdict':<15}")
+    print("-" * 110, flush=True)
+
+    falsifiers = []
+    for label, ell, m, A_str, B_str, max_d in CASES:
+        G = ZmZn(ell, m)
+        try:
+            A = Poly.from_string(A_str, G)
+            B = Poly.from_string(B_str, G)
+        except Exception as exc:
+            print(f"  [{label}] PARSE FAIL: {exc}", flush=True)
+            continue
+
+        elem_ab = is_g_odd_elementary_abelian(G)
+        c = joint_support_subgroup_index(A, B, G)
+        checks = bb_check_matrices(A, B)
+        params = code_params(checks)
+        if params.k == 0:
+            print(f"  {label:<60} {c:>3} {params.k:>4} {'-':>5} {'-':>5} {'-':>4} {'k=0':<15}")
+            continue
+        if c < 3 or not elem_ab:
+            print(f"  {label:<60} {c:>3} {params.k:>4} {'-':>5} {'-':>5} {'-':>4} {'out':<15}")
+            continue
+
+        r = test_case(label, G, A_str, B_str, max_d=max_d, skip_sat=False)
+        if r.bound_r4 is None:
+            verdict = "R4 UNABLE"
+        elif r.d is None:
+            verdict = "SAT fail"
+        elif r.bound_r4 > r.d:
+            verdict = f"*VIOLATES* gap +{r.bound_r4 - r.d}"
+            falsifiers.append((label, A_str, B_str, G.label(), c, r.bound_r4, r.d))
+        elif r.bound_r4 == r.d:
+            verdict = "tight"
+        else:
+            verdict = f"loose gap -{r.d - r.bound_r4}"
+        print(f"  {label:<60} {c:>3} {r.k:>4} {str(r.bound_orig):>5} {str(r.bound_r4):>5} "
+              f"{str(r.d):>4} {verdict:<15}", flush=True)
+
+    print("\n=== Summary ===")
+    if falsifiers:
+        print(f"  Falsifiers found ({len(falsifiers)}):")
+        for f in falsifiers:
+            print(f"    {f[3]:<10} A={f[1]!r:<22} B={f[2]!r:<28} c={f[4]} R4={f[5]} d={f[6]}")
+    else:
+        print(f"  No falsifiers in this probe set.")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/bb_lab/scripts/adv_attack3_verify.py
+++ b/experiments/bb_lab/scripts/adv_attack3_verify.py
@@ -1,0 +1,181 @@
+"""Verify the Z_3 × Z_15 falsifier.
+
+Case: G = Z_3 × Z_15, A = 1 + x + x², B = 1 + y + y² + y³ + y⁴.
+Reported:
+  - n = 90, k = 16
+  - elem_ab G_odd = True (Z_3 × Z_3 × Z_5, each prime part elem-ab)
+  - c = 3
+  - weights 3, 5 both odd
+  - R4 raw = 12, R4 bound = 4
+  - d_X = 2  → VIOLATION
+
+Sanity checks:
+  1. Re-derive (n, k) directly from check-matrix ranks.
+  2. Re-run SAT distance with explicit small caps (1, 2, 3) to find the
+     exact distance, NOT just the first SAT result.
+  3. Find an explicit weight-2 X-logical witness (if d=2 is real).
+  4. Compute Lin-Pryadko's d_A^⊥ (min weight in ker(M_A)) and compare to ρ_A.
+  5. Verify the elementary-abelian classifier on G_odd.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from bb_lab.checks import bb_check_matrices, circulant
+from bb_lab.codeparams import code_params
+from bb_lab.degeneracy import is_g_odd_elementary_abelian
+from bb_lab.group import ZmZn
+from bb_lab.linalg import nullspace_f2, rank_f2
+from bb_lab.poly import Poly
+from bb_lab.radical_weight import (
+    bb_radical_bound,
+    joint_support_subgroup_index,
+)
+from bb_lab.sat_distance import x_distance
+
+
+def main():
+    print("=== VERIFICATION: Z_3 × Z_15 falsifier ===\n", flush=True)
+    G = ZmZn(3, 15)
+    A_str = "1 + x + x^2"
+    B_str = "1 + y + y^2 + y^3 + y^4"
+    A = Poly.from_string(A_str, G)
+    B = Poly.from_string(B_str, G)
+
+    print(f"  G = {G.label()},  |G| = {G.cardinality}")
+    print(f"  A = {A_str},  |supp(A)| = {len(A.support)}")
+    print(f"  B = {B_str},  |supp(B)| = {len(B.support)}")
+    print(f"  weight(A) odd: {len(A.support) % 2 == 1}")
+    print(f"  weight(B) odd: {len(B.support) % 2 == 1}")
+    print(f"  G_odd elem-ab (loose): {is_g_odd_elementary_abelian(G)}")
+    c = joint_support_subgroup_index(A, B, G)
+    print(f"  c = {c}")
+
+    print("\n--- Check 1: code parameters ---")
+    checks = bb_check_matrices(A, B)
+    params = code_params(checks)
+    print(f"  n = {params.n}, k = {params.k}")
+    print(f"  rank(H_X) = {params.rank_HX}, rank(H_Z) = {params.rank_HZ}")
+    print(f"  Total qubits = 2|G| = {2*G.cardinality}, "
+          f"stabilizer count = {params.rank_HX + params.rank_HZ}, "
+          f"logical count k = n - rank(H_X) - rank(H_Z) = "
+          f"{params.n - params.rank_HX - params.rank_HZ}")
+
+    print("\n--- Check 2: SAT distance at small caps ---")
+    for cap in (1, 2, 3, 4, 5, 6):
+        try:
+            res = x_distance(checks, weight_upper_bound=cap)
+            d = res.distance
+            print(f"  cap = {cap}: d_X = {d}", flush=True)
+        except Exception as exc:
+            print(f"  cap = {cap}: SAT exception {exc!r}", flush=True)
+
+    print("\n--- Check 3: find an explicit weight-2 X-logical witness ---")
+    # An X-logical (α, β) ∈ ker(H_Z) \ rowspan(H_X). For d = 2, try
+    # all weight-2 (α, β) and check ker(H_Z) and not rowspan(H_X).
+    M_A = circulant(A).astype(np.uint8)
+    M_B = circulant(B).astype(np.uint8)
+    nG = G.cardinality
+    H_X = np.hstack([M_A, M_B]).astype(np.uint8)
+    H_Z = np.hstack([M_B.T, M_A.T]).astype(np.uint8)
+    print(f"  H_X shape: {H_X.shape}, H_Z shape: {H_Z.shape}", flush=True)
+
+    # Find weight-2 vectors in ker(H_Z) not in rowspan(H_X)
+    # First compute ker(H_Z) basis
+    ker_HZ = nullspace_f2(H_Z)
+    print(f"  dim ker(H_Z) = {ker_HZ.shape[0]}")
+    # rowspan(H_X) = stacked-row span
+    # An X-logical is in ker(H_Z) but not in rowspan(H_X)
+    # Check: rank(H_X stacked under ker_HZ row?) = rank(H_X) + (1 if v not in span else 0)
+    rank_HX = rank_f2(H_X)
+    print(f"  rank(H_X) = {rank_HX}")
+
+    # Enumerate weight-2 vectors and test
+    print(f"  Enumerating weight-2 vectors ({2*nG*(2*nG-1)//2} total)...", flush=True)
+    found_witnesses = []
+    for i in range(2*nG):
+        for j in range(i+1, 2*nG):
+            v = np.zeros(2*nG, dtype=np.uint8)
+            v[i] = v[j] = 1
+            # Check v ∈ ker(H_Z)
+            HZv = (H_Z @ v) % 2
+            if HZv.any():
+                continue
+            # v is in ker(H_Z). Check if in rowspan(H_X).
+            stack = np.vstack([H_X, v.reshape(1, -1)])
+            if rank_f2(stack) == rank_HX:
+                continue  # in rowspan, not a logical
+            found_witnesses.append((i, j))
+            if len(found_witnesses) >= 3:
+                break
+        if len(found_witnesses) >= 3:
+            break
+
+    if found_witnesses:
+        print(f"  Found {len(found_witnesses)} weight-2 X-logical witnesses (showing up to 3):")
+        for i, j in found_witnesses:
+            block_i = "α" if i < nG else "β"
+            pos_i = i if i < nG else i - nG
+            block_j = "α" if j < nG else "β"
+            pos_j = j if j < nG else j - nG
+            print(f"    indices ({i}, {j})  =  ({block_i}[{pos_i}], {block_j}[{pos_j}])")
+    else:
+        print(f"  *** NO weight-2 X-logical found ***  — d_X > 2, SAT result inconsistent!")
+
+    print("\n--- Check 4: Lin-Pryadko d_A^⊥ comparison ---")
+    # d_A^⊥ = min weight of nonzero f ∈ ker(M_A^T) (or ker(M_A); abelian so often equal)
+    # Use Gray-code via _min_weight_in_basis from radical_weight
+    from bb_lab.radical_weight import _min_weight_in_basis
+    nullsp_MA = nullspace_f2(M_A)
+    nullsp_MAt = nullspace_f2(M_A.T)
+    print(f"  dim ker(M_A)  = {nullsp_MA.shape[0]}")
+    print(f"  dim ker(M_A^T) = {nullsp_MAt.shape[0]}")
+    if nullsp_MA.shape[0] <= 22:
+        dA_perp = _min_weight_in_basis(nullsp_MA)
+        print(f"  d_A^⊥ (LP, ker(M_A))  = {dA_perp}")
+    else:
+        print(f"  d_A^⊥ (LP, ker(M_A))  = (dim {nullsp_MA.shape[0]} > 22; skipped)")
+    if nullsp_MAt.shape[0] <= 22:
+        dAt_perp = _min_weight_in_basis(nullsp_MAt)
+        print(f"  d_A^⊥ (LP, ker(M_A^T)) = {dAt_perp}")
+
+    bound_orig = bb_radical_bound(A, B, G)
+    print(f"\n  C-v3 per-orbit bound = {bound_orig}")
+
+    # Compute the R4 bound directly to confirm
+    from tier3_cv3_r4_crossorbit import r4_cross_orbit_bound
+    r4_bound, r4_info = r4_cross_orbit_bound(A, B, G)
+    print(f"  R4 cross-orbit bound = {r4_bound}, info = {r4_info}")
+
+    # Lin-Pryadko bound check
+    if nullsp_MA.shape[0] <= 22:
+        lp_bound_A = -(-dA_perp // c)   # ceiling
+        print(f"  Lin-Pryadko bound from d_A^⊥: ⌈{dA_perp} / {c}⌉ = {lp_bound_A}")
+    if nullsp_MAt.shape[0] <= 22:
+        lp_bound_At = -(-dAt_perp // c)
+        print(f"  Lin-Pryadko bound from d_(A^T)^⊥: ⌈{dAt_perp} / {c}⌉ = {lp_bound_At}")
+
+    print("\n--- Verdict ---")
+    if found_witnesses:
+        print(f"  d_X = 2 (confirmed by explicit witness)")
+        print(f"  R4 bound = {r4_bound}")
+        if r4_bound is not None and r4_bound > 2:
+            print(f"\n  *** CONJECTURE FALSIFIED: R4 bound {r4_bound} > d_X = 2 ***")
+        # Also check if Lin-Pryadko is also violated (shouldn't be, by theorem)
+        if nullsp_MA.shape[0] <= 22 and -(-dA_perp // c) > 2:
+            print(f"  WARNING: Lin-Pryadko bound also exceeds d_X — something is wrong")
+        else:
+            print(f"  Lin-Pryadko's bound is satisfied (≤ d_X = 2), so this is a")
+            print(f"  GENUINE falsifier of the R4 strengthening, not an artifact.")
+    else:
+        print(f"  Could not confirm d_X = 2 by witness — SAT may have given wrong answer")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/bb_lab/scripts/adv_attack3_z3xz7.py
+++ b/experiments/bb_lab/scripts/adv_attack3_z3xz7.py
@@ -1,0 +1,174 @@
+"""Adversarial Attack 3: BB codes on G_odd = Z_3 × Z_7 (multi-prime).
+
+The conjecture's empirical evidence is dominated by G_odd = Z_3 × Z_3
+(roughly all Bravyi codes, most of the 74-row in-scope corpus). The
+multi-prime G_odd case has been tested in only 1 testable instance
+(B5: Z_7 × Z_7 with x+x³, y+y³).
+
+This attack uses G = Z_6 × Z_7 (= Z_2 × Z_3 × Z_7), so:
+  G_odd = Z_3 × Z_7  (loose elem-ab: rank 1 for each prime ✓)
+  G_2 = Z_2
+
+We pick A and B by hand to get c = 3 and k > 0:
+  A = 1 + x + x^2          # supp = {(0,0), (1,0), (2,0)} ⊂ Z_6 × {0}, generates Z_6 × {0}
+  B = 1 + y + x^3          # supp = {(0,0), (0,1), (3,0)} ⊂ {0,3} × Z_7
+                           # generates ⟨(0,1), (3,0)⟩ = {0,3} × Z_7, |G_b| = 14
+  G_a ∩ G_b = {0,3} × {0}, order 2
+  c = |G_a| / |G_a ∩ G_b| = 6/2 = 3  ✓
+
+We also probe several variant polynomial choices to widen coverage.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from tier3_cv3_r4_crossorbit import test_case
+from bb_lab.checks import bb_check_matrices
+from bb_lab.codeparams import code_params
+from bb_lab.degeneracy import is_g_odd_elementary_abelian
+from bb_lab.group import ZmZn
+from bb_lab.poly import Poly
+from bb_lab.radical_weight import joint_support_subgroup_index
+
+
+CASES = [
+    # (label, ell, m, A_str, B_str, max_d)
+    # For multi-prime G_odd we need BOTH A and B to vanish on at least one orbit
+    # — picking A with Z_p1-vanishing and B with Z_p2-vanishing won't intersect.
+    # The trick: both A and B must contain the SAME prime's cube/p-root sum.
+
+    # Z_6 × Z_5  (G_odd = Z_3 × Z_5, G_2 = Z_2)
+    # A cube-vanish via Z_3-sum on x-axis, B fifth-vanish via Z_5-sum on y-axis
+    ("Z6xZ5  cube-x / 5th-y (both fully-axis-vanishing)",
+        6, 5, "1 + x + x^2", "1 + y + y^2 + y^3 + y^4", 10),
+    # Variants with shifts
+    ("Z6xZ5  cube-x shifted / 5th-y",
+        6, 5, "1 + x^2 + x^4", "1 + y + y^2 + y^3 + y^4", 10),
+    ("Z6xZ5  cube-x / shifted-5th-y",
+        6, 5, "1 + x + x^2", "y + y^2 + y^3 + y^4 + 1", 10),
+    # Different weights — try mixing
+    ("Z6xZ5  weight-3/3 cube/cube on x (B = A·y) — degenerate test",
+        6, 5, "1 + x + x^2", "y + x*y + x^2*y", 10),
+    # Z_6 × Z_5 with B containing cube-root vanishing on x-axis (so both A, B have Z_3 vanishing)
+    ("Z6xZ5  both-cube-x",
+        6, 5, "1 + x + x^2", "1 + x^2 + x^4 + y + x*y", 10),
+    # Z_10 × Z_3 = Z_2 × Z_5 × Z_3 (G_odd = Z_3 × Z_5; G_2 = Z_2)
+    ("Z10xZ3 5th-y / cube-x",
+        10, 3, "1 + y + y^2", "1 + x + x^2 + x^3 + x^4", 10),
+    # Z_3 × Z_15 = Z_3 × Z_3 × Z_5 = (Z_3)² × Z_5 (multi-prime, BOTH primes elem-ab)
+    # G_2 trivial, semisimple!
+    ("Z3xZ15 (semisimple multi-prime) cube/5th",
+        3, 15, "1 + x + x^2", "1 + y + y^2 + y^3 + y^4", 10),
+    # Z_6 × Z_15: G_odd = Z_3 × Z_3 × Z_5 (loose elem-ab), G_2 = Z_2
+    ("Z6xZ15 nonsemisimple multi-prime",
+        6, 15, "1 + x + x^2", "1 + y + y^2 + y^3 + y^4", 10),
+]
+
+
+def main():
+    print("=== Adversarial Attack 3: G_odd = Z_3 × Z_7 (multi-prime) ===\n", flush=True)
+
+    n_inscope = 0
+    n_tested = 0
+    n_violations = 0
+    n_tight = 0
+    n_loose = 0
+    n_kzero = 0
+    n_outscope = 0
+    violators: list[dict] = []
+
+    for label, ell, m, A_str, B_str, max_d in CASES:
+        G = ZmZn(ell, m)
+        try:
+            A = Poly.from_string(A_str, G)
+            B = Poly.from_string(B_str, G)
+        except Exception as exc:
+            print(f"  [{label}] PARSE FAIL: {exc}", flush=True)
+            continue
+        c = joint_support_subgroup_index(A, B, G)
+        elem_ab = is_g_odd_elementary_abelian(G)
+        in_hypothesis = (c >= 3) and elem_ab
+
+        # Get n, k cheaply first
+        try:
+            checks = bb_check_matrices(A, B)
+            params = code_params(checks)
+            n, k = params.n, params.k
+        except Exception as exc:
+            print(f"  [{label}] CHECKS FAIL: {exc}", flush=True)
+            continue
+
+        print(f"  [{label}]")
+        print(f"    G = {G.label()}  A = {A_str}  B = {B_str}")
+        print(f"    n = {n}, k = {k}, c = {c}, elem_ab = {elem_ab}, in_hypothesis = {in_hypothesis}")
+
+        if not in_hypothesis:
+            n_outscope += 1
+            print(f"    OUT OF HYPOTHESIS DOMAIN — skipped\n", flush=True)
+            continue
+        if k == 0:
+            n_kzero += 1
+            print(f"    k = 0 (no logicals) — skipped\n", flush=True)
+            continue
+
+        n_inscope += 1
+
+        # Run test_case to compute SAT and R4
+        t0 = time.time()
+        r = test_case(label=label, G=G, A_str=A_str, B_str=B_str,
+                      max_d=max_d, skip_sat=False)
+        elapsed = time.time() - t0
+        print(f"    R4 info: {r.info}")
+        print(f"    bound_orig (per-orbit) = {r.bound_orig}")
+        print(f"    bound_r4   (cross-orbit) = {r.bound_r4}")
+        print(f"    d_X = {r.d}")
+        print(f"    elapsed: {elapsed:.1f}s")
+
+        if r.bound_r4 is None:
+            print(f"    R4 UNABLE (basis dim too large)\n", flush=True)
+            continue
+        if r.d is None:
+            print(f"    SAT could not determine d\n", flush=True)
+            continue
+
+        n_tested += 1
+        if r.bound_r4 > r.d:
+            n_violations += 1
+            violators.append({"label": label, "A": A_str, "B": B_str,
+                              "G": G.label(), "c": c, "k": k,
+                              "bound_r4": r.bound_r4, "d": r.d})
+            print(f"    *** CONJECTURE FALSIFIED *** R4 = {r.bound_r4} > d = {r.d}\n", flush=True)
+        elif r.bound_r4 == r.d:
+            n_tight += 1
+            print(f"    tight: R4 = d = {r.d}\n", flush=True)
+        else:
+            n_loose += 1
+            print(f"    loose-correct: R4 = {r.bound_r4} < d = {r.d} (gap {r.d - r.bound_r4})\n", flush=True)
+
+    print(f"\n=== Summary ===")
+    print(f"  Total cases:         {len(CASES)}")
+    print(f"  Out of hypothesis:   {n_outscope}")
+    print(f"  k = 0 (no logicals): {n_kzero}")
+    print(f"  In-scope tested:     {n_tested}")
+    print(f"  Tight:               {n_tight}")
+    print(f"  Loose-correct:       {n_loose}")
+    print(f"  **Violations:**      {n_violations}")
+    if n_violations > 0:
+        print(f"\n  *** CONJECTURE FALSIFIED on G_odd = Z_3 × Z_7 ***")
+        for v in violators:
+            print(f"    {v}")
+    elif n_tested == 0:
+        print(f"\n  Inconclusive: no in-scope k>0 instance succeeded.")
+        print(f"  This is itself a flag: the multi-prime regime may not")
+        print(f"  produce k>0 codes for c≥3 polynomials we can construct by hand.")
+    else:
+        print(f"\n  Conjecture SURVIVES this attack on G_odd = Z_3 × Z_7 ({n_tested} tested).")
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/attempts/bb_distance_conjecture_radical_weight_narrow_tier3/result.md
+++ b/pipeline/attempts/bb_distance_conjecture_radical_weight_narrow_tier3/result.md
@@ -172,3 +172,45 @@ fresh theory.
 The 4-tier pipeline architecture (HANDOFF.md §2) caught both
 the original failure (via T3) and the false-tight-refinement
 (H_UNIT²) BEFORE Lean — saving weeks of misdirected formalization.
+
+---
+
+## POSTSCRIPT (2026-05-27): R1 + R4 itself FALSIFIED
+
+The "loose-but-correct" R1 + R4 conjecture that this document recommended
+for Lean formalization (§"Recommended next steps" item 1) has now been
+falsified by a clean in-hypothesis counterexample:
+
+> `G = Z_3 × Z_15`, `A = 1 + x + x²`, `B = 1 + y + y² + y³ + y⁴`.
+> All R1 + R4 hypotheses hold (odd weights, loose elem-ab `G_odd`, `c = 3`).
+> R4 bound = 4 but `d_X = 2`. **Conjecture falsified, gap +2**.
+
+The mechanism is the proof gap predicted by abstract critique but never
+explicitly demonstrated: `(1 + x) ∈ ker(M_A)` of weight 2 lives on
+A-only-vanishing orbits (not joint-vanishing), so R4's restriction to
+`W(A, B)` doesn't see it. Lin–Pryadko Statement 12 (using full `d_A^⊥`)
+remains correct and is tight at 2 on this instance.
+
+Verification: 45 explicit weight-2 X-logical witnesses found by
+brute-force enumeration; R4 raw value 12 verified by exhaustive
+enumeration of all 255 nonzero F₂-combinations in the 8-dim basis;
+CSS commutation, `(n, k)`, and Frobenius orbit analysis all confirmed
+by independent paths. See [`notes/Cv4_R4_falsified.md`](../../../experiments/bb_lab/notes/Cv4_R4_falsified.md)
+and scripts `experiments/bb_lab/scripts/adv_attack3_{z3xz7, verify, recheck, scope}.py`.
+
+**Updated recommendations:**
+
+1. ~~Write `HANDOFF_C4_R4.md`~~ — **WITHDRAWN.** R1 + R4 has no provable
+   form in its currently-stated hypothesis domain.
+2. **Lin–Pryadko Statement 12 remains the only correct Lean target**
+   for analytic distance bounds on BB codes in the C-program's lineage.
+3. The empirical "0 violations on c ≥ 3" finding from the corpus sweep
+   is now understood as an artifact of the corpus being dominated by
+   single-prime `G_odd`. The failure regime is multi-prime `G_odd` with
+   rank-1 on at least one prime — which includes `[[90, 8, 10]]`'s
+   group structure (`Z_3² × Z_5`), though its specific polynomials
+   happen to avoid the failure.
+4. **The C-program (Cv1 → Cv2 → Cv3 → R1+R4) is closed** with no
+   surviving bound on the Bravyi engineering target. The `w_1` weight
+   invariant (Cv1) stands as a standalone contribution; the
+   distance-bound thread is exhausted.


### PR DESCRIPTION
## Summary

The R1+R4 loose-but-correct candidate — the last surviving bound from the C-program (Cv1 → Cv2 → Cv3 → R1+R4) and the recommended Lean formalization target from the prior Tier-3 round — is **falsified** by a clean in-hypothesis counterexample on multi-prime `G_odd`.

**The killer:**
```
G = Z_3 × Z_15,  A = 1+x+x²,  B = 1+y+y²+y³+y⁴
|A| = 3, |B| = 5 (both odd ✓)
G_odd = Z_3² × Z_5 (loose elem-ab ✓)
c = 3 ✓
n = 90, k = 16, d_X = 2
R4 bound = ⌈12/3⌉ = 4  →  FALSIFIED with gap +2
```

The mechanism is the "proof gap" predicted but never previously realized: `(1+x) ∈ ker(M_A)` of weight 2 is supported on A-only-vanishing orbits, so R4's restriction to the joint-vanishing direct sum doesn't see it. Lin–Pryadko Statement 12 (using the full `ker(M_A)`) remains correct and is tight at `d_X = 2` on this instance.

## Verification (each quantity confirmed by ≥2 independent methods)

- **CSS commutation** `H_X · H_Z^T = 0` (mod 2): manual circulants + lab `bb_check_matrices`
- **n, k**: manual rank + lab `code_params`
- **`d_X = 2`**: SAT (cap=2) + 45 explicit weight-2 X-logical witnesses, each verified to be in `ker(H_Z)` and NOT in `rowspan(H_X)` via rank-increase test
- **`d_X ≥ 2`**: brute-force enumeration of all 90 weight-1 vectors, zero logicals
- **R4 raw = 12**: Gray-code + random sampling + **exhaustive enumeration of all 255 nonzero F₂-combinations** of the 8-dim basis
- **2 joint-vanishing orbits**: lab + manual Frobenius analysis on `Z_3 × Z_3 × Z_5` characters
- **Lin–Pryadko satisfied**: explicit `(1 + y + y⁵ + y⁶ + y¹⁰ + y¹¹) ∈ ker(M_B)` of weight 6 verified, giving LP bound `⌈6/3⌉ = 2 = d_X`

## Adversarial attack ledger

| Attack | Outcome |
|---|---|
| #1: R4 on `(x³+y⁴+y⁵, y³+x+x²)` over `Z_12 × Z_12` | conjecture survives tightly (R4 = d = 12) |
| #2: weight-5 enumeration over `Z_6 × Z_6` | stopped after Attack 3's verdict |
| #3: multi-prime `G_odd` constructions | **3 falsifiers found** including non-semisimple |
| #4: proof-gap construction | subsumed — the falsifier *is* a proof-gap counterexample realized concretely |

## Scope of the failure

| `G` | `G_odd` | semisimple? | Verdict |
|---|---|:---:|---|
| `Z_3 × Z_15` | `Z_3² × Z_5` multi-prime | yes | **FALSIFIES** |
| `Z_6 × Z_15` | `Z_3² × Z_5` multi-prime | no | **FALSIFIES** |
| `Z_3 × Z_30` | `Z_3² × Z_5` multi-prime | no | **FALSIFIES** |
| `Z_3 × Z_3` | `Z_3²` single-prime | yes | tight |
| `Z_15 × Z_15` | rank-2 each | yes | loose-correct |
| `Z_12 × Z_12` (Bravyi) | `Z_3²` single-prime | no | satisfies (prior) |

The published Bravyi codes `[[72,12,6]]`, gross `[[144,12,12]]`, `[[288,12,18]]` all have single-prime `G_odd` and are NOT in the falsifier regime. `[[90,8,10]]`'s group structure IS in the regime by construction, but its specific polynomials avoid the failure mode.

## Implications

1. **R1+R4 is dead** in its currently-stated hypothesis domain.
2. **Lin–Pryadko Statement 12** remains the only correct analytic distance-bound target for Lean.
3. The "0 violations at `c ≥ 3`" corpus finding is now understood as a side effect of the corpus being dominated by single-prime `G_odd`.
4. **The C-program (Cv1 → Cv2 → Cv3 → R1+R4) is closed** with no surviving bound on the Bravyi engineering target. The `w_1` weight invariant (Cv1) remains as a standalone contribution.

The `pipeline/attempts/.../result.md` postscript reflects the updated recommendations.

## Test plan

- [ ] `cd experiments/bb_lab && uv run pytest -m 'not slow' -q` still green (no source code touched)
- [ ] `uv run python scripts/adv_attack3_z3xz7.py` reproduces the falsifier
- [ ] `uv run python scripts/adv_attack3_recheck.py` reproduces the full multi-path verification
- [ ] `uv run python scripts/adv_attack3_scope.py` reproduces the 3-falsifier structural-scope table

🤖 Generated with [Claude Code](https://claude.com/claude-code)