### PR TITLE
Clean up the MImBound formalization: prune superseded lemmas + refresh docs

### DIFF
--- a/QEC/Stabilizer/Codes/BivariateBicycle.lean
+++ b/QEC/Stabilizer/Codes/BivariateBicycle.lean
@@ -60,27 +60,35 @@ code and its `[[72, 12, 6]]` base, related by a 2:1 covering:
                     (`lightStabilizerClassification_holds`) by the effective
                     CRT-engine classification, making `DangerousSectorGe12`
                     unconditional
-- `MImClassify`   — the safe-sector confined-frame floor (A4 §§9–13) toward
-                    discharging `MImBound`: the weight join (`chainWeight` as a
-                    per-block per-layer sum), the coset parity, and the `ker ∂₂`
-                    basis with M-VANISH (`off₀ = off₂ = 0`), the closed weight
-                    form (`costFromComps`), and the coset `f`-dependence. WIP.
+- `MImClassify`   — the safe-sector confined-frame floor *reduction* (A4 §§9–13): the weight
+                    join (`chainWeight` as a per-block per-layer sum), the `ker ∂₂` basis with
+                    M-VANISH (`off₀ = off₂ = 0`), the exact per-slot weight (Fourier bijection),
+                    and the closed coset weight form `chainWeight_coset_eq` (= `costFromComps` of
+                    the seam offsets ⊕ engine-multiplied free datum)
 - `MImFloorData`  — machine-generated cost tables (`D3V`, `RCELL`) and Γⱼ coset-generator
                     / fiber data for the floor engine (orbit-independent; emitted by
                     `scripts/gen_floor_lean.py`)
-- `MImFloor`      — the native-decidable confined-floor engine: the Nat-encoded per-cell
-                    cost (`exCost`), the slab-min / offset-aware relaxed lower bounds
-                    (`slabMin`, `relaxed`), their soundness keystones (`cellMin_le`,
-                    `rcell_le`) and monotone lemmas (`slabMin_le_exCost`,
-                    `relaxed_le_exCost`), underpinning the `floorOK` two-phase decision
-                    (validated `true` for all five orbits). WIP toward `mimBound_holds`.
+- `MImFloor`      — the native-decidable confined-floor engine: the Nat-encoded per-cell cost
+                    (`exCost`), the slab-min / offset-aware relaxed lower bounds (`slabMin`,
+                    `relaxed`), their soundness keystones (`cellMin_le`, `rcell_le`) and monotone
+                    lemmas, plus the structural / flat-index soundness (`floorOK_sound`/`_flat`)
+                    and the chain-weight bridge (`costFromComps_eq_exCost`)
 - `MImMembership` — the Γ-membership indices (`gammaIdx0`..`gammaIdx4`) and their correctness
-                    (`mem0`..`mem4`, `native_decide`): each `rmul P̂ⱼ (Vⱼ f)` sits at the
-                    computed index in Γⱼ, on both blocks (the B̂/Â engine-multiplier
-                    convention, verified against `seamC`)
+                    (`mem0`..`mem4`, `native_decide`: each `rmul P̂ⱼ (Vⱼ f)` sits at the computed
+                    index in Γⱼ), plus the general per-orbit floor `floor_of_data`
+- `MImTransport`  — the y-translation symmetry: `seamC` is y-covariant at the chain level
+                    (`seamC_shiftYk_combo`) and `chainWeight` is translation-invariant, giving
+                    the transport reduction `floor_shiftYk_combo` (a class's floor lifts to its
+                    `(0,k)`-translate)
+- `MImFloorY0..Y12` — the safe-sector floor proven for each of the 13 y-orbit representatives
+                    (per-orbit `native_decide` `floorOK = true` leaf + `floor_of_data`)
+- `MImAssembly`   — **discharges `MImBound`** (`mimBound_holds`): the 64-case y-orbit dispatch
+                    (`floor_kcombo`) reduces every `ker ∂₂` class to a y-orbit rep; then the
+                    **unconditional** `grossStabilizerCode_hasCodeDistance_12_uncond` and the
+                    bundled `grossStabilizerCodeWithDistance : StabilizerCodeWithDistance 144 12 12`
 
-The full `StabilizerCode` packaging is complete and the A4 §6.3 classification
-hypothesis is discharged in `LightStabClassify`, leaving `MImBound` (A4 Part II
-(M-im)) as the single remaining CRT-engine hypothesis for `d = 12`; its discharge
-is under construction in `MImClassify`.
+Both CRT-engine inputs — `LightStabilizerClassification` (`LightStabClassify`) and `MImBound`
+(`MImAssembly`) — are now discharged, so the distance of the gross `[[144,12,12]]` code is
+**unconditional and axiom-clean** (the standard three axioms + the `native_decide` compiler
+axiom; no `sorry`).
 -/

--- a/QEC/Stabilizer/Codes/BivariateBicycle/MImClassify.lean
+++ b/QEC/Stabilizer/Codes/BivariateBicycle/MImClassify.lean
@@ -1,21 +1,39 @@
 /-
-# Phase 6: discharging `MImBound` — the safe-sector confined-frame floor
+# Phase 6: reducing `MImBound` to the confined-frame floor (§§0–7)
 
-`MImBound` (`SafeSector.lean`, A4 Part II / Theorem D) is the last assumed `Prop`
-for an unconditional `d(gross) = 12`: every base 1-cycle in a nonzero Smith class
-`[seamC ζ]` (`ζ ∈ ker ∂₂`) has weight ≥ 12.  The paper proof is the confined-frame
-collapse of A4 §§9–13; this module formalizes it, reusing the CRT frame
-(`CRTFrame.lean`) and the layer/Fourier machinery built for the dangerous sector
-(`LightStab.lean`).
+`MImBound` (`SafeSector.lean`, A4 Part II / Theorem D) was the last assumed `Prop` for an
+unconditional `d(gross) = 12`: every base 1-cycle in a nonzero Smith class `[seamC ζ]`
+(`ζ ∈ ker ∂₂`) has weight ≥ 12, even though the base `[[72,12,6]]` code has distance only 6.
 
-## Structure
+This module performs the **algebraic reduction**: it rewrites the coset weight
+`chainWeight (seamC ζ + ∂₂ f)` into the closed `costFromComps` form that the native-decidable
+floor engine consumes.  The discharge is then completed downstream — `MImClassify` (reduction)
+→ `MImFloorData` / `MImFloor` (engine + soundness) → `MImMembership` (Γ-membership + the
+general per-orbit floor) → `MImTransport` (the y-translation symmetry) → `MImFloorY0..Y12`
+(the 13 y-orbit-rep floors) → `MImAssembly` (`mimBound_holds`, and the unconditional distance
+theorem).  Reuses the CRT frame (`CRTFrame.lean`) and the layer/Fourier machinery built for
+the dangerous sector (`LightStab.lean`).
 
-* **§0 weight join** — `chainWeight w = bwt (leftHalf w) + bwt (rightHalf w)`
-  and its layer-sum corollary, bridging the noncomputable `bb72Complex.chainWeight`
-  to the per-block, per-`Z₂²`-layer `weight3 (slice …)` decomposition that the
-  CRT frame bounds.  (This is the "join" the route hinges on; it is structural,
-  not a research item, because `seamC ζ + ∂₂ f` is a base 1-chain and `weight_bridge`
-  already decomposes a block over its `Z₂²` layers.)
+## Structure (the section numbers track A4 §§9–13)
+
+* **§0 weight join** — `chainWeight w = bwt (leftHalf w) + bwt (rightHalf w)` and its layer-sum
+  corollary, bridging the noncomputable `bb72Complex.chainWeight` to the per-block, per-`Z₂²`-
+  layer `weight3 (slice …)` decomposition.  (The "join" the route hinges on; structural, since
+  `seamC ζ + ∂₂ f` is a base 1-chain and `weight_bridge` already decomposes a block.)
+* **§2 `ker ∂₂` basis, spanning, M-VANISH** — the systematic basis `kb0..kb5`, `kerBasis_spans`
+  (every `ζ ∈ ker ∂₂` is reconstructed from its six free-cell coordinates via `recon`/`kcombo`),
+  and A4 §9.4 Sharpening 1, `off_vanish` (CRT components 0 and 2 of `seamC ζ` vanish).
+* **§2b coset block decomposition** — `leftHalf_coset`/`rightHalf_coset`: the coset splits as
+  the seam profile plus `A⋆f` / `B⋆f`.
+* **§3 coset CRT profile** — `Vcoset_L0..R4`: `Vⱼ(coset) = offⱼ(ζ) ⊕ P̂ⱼ · Vⱼ f` (the
+  `f`-dependence, via `V_add` and the engine multipliers `Ahat1`/`Ahat4`/`Bhat2`/`unitHat`).
+* **§5 exact per-slot weight** — `weight3_eq_wt5` (the Fourier bijection on `Z₃²`): `weight3`
+  is an EXACT function of the five CRT components (`WT5_TABLE`, `native_decide`).
+* **§6 closed weight form** — `chainWeight_eq_costFromComps`: `chainWeight` as the `Z₂²`-slot
+  sum of the ten CRT components' `wt5OfComps`.
+* **§7 coset weight in component form** — `chainWeight_coset_eq`: composes §6 with §3 to write
+  the coset weight as `costFromComps` of `shifted (seam offset) multiplier (Vⱼ f)` — the exact
+  input the floor engine ranges over.
 
 ## Convention bridge (lab notes → repo)
 
@@ -82,23 +100,6 @@ theorem chainWeight_eq_layer_sum (w : BaseGroup × Fin 2 → ZMod 2) :
         + (∑ s : ZMod 2 × ZMod 2, weight3 (slice (rightHalf w) s)) := by
   rw [chainWeight_eq_bwt_blocks, weight_bridge, weight_bridge]
 
-/-! ## §1 Parity: every Smith-coset element has even weight
-
-The coset element `seamC ζ + ∂₂ f` is a base 1-cycle (`seamC_mem_cycles` puts
-`seamC ζ` in cycles; `∂₂ f` is a boundary, hence a cycle), so it has even weight
-(A4 §9.3 (PAR)).  Combined with the §§11–13 floor of ≥ 10 and the §13 kill of the
-weight-10 achievers, evenness lifts the bound to ≥ 12 on the wt-16/18 orbits. -/
-
-/-- Every Smith-coset element is a base 1-cycle, hence has even chain weight. -/
-theorem coset_weight_even (ζ f : BaseGroup → ZMod 2)
-    (hζ : bbBoundary2Fn baseA baseB ζ = 0) :
-    Even (bb72Complex.chainWeight (seamC ζ + bbBoundary2Fn baseA baseB f)) := by
-  have hbd : bbBoundary2Fn baseA baseB f ∈ bb72Complex.boundaries := ⟨f, rfl⟩
-  have hcyc : seamC ζ + bbBoundary2Fn baseA baseB f ∈ bb72Complex.cycles :=
-    Submodule.add_mem _ (seamC_mem_cycles hζ) (bb72Complex.boundaries_le_cycles hbd)
-  rw [bb72Complex_chainWeight_eq, Nat.even_iff]
-  exact cycle_weight_even _ hcyc
-
 /-! ## §2 The `ker ∂₂` basis, spanning, and M-VANISH (A4 §9.3–§9.4)
 
 `ker ∂₂ = {ζ : conv baseA ζ = 0 ∧ conv baseB ζ = 0}` is 6-dimensional (64 elements,
@@ -129,8 +130,6 @@ def kb4 : BaseGroup → ZMod 2 :=
 def kb5 : BaseGroup → ZMod 2 :=
   mkZeta [(0,0),(0,2),(1,2),(1,3),(1,4),(1,5),(2,0),(2,1),(2,2),
           (2,3),(3,1),(3,2),(3,3),(3,4),(4,1),(4,3),(5,1),(5,5)]
-
-def freeCells : List BaseGroup := [(4,4),(4,5),(5,2),(5,3),(5,4),(5,5)]
 
 -- 324 (out, in, block) factorization entries
 def cPairs : List (BaseGroup × BaseGroup × Fin 2) :=
@@ -342,55 +341,12 @@ theorem Vcoset_R4 : V psi4 s (rightHalf (seamC ζ + bbBoundary2Fn baseA baseB f)
     = fadd (V psi4 s (rightHalf (seamC ζ))) (rmul Bhat2 (fun s' => V psi4 s' f) s) := by
   rw [rightHalf_coset, V_add, mult_B4]
 
-/-! ## §4 The per-slot floor: a comprehensive d₃ table (A4 §10.2 input)
-
-The §10 slot frame bounds each `Z₂²`-layer's weight by the d₃ cost of its `Z₃²`-torus
-Fourier-support pattern.  `oneBlock_core` (`LightStab`) used three hand-picked patterns
-(`d3_psi1/3_ge6`, `d3_psi1or3_ge4`); the safe-sector orbits exercise the full range, so we
-tabulate the d₃ lower bound for **all 32** support patterns (`dlbTable`, `native_decide` over
-the 512 layers) and phrase it on a block-slice in terms of the CRT components `V psiⱼ` that
-the §3 f-dependence produces. -/
-
-/-- 5-bit Fourier-support pattern of a torus layer (chars ψ₀..ψ₄). -/
-def suppPat (g : ZMod 3 × ZMod 3 → ZMod 2) : Nat :=
-  (if fhat3 g (0,0) ≠ 0 then 1 else 0) + (if fhat3 g (0,1) ≠ 0 then 2 else 0) +
-  (if fhat3 g (1,0) ≠ 0 then 4 else 0) + (if fhat3 g (1,1) ≠ 0 then 8 else 0) +
-  (if fhat3 g (1,2) ≠ 0 then 16 else 0)
-
-/-- d₃ lower bound per support pattern (`P = 0..31`): the minimum `weight3` over nonzero
-torus layers whose Fourier support is `⊆ P`. -/
-def dlbTable : Array Nat :=
-  #[0,9,6,3,6,3,4,3,6,3,4,3,4,3,2,2,6,3,4,3,4,3,2,2,4,3,2,2,2,2,2,1]
-
-/-- **Comprehensive d₃ table** (generalizes `d3_psi1_ge6`/`d3_psi3_ge6`/`d3_psi1or3_ge4`):
-every nonzero torus layer has weight ≥ the table value of its support pattern. -/
-theorem d3_table : ∀ g : ZMod 3 × ZMod 3 → ZMod 2, g ≠ 0 →
-    dlbTable.getD (suppPat g) 0 ≤ weight3 g := by
-  native_decide
-
-/-- The support pattern of a block's slice, in terms of the CRT components `V psiⱼ`. -/
-def Vpat (b : BaseGroup → ZMod 2) (s : ZMod 2 × ZMod 2) : Nat :=
-  (if V psi0 s b ≠ 0 then 1 else 0) + (if V psi1 s b ≠ 0 then 2 else 0) +
-  (if V psi2 s b ≠ 0 then 4 else 0) + (if V psi3 s b ≠ 0 then 8 else 0) +
-  (if V psi4 s b ≠ 0 then 16 else 0)
-
-theorem Vpat_eq_suppPat (b : BaseGroup → ZMod 2) (s : ZMod 2 × ZMod 2) :
-    Vpat b s = suppPat (slice b s) := by
-  unfold Vpat suppPat
-  rw [fourier_bridge0, fourier_bridge1, fourier_bridge2, fourier_bridge3, fourier_bridge4]
-
-/-- **Per-slice floor**: a nonzero block-slice has weight ≥ the d₃-table value of its
-CRT-component support pattern. -/
-theorem slice_floor (b : BaseGroup → ZMod 2) (s : ZMod 2 × ZMod 2) (h : slice b s ≠ 0) :
-    dlbTable.getD (Vpat b s) 0 ≤ weight3 (slice b s) := by
-  rw [Vpat_eq_suppPat]; exact d3_table _ h
-
 /-! ## §5 The exact per-slot weight (the Fourier bijection)
 
 The torus-Fourier map `g ↦ (V₀,…,V₄)` is a BIJECTION on the 512 layers (Z₃² is
-coprime to char 2), so `weight3` is an EXACT function of the 5 CRT components — upgrading
-the d₃ table (§4) from an inequality to an equality `weight3 (slice b s) = wt5OfComps (V ψⱼ s b)`.
-This is the form the §10 slot frame minimizes over the coset's free data. -/
+coprime to char 2), so `weight3` is an EXACT function of the 5 CRT components:
+`weight3 (slice b s) = wt5OfComps (V ψⱼ s b)`.  This exact per-slot weight is what the
+confined-floor engine (`MImFloor`) minimizes over the coset's free data. -/
 
 /-- The exact weight of a torus layer as a function of its 5 CRT-Fourier components
 (`v₀ ∈ {0,1}`; index `v₀ + 2·(v₁ + 4·(v₂ + 4·(v₃ + 4·v₄)))`). -/

--- a/QEC/Stabilizer/Codes/BivariateBicycle/StabilizerCode.lean
+++ b/QEC/Stabilizer/Codes/BivariateBicycle/StabilizerCode.lean
@@ -2953,7 +2953,9 @@ theorem grossStabilizerCode_logical_weight_ge_6
 /-- **`HasCodeDistance grossStabilizerCode 12`**, conditional only on `MImBound`.
 The `LightStabilizerClassification` input (`hC`) is discharged by
 `LightStab.lightStabilizerClassification_holds`; everything else — the packaging and
-the chain-level distance — is unconditional. -/
+the chain-level distance — is unconditional.  `MImBound` itself is discharged in
+`MImAssembly` (`LightStab.mimBound_holds`); for the fully unconditional statement see
+`grossStabilizerCode_hasCodeDistance_12_uncond` there. -/
 theorem grossStabilizerCode_hasCodeDistance_12 (hMim : MImBound) :
     HasCodeDistance grossStabilizerCode 12 := by
   have hleast := gross_pauli_distance_eq_12_of_engine


### PR DESCRIPTION
Follow-up to #48 (the unconditional `d = 12` Gross `[[144,12,12]]` proof, now merged). A focused cleanup pass over the `MImBound` formalization — no change to any result; the full BB umbrella rebuilds clean.

## Remove dead code

A whole-tree reference scan over the 162 `MImBound` declarations found only a handful unused; these are leftovers from the **pre-engine exploratory approach**, all confirmed unreferenced:

- **§4 in full** (`suppPat`, `dlbTable`, `d3_table`, `Vpat`, `Vpat_eq_suppPat`, `slice_floor`) — the d₃-*inequality* table, superseded by §5's exact Fourier bijection `weight3_eq_wt5` (verified entirely self-referential — nothing outside §4 used it).
- **§1 `coset_weight_even`** — the coset-parity lemma, whose stated purpose (the old §11–13 "≥ 10 floor + kill the weight-10 achievers" argument) was replaced by the direct ≥ 12 confined-floor engine.
- **`freeCells`** — a redundant list (the cells are spelled inline in `recon` / `recon_eq_kcombo`).

Kept `kerBasis_mem` (a standalone `native_decide` sanity-check that the hand-written `kb0..kb5` really lie in `ker ∂₂`). Re-scanned afterward to confirm no cascade.

## Refresh documentation

- Expanded the `MImClassify` header from a one-section stub into a full **§0 / §2 / §2b / §3 / §5 / §6 / §7** section map plus the downstream discharge pipeline (`MImClassify → MImFloor… → MImMembership → MImTransport → MImFloorY* → MImAssembly`).
- Refreshed the `BivariateBicycle` umbrella docstring: documented the `MImTransport` / `MImFloorY0..Y12` / `MImAssembly` modules and recorded that **both** CRT-engine inputs are discharged (unconditional, axiom-clean) — dropping the stale "WIP / under construction" notes.
- Fixed the now-dangling `§4` reference in §5's docstring; added a forward-reference from the conditional distance theorem to the unconditional one.

## Verification

3 files changed, +67 / −101. No `sorry`, no axiom change; the BB umbrella builds clean (`lake build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)