### PR TITLE
A13: deck-trivial ⟹ k-constant along Z_{2^r} towers — descent theorem + axiom-clean Lean core

### DIFF
--- a/QEC/Stabilizer/Framework/Homological.lean
+++ b/QEC/Stabilizer/Framework/Homological.lean
@@ -9,3 +9,4 @@ import QEC.Stabilizer.Framework.Homological.Covering
 import QEC.Stabilizer.Framework.Homological.BBDuality
 import QEC.Stabilizer.Framework.Homological.BBCover
 import QEC.Stabilizer.Framework.Homological.BBDoubling
+import QEC.Stabilizer.Framework.Homological.BBDeckTower

--- a/QEC/Stabilizer/Framework/Homological/BBDeckTower.lean
+++ b/QEC/Stabilizer/Framework/Homological/BBDeckTower.lean
@@ -1,0 +1,212 @@
+/-
+# The deck-tower descent: `σ_* = id` forces Bezout membership (A13)
+
+This file formalizes the **hard direction** of the tour-de-gross tower
+question (research note `experiments/bb_lab/notes/A13_deck_tower_plan.md`):
+
+> For a free `ℤ_{2^r}` doubling cover with deck generator `σ`, if the deck
+> acts trivially on `H₁` of the top complex, then `1 + σ ∈ (A, B)` — hence
+> (counting lemma) `k(top) = k(base)`, and the whole deck acts trivially at
+> every intermediate level.
+
+The converse (`membership ⟹ deck-trivial`, Koszul annihilation) is already
+formalized as `Quantum.Stabilizer.Homological.BB.deckTrivial_of_bezout`
+(A12). Together they give the family statement **deck-trivial ⟺ k constant
+along the tower**.
+
+## What is proved here, and how it maps to the geometry
+
+Everything is stated over an abstract commutative ring `S` of characteristic
+two, for an element `ε` (the reduced deck translation `1 + σ`, so
+`ε^{2^r} = (1+σ)^{2^r} = 1 + σ^{2^r} = 0` in char two) and a pair `A B : S`.
+The two geometric inputs become two hypotheses:
+
+* **`EpsFree ε N`** — `Ann_S(ε^t) = ε^{N-t}·S`. In the model
+  `S = 𝔽₂[G]`, `G = Z_{2^r ℓ} × Z_m`, this holds because `S` is *free* as a
+  module over the subgroup algebra `Λ = 𝔽₂[⟨σ⟩] ≅ 𝔽₂[ε]/(ε^{2^r})` (a chain
+  ring, where the annihilator identity is elementary), and freeness
+  transports annihilators.
+* **`DeckTrivial ε A B`** — for every Koszul 1-cycle `(y₁, y₂)` (`A y₁ + B y₂
+  = 0`) the shifted chain `ε·(y₁, y₂)` is a boundary `(B z, A z)`. This is
+  exactly `ε · H₁ = 0`, i.e. `σ_* = id` on `H₁` (char two: `σ_* - id` is
+  multiplication by `ε`).
+
+The engine is `descent`: from a membership witness `ε^t ∈ (A,B)` and
+`DeckTrivial`, one deck application on the *canonical cycle* `ε^{N-t}(f,g)`
+produces `ε ∈ (A,B) + ε^{N-t}·S` (the key step is that the returned boundary
+coefficient `z` satisfies `ε^t z = 0`, so `EpsFree` divides it by `ε^{N-t}`).
+`iterate` then bootstraps the tail `ε^{N-t}·S` away using only `ε^N = 0`
+(each `boost` pass grows the tail exponent). The entry witness at
+`t = 2^{r-1}` is A12 applied to the top `ℤ₂`-step; here it is taken as the
+hypothesis `ε^m ∈ (A,B)`, `2 ≤ m ≤ N-2`.
+
+The `experiments/bb_lab/scripts/a13_deck_tower_block_sweep.py` screen checks
+this statement, the canonical-cycle mechanism, and the intermediate
+identities exhaustively on CRT blocks up to deck order 8; all clean.
+-/
+
+import Mathlib.RingTheory.Ideal.Span
+import Mathlib.Algebra.CharP.Two
+import Mathlib.Tactic.LinearCombination
+
+namespace Quantum
+namespace Stabilizer
+namespace Homological
+namespace BBDeckTower
+
+variable {S : Type*} [CommRing S]
+
+/-- **ε-freeness** (the annihilator shape of a free `𝔽₂[ε]/(ε^N)`-module):
+every element killed by `ε^t` is divisible by `ε^{N-t}`. Satisfied in the
+model `S = 𝔽₂[G]` with `ε = 1 + σ` of deck order `N`, since `S` is free over
+the chain ring `𝔽₂[⟨σ⟩]`. -/
+def EpsFree (ε : S) (N : ℕ) : Prop :=
+  ∀ t, 1 ≤ t → t ≤ N → ∀ x : S, ε ^ t * x = 0 → ∃ y : S, x = ε ^ (N - t) * y
+
+/-- **Deck-triviality on `H₁`**: every Koszul 1-cycle, shifted by `ε`, is a
+Koszul boundary. Over char two this is `ε · H₁ = 0`, i.e. `σ_* = id`. -/
+def DeckTrivial (ε A B : S) : Prop :=
+  ∀ y₁ y₂ : S, A * y₁ + B * y₂ = 0 → ∃ z : S, ε * y₁ = B * z ∧ ε * y₂ = A * z
+
+/-- **One bootstrap pass** (pure commutative-ring algebra, no char or
+freeness): a tail `ε^{j+1}·S` is re-expressed with the strictly larger tail
+exponent `(j+1)+j`. Iterated, this walks the tail exponent past `N`. -/
+theorem boost (ε A B : S) (j : ℕ)
+    (h : ∃ p q v : S, ε = p * A + q * B + ε ^ (j + 1) * v) :
+    ∃ p q v : S, ε = p * A + q * B + ε ^ (j + 1 + j) * v := by
+  obtain ⟨p, q, v, hpqv⟩ := h
+  exact ⟨p + ε ^ j * v * p, q + ε ^ j * v * q, v * v, by
+    linear_combination (1 + ε ^ j * v) * hpqv⟩
+
+/-- **The tail-elimination iteration.** With `ε^N = 0`, any expression
+`ε = p·A + q·B + ε^m·v` with `2 ≤ m` collapses to `ε ∈ (A,B)`: repeated
+`boost` grows `m` until `ε^m = 0`. Fuel `k` bounds `N - m`. -/
+theorem iterate_aux (ε A B : S) (N : ℕ) (hN : ε ^ N = 0) :
+    ∀ (k m : ℕ), 2 ≤ m → N ≤ m + k →
+      (∃ p q v : S, ε = p * A + q * B + ε ^ m * v) → ε ∈ Ideal.span {A, B} := by
+  intro k
+  induction k with
+  | zero =>
+    intro m _ hNmk h
+    obtain ⟨p, q, v, hpqv⟩ := h
+    have hεm : ε ^ m = 0 := by
+      obtain ⟨d, hd⟩ := Nat.exists_eq_add_of_le (show N ≤ m by omega)
+      rw [hd, pow_add, hN, zero_mul]
+    rw [hεm, zero_mul, add_zero] at hpqv
+    exact (Ideal.mem_span_pair).mpr ⟨p, q, hpqv.symm⟩
+  | succ k ih =>
+    intro m hm2 hNmk h
+    rcases Nat.lt_or_ge m N with hmN | hNm
+    · obtain ⟨j, rfl⟩ : ∃ j, m = j + 1 := ⟨m - 1, by omega⟩
+      exact ih (j + 1 + j) (by omega) (by omega) (boost ε A B j h)
+    · obtain ⟨p, q, v, hpqv⟩ := h
+      have hεm : ε ^ m = 0 := by
+        obtain ⟨d, hd⟩ := Nat.exists_eq_add_of_le hNm
+        rw [hd, pow_add, hN, zero_mul]
+      rw [hεm, zero_mul, add_zero] at hpqv
+      exact (Ideal.mem_span_pair).mpr ⟨p, q, hpqv.symm⟩
+
+/-- Convenience wrapper: `ε = p·A + q·B + ε^m·v` with `2 ≤ m` and `ε^N = 0`
+gives `ε ∈ (A,B)`. -/
+theorem iterate (ε A B : S) (N : ℕ) (hN : ε ^ N = 0) {m : ℕ} (hm : 2 ≤ m)
+    (h : ∃ p q v : S, ε = p * A + q * B + ε ^ m * v) :
+    ε ∈ Ideal.span {A, B} :=
+  iterate_aux ε A B N hN N m hm (by omega) h
+
+variable [CharP S 2]
+
+/-- **The descent step.** Given a membership witness `ε^t = f·A + g·B` at a
+level `1 ≤ t ≤ N-1` and deck-triviality, one deck application on the
+canonical cycle `ε^{N-t}·(f,g)` yields `ε = p·A + q·B + ε^{N-t}·v`. -/
+theorem descent (ε A B : S) (N : ℕ) (hN : ε ^ N = 0)
+    (hfree : EpsFree ε N) (hR : DeckTrivial ε A B)
+    {t : ℕ} (h1 : 1 ≤ t) (h2 : t ≤ N - 1)
+    {f g : S} (hfg : ε ^ t = f * A + g * B) :
+    ∃ p q v : S, ε = p * A + q * B + ε ^ (N - t) * v := by
+  set s := N - t with hs
+  have htN : t ≤ N := le_trans h2 (Nat.sub_le N 1)
+  have hst : s + t = N := Nat.sub_add_cancel htN
+  have hs1 : 1 ≤ s := by omega
+  have hsN : s ≤ N := by omega
+  have hNs : N - s = t := by omega
+  -- the canonical cycle `(ε^s f, ε^s g)`
+  have hcyc : A * (ε ^ s * f) + B * (ε ^ s * g) = 0 := by
+    have e : A * (ε ^ s * f) + B * (ε ^ s * g) = ε ^ s * (f * A + g * B) := by
+      ring
+    rw [e, ← hfg, ← pow_add, hst, hN]
+  obtain ⟨z, hz1, hz2⟩ := hR _ _ hcyc
+  -- `ε^t z = 0`
+  have hz0 : ε ^ t * z = 0 := by
+    have e : ε ^ t * z = f * (A * z) + g * (B * z) := by rw [hfg]; ring
+    rw [e, ← hz2, ← hz1]
+    have e2 : f * (ε * (ε ^ s * g)) + g * (ε * (ε ^ s * f))
+        = ε * ε ^ s * (f * g) + ε * ε ^ s * (f * g) := by ring
+    rw [e2, CharTwo.add_self_eq_zero]
+  -- divide `z` by `ε^s`
+  obtain ⟨u, hu⟩ := hfree t h1 htN z hz0
+  rw [← hs] at hu
+  -- `ε f = ε^t p + B u`
+  have h5f : ε ^ s * (ε * f + B * u) = 0 := by
+    have e : ε ^ s * (ε * f + B * u) = ε * (ε ^ s * f) + ε ^ s * (B * u) := by
+      ring
+    rw [e, hz1, hu]
+    have e2 : B * (ε ^ s * u) + ε ^ s * (B * u) = ε ^ s * (B * u) + ε ^ s * (B * u) := by
+      ring
+    rw [e2, CharTwo.add_self_eq_zero]
+  obtain ⟨p, hp⟩ := hfree s hs1 hsN _ h5f
+  rw [hNs] at hp
+  have hεf : ε * f = ε ^ t * p + B * u := by
+    have := eq_sub_of_add_eq hp; rwa [CharTwo.sub_eq_add] at this
+  -- `ε g = ε^t q + A u`
+  have h5g : ε ^ s * (ε * g + A * u) = 0 := by
+    have e : ε ^ s * (ε * g + A * u) = ε * (ε ^ s * g) + ε ^ s * (A * u) := by
+      ring
+    rw [e, hz2, hu]
+    have e2 : A * (ε ^ s * u) + ε ^ s * (A * u) = ε ^ s * (A * u) + ε ^ s * (A * u) := by
+      ring
+    rw [e2, CharTwo.add_self_eq_zero]
+  obtain ⟨q, hq⟩ := hfree s hs1 hsN _ h5g
+  rw [hNs] at hq
+  have hεg : ε * g = ε ^ t * q + A * u := by
+    have := eq_sub_of_add_eq hq; rwa [CharTwo.sub_eq_add] at this
+  -- `ε^{t+1} = ε^t (p A + q B)`
+  have h7 : ε ^ t * ε = ε ^ t * (p * A + q * B) := by
+    have lhs : ε ^ t * ε = ε * (f * A + g * B) := by rw [← hfg]; ring
+    rw [lhs]
+    have e : ε * (f * A + g * B) = ε * f * A + ε * g * B := by ring
+    rw [e, hεf, hεg]
+    have e2 : (ε ^ t * p + B * u) * A + (ε ^ t * q + A * u) * B
+        = ε ^ t * (p * A + q * B) + (A * B * u + A * B * u) := by ring
+    rw [e2, CharTwo.add_self_eq_zero, add_zero]
+  -- `ε + (p A + q B) ∈ ann(ε^t) = ε^s S`
+  have h8 : ε ^ t * (ε + (p * A + q * B)) = 0 := by
+    have e : ε ^ t * (ε + (p * A + q * B)) = ε ^ t * ε + ε ^ t * (p * A + q * B) := by
+      ring
+    rw [e, h7, CharTwo.add_self_eq_zero]
+  obtain ⟨v, hv⟩ := hfree t h1 htN _ h8
+  rw [← hs] at hv
+  refine ⟨p, q, v, ?_⟩
+  have := eq_sub_of_add_eq hv
+  rw [CharTwo.sub_eq_add] at this
+  linear_combination this
+
+/-- **A13, the hard direction (⟹).** For a free `ℤ_{2^r}` doubling cover
+(`ε = 1 + σ`, deck order `N`, `ε^N = 0`, `EpsFree`), deck-triviality on `H₁`
+forces the Bezout membership `ε ∈ (A, B)`. The entry `ε^m ∈ (A,B)` with
+`2 ≤ m ≤ N-2` is A12 applied to the top `ℤ₂`-step (`m = 2^{r-1}`; needs
+`r ≥ 2`, i.e. `N ≥ 4`). Combined with `deckTrivial_of_bezout` (the ⟸) this
+gives **deck-trivial ⟺ `ε ∈ (A,B)` ⟺ k constant along the tower**. -/
+theorem eps_mem_of_deckTrivial (ε A B : S) (N : ℕ) (hN : ε ^ N = 0)
+    (hfree : EpsFree ε N) (hR : DeckTrivial ε A B)
+    {m : ℕ} (hm2 : 2 ≤ m) (hmN : m ≤ N - 2)
+    (hentry : ε ^ m ∈ Ideal.span {A, B}) :
+    ε ∈ Ideal.span {A, B} := by
+  obtain ⟨f, g, hfg⟩ := (Ideal.mem_span_pair).mp hentry
+  have hd := descent ε A B N hN hfree hR (show 1 ≤ m by omega)
+    (show m ≤ N - 1 by omega) hfg.symm
+  exact iterate ε A B N hN (m := N - m) (by omega) hd
+
+end BBDeckTower
+end Homological
+end Stabilizer
+end Quantum

--- a/experiments/bb_lab/notes/A12_deck_homotopy_R.md
+++ b/experiments/bb_lab/notes/A12_deck_homotopy_R.md
@@ -335,6 +335,13 @@ verbatim) ⟹ deck acts trivially (Koszul annihilation, same two lines). And
 becomes a Bockstein spectral sequence; the A12 inequality should be its
 first-page shadow. A clean statement here ("deck trivial ⟺ k constant
 along the tower") is the theorem the family paper wants.
+*Status (2026-07-02):* promoted to fork **A13** — plan in
+[`A13_deck_tower_plan.md`](A13_deck_tower_plan.md). Headlines there:
+"deck trivial at *every* level ⟺ k constant" is already a theorem
+(stepwise A12 + counting), the gross x-ladder is certified uniformly in
+`r` by the level-free witness `(1+x²)B² = 1+x⁶`, and Q(r) itself is
+compressed (planning-grade) to the vanishing of one divided class
+`ε̄φ ∈ H₁(S/ε^{t*})` at the critical level `t* = min{t : ε^t ∈ (A,B)}`.
 
 **OQ2 — The Bockstein equality (mathematical core).** Is
 `dim (1+σ)H₁ = k̃ − k` always? Equivalent forms: `δ₁∘δ₂ = 0`;

--- a/experiments/bb_lab/notes/A12_deck_homotopy_R.md
+++ b/experiments/bb_lab/notes/A12_deck_homotopy_R.md
@@ -335,13 +335,19 @@ verbatim) ⟹ deck acts trivially (Koszul annihilation, same two lines). And
 becomes a Bockstein spectral sequence; the A12 inequality should be its
 first-page shadow. A clean statement here ("deck trivial ⟺ k constant
 along the tower") is the theorem the family paper wants.
-*Status (2026-07-02):* promoted to fork **A13** — plan in
-[`A13_deck_tower_plan.md`](A13_deck_tower_plan.md). Headlines there:
-"deck trivial at *every* level ⟺ k constant" is already a theorem
-(stepwise A12 + counting), the gross x-ladder is certified uniformly in
-`r` by the level-free witness `(1+x²)B² = 1+x⁶`, and Q(r) itself is
-compressed (planning-grade) to the vanishing of one divided class
-`ε̄φ ∈ H₁(S/ε^{t*})` at the critical level `t* = min{t : ε^t ∈ (A,B)}`.
+*Status (2026-07-02): **RESOLVED — YES**, fork **A13**
+([`A13_deck_tower_plan.md`](A13_deck_tower_plan.md) §0★).* `σ_* = id` on
+`H₁(top)` **does** force `k(top) = k(base)` for every free `ℤ_{2^r}` tower
+(`r ≥ 2`; `r = 1` is this note). Proof: A12 on the top `ℤ₂`-step gives the
+entry `ε^{N/2} ∈ (A,B)`, then a **descent** — apply (R) to the canonical
+cycle `ε^{N-t}(f,g)`; the boundary coefficient `z` satisfies `ε^t z = 0`,
+so ε-freeness divides it (`z = ε^{N-t}u`), yielding
+`ε ∈ (A,B) + ε^{N-t}S` — plus a ring-algebra iteration eliminating the
+tail. Simpler than the planned route: no spectral sequence, no `Ob`-class,
+no induction on `r`. The core descent is Lean-formalized axiom-clean
+(`BBDeckTower.lean`, `eps_mem_of_deckTrivial`); screens exhaustive to deck
+order 8. The compressed "divided class `ε̄φ`" picture (planning-grade
+below) was correct but unnecessary — the direct descent bypasses it.
 
 **OQ2 — The Bockstein equality (mathematical core).** Is
 `dim (1+σ)H₁ = k̃ − k` always? Equivalent forms: `δ₁∘δ₂ = 0`;

--- a/experiments/bb_lab/notes/A13_deck_tower_plan.md
+++ b/experiments/bb_lab/notes/A13_deck_tower_plan.md
@@ -1,11 +1,94 @@
-# A13 — Deck-trivial ⟺ k constant along ℤ_{2^r} doubling towers (OQ1) — PLAN
+# A13 — Deck-trivial ⟺ k constant along ℤ_{2^r} doubling towers (OQ1)
 
-**Status: OPENED — plan only (2026-07-02). No result is claimed in this
-note; §3's derivations are planning-grade and their adversarial
-verification is work item W1.**
+**Status: RESOLVED — YES (2026-07-02).** `σ_* = id` on `H₁(top)` forces
+`k(top) = k(base)` for every free `ℤ_{2^r}` doubling tower (`r ≥ 2`; `r = 1`
+is A12). The hard direction is a completed elementary proof (§0★), its core
+descent is **formalized in Lean, axiom-clean** (`eps_mem_of_deckTrivial` in
+`QEC/Stabilizer/Framework/Homological/BBDeckTower.lean`), and the statement
++ mechanism + every intermediate identity pass exhaustive/sampled screens
+(§0★). The clean family statement **deck-trivial ⟺ k constant along the
+tower** now holds.
 Branch: `claude/a13-deck-trivial-tower` (off PR #53 head).
 Predecessor: [`A12_deck_homotopy_R.md`](A12_deck_homotopy_R.md) — this is
-its §8 **OQ1**, promoted to its own fork.
+its §8 **OQ1**, promoted to its own fork. The plan below (§1–§8) is retained
+as written; §0★ records the resolution.
+
+## 0★. Resolution (2026-07-02)
+
+**Theorem A13 (Q(r), answered).** For a free `ℤ_{2^r}` BB cover
+(`ε = 1+σ`, deck order `N = 2^r`, `ε^N = 0`, `S = 𝔽₂[G]` free over
+`Λ = 𝔽₂[⟨σ⟩]`), the following are equivalent:
+`σ_* = id` on `H₁(top)`  ⟺  `ε ∈ (A,B)`  ⟺  `k(top) = k(base)`  ⟺  the
+whole deck acts trivially at every level of the tower.
+
+**The proof that closed it (the §3 gap, filled).** Running the S3/S7
+mechanism forced the missing step. Under (R_r): A12 on the top `ℤ₂`-step
+gives the entry `ε^{N/2} ∈ (A,B)` (`(σ^{N/2})_* = (σ_*)^{N/2} = id`). Then
+the **descent** — apply (R_r) to the *canonical cycle* `ε^{N-t}(f,g)` where
+`ε^t = fA+gB`:
+
+1. the returned boundary coefficient `z` satisfies `ε^t z = 0` (two-line
+   char-2 cancellation using the witness), **so `EpsFree` divides it:
+   `z = ε^{N-t}u`** — this is the step §3 was missing;
+2. back-substitution gives `εf = ε^t p + Bu`, `εg = ε^t q + Au`, hence
+   `ε^{t+1} = ε^t(pA+qB)`, so `ε^t(ε + pA + qB) = 0`;
+3. `EpsFree` again: `ε = pA + qB + ε^{N-t}v`, i.e. `ε ∈ (A,B) + ε^{N-t}S`.
+
+Entry `t = N/2` (needs `N ≥ 4`, `r ≥ 2`) feeds the **iteration**: `boost`
+grows the tail exponent (`ε ∈ (A,B) + ε^m S ⟹ ∈ (A,B) + ε^{2m-1}S`, pure
+ring algebra) until it passes `N` and `ε^m = 0`, leaving `ε ∈ (A,B)`. ∎
+
+This subsumes the planning-grade R2–R5 (§3) and is *stronger and simpler*:
+no spectral sequence, no `Ob`-class bookkeeping, no induction on `r` — one
+deck application on one cycle, then a ring-algebra iteration. R3/R6/(★) are
+now corollaries or unused; the Bockstein-SS frame (Attack A) and Frobenius
+pairing (Attack B) were not needed.
+
+**Lean (public-side, axiom-clean).**
+`QEC/Stabilizer/Framework/Homological/BBDeckTower.lean` (builds in 1.4 s,
+axioms = `propext, Classical.choice, Quot.sound` only). Contents:
+- `EpsFree ε N`, `DeckTrivial ε A B` — the two geometric inputs as abstract
+  char-2-ring predicates (see the file header for the `𝔽₂[G]` model);
+- `descent` — steps 1–3 above (axioms `propext, Quot.sound`);
+- `boost`, `iterate_aux`, `iterate` — the tail-elimination (char-independent);
+- `eps_mem_of_deckTrivial` — the headline ⟹, entry `ε^m ∈ (A,B)` (`2 ≤ m ≤
+  N-2`) taken as hypothesis (= A12 top-step).
+Pairs with the existing `BB.deckTrivial_of_bezout` (the ⟸) to give the full
+iff at the ring level.
+
+**Scope / what is NOT yet formalized (honest).** The Lean theorem is the
+*ring-theoretic core*. Two bridges remain paper-level: (i) `DeckTrivial` and
+`EpsFree` are the abstract predicates, not yet derived from the concrete
+`bbChainComplex` deck action and `𝔽₂[G]`-freeness (freeness over the
+subgroup algebra `𝔽₂[⟨σ⟩]`); (ii) the entry `ε^m ∈ (A,B)` is imported as
+A12's top-step result rather than re-proved. Both are the same
+`H₁`-dictionary work flagged as plan item L1 (a genuine formalization
+project); neither is a mathematical gap. `k(top)=k(base) ⟺ ε∈(A,B)` is the
+counting lemma (A12 Lemma 0/1), paper-level here.
+
+**Screens (refutation-first, all clean).**
+- [`a13_deck_tower_block_sweep.py`](../scripts/a13_deck_tower_block_sweep.py):
+  the endpoint `(R) ⟺ ε∈(A,B)` (S1), the canonical-violator mechanism (S3),
+  divided-class liveness (S7), A12 top-step regression (S4), and the R3/S6/S8
+  structural identities — **exhaustive** on `𝔽₂[Z₄]`, `𝔽₂[Z₈]` (`N=4,8`),
+  `𝔽₄[Z₄]`, `𝔽₂[Z₄×Z₂]` (both deck classes); **sampled** (uniform + a
+  targeted `ε²∈I` stratum) on `𝔽₂[Z₈×Z₂]`, `𝔽₂[Z₄×Z₄]`, `𝔽₄[Z₄×Z₂]`.
+  Zero S1 mismatches anywhere; S3/S7 fire on every `2≤t*≤N-2` pair.
+- [`a13_gross_ladder.py`](../scripts/a13_gross_ladder.py): the gross x-tower
+  `Z_{6·2^j}×Z₆`, `j=0..3` (up to `[[576,12,·]]`) — `k≡12` and full
+  deck-triviality at every level from the single level-free witness
+  `(1+x²)B² = 1+x⁶` (**T3/P0 confirmed**); plus the full battery on genuine
+  weight-3 `Z₁₂×Z₃` cover pairs (0 mismatches, S3/S7/S4 firing).
+  `𝔽₈` blocks remain out of scope (same residual as the A12 sweep).
+
+**Implications for the family paper.** Template condition 2 is now a clean
+equivalence at every tower level, not a per-instance certificate hunt: it
+*is* the k-check. The k-row of the tour-de-gross family is a theorem (T1–T3
++ A13). What A13 does **not** touch — and where growing distance must come
+from — is the value-carrying safe floor (condition 3); see the caveats in
+the parent conversation (BT cross-section cap on the pure x-tower;
+growing-`d` needs the 2D/twisted route, where each free-`ℤ₂` sub-step reuses
+this same equivalence).
 
 ## 0. The question, and what is already a theorem
 

--- a/experiments/bb_lab/notes/A13_deck_tower_plan.md
+++ b/experiments/bb_lab/notes/A13_deck_tower_plan.md
@@ -1,0 +1,316 @@
+# A13 — Deck-trivial ⟺ k constant along ℤ_{2^r} doubling towers (OQ1) — PLAN
+
+**Status: OPENED — plan only (2026-07-02). No result is claimed in this
+note; §3's derivations are planning-grade and their adversarial
+verification is work item W1.**
+Branch: `claude/a13-deck-trivial-tower` (off PR #53 head).
+Predecessor: [`A12_deck_homotopy_R.md`](A12_deck_homotopy_R.md) — this is
+its §8 **OQ1**, promoted to its own fork.
+
+## 0. The question, and what is already a theorem
+
+For a free `Z_{2^r}` BB cover tower `G_r → G_{r-1} → ⋯ → G_0` (iterated
+x-doubling, same polynomials `A, B` at every level — the tour-de-gross
+family route), with `σ = ·x^ℓ` generating the full deck `Δ ≅ Z_{2^r}`:
+
+> **Q(r).** Does `σ_* = id` on `H₁(top)` force `k(top) = k(base)`?
+
+`Q(1)` is Theorem A12. The target statement for the family paper is
+"deck trivial ⟺ k constant along the tower".
+
+**Theorem inventory — what needs no new mathematics** (write-up items
+only; each is a short corollary of A12 + the counting lemma):
+
+- **T1 (counting along the tower).** `k_j = 2·dim S/((A,B) + (ε^{2^j}))`
+  (Lemma 0 of A12 at each level), and the ideals `(ε^{2^j})` shrink as
+  `j` grows, so `k_0 ≤ k_1 ≤ ⋯ ≤ k_r`: *k is monotone up the tower*, and
+  "k constant along the tower" ⟺ the single equality `k_r = k_0` ⟺
+  `ε ∈ (A,B)` (counting lemma with `I_Δ = (ε)`; `I_Δ` is principal for
+  cyclic decks).
+- **T2 (per-level deck-triviality ⟺ k constant).** "`σ̄_* = id` on
+  `H₁(S_j)` for **every** level `j`" ⟺ `k` constant. ⟸: membership +
+  Koszul annihilation at each level. ⟹: each consecutive pair
+  `S_{j+1}/S_j` is a free ℤ₂ BB cover whose deck generator is a power of
+  `σ̄`, so Theorem A12 applies stepwise and `k_{j+1} = k_j` for all `j`.
+  **So the entire content of Q(r) is weakening "every level" to "top
+  level only".**
+- **T3 (the gross tower is certified uniformly in r — see §4).**
+
+**The precise gap** (OQ1's phrasing): does `σ_* = id` upstairs force the
+induced `σ̄_* = id` on `H₁(mid)`? Not obvious — `p_*` need not be
+surjective. §3 turns this into the vanishing of one canonical class.
+
+## 1. Notation (fixed for the whole fork)
+
+- `G_j = Z_{2^j ℓ} × Z_m`, `S_j = F₂[G_j]`; `S := S_r` (top), base `S_0`.
+  Everything is stated for x-towers; the y-axis case is the transpose.
+- `σ = ·x^ℓ ∈ S`, `ε = 1 + σ`. Char-2 Frobenius: `1 + σ^{2^j} = ε^{2^j}`.
+  Hence `S_j ≅ S/ε^{2^j}S`, and the deck of `S` over `S_j` is
+  `⟨σ^{2^j}⟩ ≅ Z_{2^{r-j}}` with augmentation ideal `(ε^{2^j})`.
+- `Λ = F₂[Δ] = F₂[ε]/(ε^{2^r})` — local chain ring; `S` is **Λ-free**
+  (group algebra over a subgroup algebra), so `Ann_S(ε^t) = ε^{2^r-t}S`.
+- `K = K(A,B;S)`: the Koszul/BB complex `S →^{(B,A)} S² →^{(A,B)} S`
+  (A12 §1 conventions). `k_j = dim H₁(A,B;S_j) = 2·dim S_j/(A,B)`.
+- **(R_r)**: `σ_* = id` on `H₁(top)` ⟺ `ε·H₁(A,B;S) = 0` (char 2:
+  `σ_* − id` acts as multiplication by `ε`).
+- `t* := min { t ≥ 0 : ε^t ∈ (A,B) ⊆ S }` — the **critical level**.
+  `Q(r)`'s conclusion ⟺ `t* ≤ 1`.
+
+## 2. Imported facts (provenance: A12, verbatim or with `I_Δ` swapped)
+
+- **K1 (counting, any finite abelian deck).** `k(top) − k(base) =
+  2·dim (I_Δ + (A,B))/(A,B) ≥ 0`, equality iff `I_Δ ⊆ (A,B)`. [A12
+  Lemma 0 + Lemma 1; OQ1 "Known" block.]
+- **K2 (Koszul annihilation).** `(A,B)` annihilates `H_*(K)`; so
+  membership ⟹ deck-trivial, at every level, on `H₁` and (via the
+  antipode, which sends `ε` to the unit multiple `σ⁻¹ε`) on `H¹`.
+- **K3 (Theorem A12, per step).** For every free ℤ₂ BB cover:
+  (R) ⟺ `k̃ = k` ⟺ deck-poly membership, with a constructive
+  certificate (`deckTrivial_of_bezout`).
+- **K4 (CRT blocks).** `S = ⊕_χ T_χ`, `T_χ = F_{2^d}[P]`, `P` = 2-part
+  of `G_r` — local Frobenius, σ-stable, Λ-free. (R_r), memberships,
+  `H₁`, and everything in §3 decompose block-wise. `P` is cyclic ⟺ the
+  undoubled coordinate `m` is odd.
+
+## 3. Planning-grade derivations (W1: verify adversarially, then promote)
+
+Derived at planning time (2026-07-02); each looks elementary but none is
+checked beyond hand-derivation. **W1 = re-derive on paper, then
+machine-check R3/R4/R5 shapes inside the §5 screens before anything
+leans on them.**
+
+- **R2 (top step).** (R_r) ⟹ `(σ^{2^{r-1}})_* = id` ⟹ [K3 on the top
+  ℤ₂-step, whose deck poly is `1 + x^{2^{r-1}ℓ} = ε^{2^{r-1}} =: μ`]
+  `k_r = k_{r-1}` and `μ = fA + gB` for some `f, g ∈ S`. In particular
+  `t* ≤ 2^{r-1}`.
+- **R3 (divided class generates coker p_*).** Let `t ≥ 1` with
+  `ε^t = fA + gB`, and `S/ε^t` the level-`t` quotient (a group algebra
+  iff `t` is a power of 2 — R3 does not care). Then
+  `φ := [(f̄, ḡ)] ∈ H₁(A,B; S/ε^t)` is a cycle class, and **every**
+  1-cycle `y` over `S/ε^t` satisfies `y = p(z) + c̄·(f̄,ḡ)` for a top
+  cycle `z`: lift `y`, write `y₁A + y₂B = ε^t c = c(fA+gB)`, and
+  `z := (y₁+cf, y₂+cg)` is an honest cycle over `S`. So
+  `H₁(S/ε^t) = p_*H₁(S) + (S/ε^t)·φ` — **coker p_* is cyclic, generated
+  by the divided class**. (Needs only the membership witness, not (R_r).)
+- **R4 (one obstruction class).** Under (R_r):
+  `ε̄·p_*H₁(S) = p_*(ε·H₁(S)) = 0`, so by R3
+  `ε̄·H₁(S/ε^t) = (S/ε^t)·(ε̄φ)`. Hence deck-triviality one level down
+  is the vanishing of the single class `Ob_t := ε̄φ = [ε(f,g) mod ε^t]`.
+  Witness-independence under (R_r): two witnesses differ by a top cycle
+  `w`, and `ε̄(φ − φ′) = p_*(ε[w]) = 0`. Element form (Massey-style,
+  parallel to OQ2's): `Ob_t = 0` ⟺ ∃`s`: `εf ≡ sB` and `εg ≡ sA`
+  (mod `ε^t S`).
+- **R5 (liveness bootstrap — unconditional).** Suppose
+  `ε^t = fA + gB` with `2 ≤ t ≤ 2^r − 2` and `Ob_t = 0` for **some**
+  witness: `εf = sB + ε^t h₁`, `εg = sA + ε^t h₂`. Then
+  `ε^{t+1} = (εf)A + (εg)B = ε^t(h₁A + h₂B)` (the `s`-terms cancel), so
+  `ε^t(ε + h₁A + h₂B) = 0`, and Λ-freeness gives
+  `ε = h₁A + h₂B + ε^q w` with `q = 2^r − t ≥ 2`. Iterating the
+  congruence `ε ≡ ε^q w (mod (A,B))` gives
+  `ε ≡ ε^{1+k(q-1)} w^k → 0`, i.e. **`ε ∈ (A,B)`**. Contrapositive
+  (the useful reading): **if `t* ≥ 2`, then `ε̄φ ≠ 0` at level `t*`,
+  for every witness — the divided class is ε-alive at the critical
+  level unless the tower is already trivial.** (Note: no (R_r), no
+  induction on r, no spectral sequence.)
+- **(★) The compressed question.** Combining R3–R5: under (R_r),
+  `ε̄H₁(A,B; S/ε^{t*}) = span(ε̄φ)`, which is nonzero iff `t* ≥ 2`. So
+
+  > **Q(r) ⟺ [(R_r) forces `ε̄·H₁(A,B; S/ε^{t*}S) = 0`]** — does
+  > deck-triviality upstairs descend to the critical level?
+
+  This is exactly OQ1's "precise gap", with `mid` sharpened to the
+  critical level and the failure locus compressed to one canonical
+  class. A counterexample must exhibit (R_r) together with `t* ≥ 2`
+  (equivalently `Ob_{t*} ≠ 0`); by K1 it then automatically has
+  `k_r > k_0`. Conversely a proof only ever needs to kill `ε̄φ`.
+- **R6 (chain blocks are done — modulo write-up).** On a block
+  `T = F_q[P]` with `P` cyclic: `T ≅ F_q[t]/(t^N)` (separable odd part),
+  Λ-freeness pins `v(ε) = N/2^r` (rank count: `dim εT = rank·(2^r−1)`),
+  and every element is `unit·t^v`. With `a = v(A) ≤ b = v(B)` (∞ for 0):
+  `dim H₁ = 2a`, and the generating cycle `(t^{b-a}, 1)` has
+  `ε·(t^{b-a},1) ∈ B₁ ⟺ a ≤ v(ε) ⟺ ε ∈ (A,B)`. Degenerate strata
+  agree (dead block `A=B=0`: `H₁ = T²`, ε acts nontrivially, (R_r)
+  fails; unit block: `H₁ = 0`, membership trivial). **So Q(r) holds for
+  every r on chain blocks; by K4, Q(r) holds outright whenever the
+  undoubled coordinate is odd.** This is the same finite
+  `(val A, val B, N)` case lemma A12's OQ2 wants — one write-up serves
+  both. The hard core is non-cyclic `P` (gross family: `m = 6`), i.e.
+  blocks `F_q[t,u]`-type with a second nilpotent direction.
+
+## 4. P0 — the gross tower is certified today (instance payoff)
+
+The gross witness is **level-free**: with `B = y³ + x + x²`,
+
+```
+(1 + x²)·B² = (1+x²)(y⁶ + x² + x⁴) = (1+x²)(1 + x² + x⁴) = 1 + x⁶
+```
+
+is an identity in `F₂[x,y]/(y⁶−1)` — it uses only `y⁶ = 1` and char 2,
+never the x-order. At every gross-tower level `G_j = Z_{6·2^j} × Z₆`
+the deck of level `j` over the `[[72,12,6]]` base is `⟨x⁶⟩ ≅ Z_{2^j}`
+with `I_Δ = (1+x⁶)`, so `1+x⁶ ∈ (B) ⊆ (A,B)` **uniformly in j**. By K1
++ K2:
+
+> **T3.** Along the whole tour-de-gross x-ladder, `k ≡ 12` and the full
+> deck acts trivially on every `H₁(level j)` — one witness, every `r`.
+
+(Consistency: level 2 is the known `[[288,12,18]]` — `k = 12` ✓. The
+witness is R0-shaped — principal in `(B)` — matching A12 §6b.)
+Consequence for sequencing: **the family paper's k-row does not wait on
+Q(r)**; Q(r) upgrades the mechanism from per-instance certificates to a
+clean equivalence. P0 also pins what a Lean certificate looks like (§6).
+
+## 5. Attacks
+
+### Attack A — Bockstein spectral sequence (the conceptual frame)
+
+The ε-adic filtration `K ⊇ εK ⊇ ⋯ ⊇ ε^{2^r-1}K ⊇ 0` has length `2^r`;
+Λ-freeness makes every graded piece the base complex, `E₁ = ⊕_{i<2^r}
+H_*(base)`, and `d₁` is A12's connecting map δ — A12's inequality is
+the first-page shadow, as OQ1 predicted. But R3–R5 show the *working*
+route is elementary: the only higher-page content Q(r) needs is the
+single class `ε̄φ`, whose page-climb is the gap between the relations
+(R_r) provides at filtration `2^{r-1}+1` — e.g. on the auxiliary top
+cycles `μs·(f,g)` (cycles since `μ² = 0`) — and the target congruence at
+filtration 1 mod `ε^{t*}`. Work items: (a) set the SS up carefully once
+(finite, multiplicative, degenerate cases); (b) express `Ob` and the
+(R_r)-relations in page terms and look for the forcing pattern; (c) keep
+the OQ2 composite `δ₁δ₂` in view — same toolbox, and any structure
+proved here (e.g. self-duality constraints on the pages) feeds OQ2.
+
+### Attack B — Frobenius duality / the perfect pairing (shortest path if
+it works)
+
+`K` is a self-dual DG algebra over the Frobenius `S`: expected perfect
+pairing `⟨z, w⟩ = λ(z₁w₂ + z₂w₁)` on `H₁` (multiplication to `H₂ =
+Ann(A,B)·e₁e₂`, then the Frobenius form λ), with ε self-adjoint.
+[Verify or source the perfectness — Gorenstein duality for Koszul
+homology; CHKV "annihilators of Koszul homology" is the adjacent
+literature per A12 §4.] Then:
+
+- membership target: `ε ∈ (A,B) ⟺ λ(ε·Ann(A,B)) = 0` (Frobenius
+  ann-duality);
+- hypothesis: (R_r) ⟺ `λ(ε(z₁w₂ + z₂w₁)) = 0` for **all** cycle pairs;
+- candidate cycles to feed in: `v·(f,g)` for `v ∈ Ann(A,B)` (cycles
+  since `vμ = 0`), the auxiliary `μs·(f,g)`, and Frobenius-square cycles
+  `(C,0)` when `A = C²` (the A8-counterexample mechanism — likely where
+  a counterexample hides if one exists).
+- **Known trap (found at planning time):** pairing `ε·v(f,g)` against a
+  generic cycle `y` and substituting `εy = s_y(B,A)` collapses to
+  `λ(v·s_y·μ) = 0` automatically — that pairing route detects nothing.
+  The needed identity must pair the coker-`p_*` direction against
+  something *not* in the ε-image. Concrete sub-task: on the §5C screens,
+  compute Gram matrices of the pairing on `H₁(S/ε^{t*})` and locate
+  which classes detect `λ(εv) ≠ 0`; reverse-engineer the identity from
+  the data.
+
+### Attack C — screens (refutation-first; lab discipline: exhaustive
+where possible, sampling only with an exact confirmatory follow-up)
+
+Extend `a12_bockstein_block_sweep.py` / `a12_deck_r_survey.py` to deck
+order `2^r ≥ 4`. For every pair record: `t*`, memberships `ε, ε², μ`,
+`εH₁ =? 0` (full (R_r), not just the top-step generator), witness
+`(f,g)`, `Ob` at levels `t*` and `2^{r-1}`, the k-profile `k_0 … k_r`,
+and pairing diagnostics.
+
+- **C0 (verify §3 before trusting it).** On every swept pair with
+  `μ ∈ (A,B)`: machine-check R3 (`H₁(S/ε^t) = p_*H₁ + span φ`), R4
+  (`ε̄H₁ = span ε̄φ` under (R_r)), R5 (no pair with `t* ≥ 2` and
+  `Ob_{t*} = 0`). Any violation = a bug in §3, found cheap.
+- **C1 (exhaustive blocks, r = 2).** `F₂[Z₄]`, `F₂[Z₈]`, `F₄[Z₄]`
+  (chain controls for R6 — expect zero hits); **`F₂[Z₄×Z₂]`** (first
+  hard block, 65,536 pairs, all order-4 decks `s` up to automorphism).
+  Next tier (`|T| = 2^16`: `F₂[Z₈×Z₂]` r∈{2,3}, `F₂[Z₄×Z₄]`,
+  `F₄[Z₄×Z₂]`, `F₈[Z₄]`): unit-normalized + translation-orbit
+  exhaustive if feasible, else stratified by ideal type + heavy
+  sampling — **log coverage honestly, no silent caps.** A hit =
+  `(R_r) ∧ t* ≥ 2` = counterexample to Q(2); then check
+  block-realizability in an actual weight-constrained BB cover pair
+  (A12 CE machinery) and against the canonical-lift convention.
+- **C2 (cover-level, r = 2, weight-3, canonical lifts).** Small grid
+  mirroring `a12_weight3_class_sweep`: `Z₁₂×Z₃` (tower over `Z₃×Z₃`),
+  `Z₁₂×Z₆` (tower over `Z₃×Z₆`), `Z₈×Z₂`, `Z₈×Z₆`, `Z₂₄×Z₃`; strict-IBM
+  stratum flagged. Failure geography: how often does (R_r) fail vs
+  `Ob ≠ 0` under partial hypotheses — maps where the theorem could
+  break.
+- **C3 (the real ladders).** Gross x-tower `j = 0..3` (up to
+  `Z₄₈×Z₆`, 576 qubits — rank computations only): verify P0
+  numerically end-to-end. The six anchorable Z₆×Z₆ classes × both axes
+  (A11): extract per-level witnesses, test whether each has a
+  **level-free witness** like P0 (conjecture: yes on engine frames,
+  R0-shaped). Uniform witnesses found here go straight into §6's Lean
+  targets and the paper's instance table.
+
+## 6. Lean staging (public-side payoff)
+
+In order; (i)–(ii) are unconditional on Q(r)'s fate:
+
+- **L0 (gross-tower certificates).** Fixed small `r`: the witness
+  identity `(1+x²)·B² = 1+x⁶` at level `r` is a finite kernel-`decide`
+  identity (pair72 precedent: 36-point `pPoly_bezout`; level 2 = 144
+  points). Route deck-triviality per level through the existing
+  `deckTrivial_of_bezout` / `deckTrivial_of_homotopy_certificate`
+  (`Framework/Homological/BBDoubling.lean`) — each tower level is an
+  `XDoubleCoverData` instance over the previous one, so **no new deck
+  machinery is needed for iterated statements**.
+- **L1 (T1/T2 write-ups).** Paper-level first; the Lean form of the
+  counting lemma (`membership ⟺ k̃ = k`, finite linear algebra) is
+  A12's noted target (i) and would make T2 formal via stepwise
+  composition. Genuine but bounded project; schedule after M4.
+- **L2 (descent lemma R3, chain level).** Constructive, no homology
+  quotients: "given a witness and a mid 1-cycle, produce the top cycle
+  and coefficient" — a good parametric lemma over `XDoubleCoverData` +
+  witness hypotheses, matching the layer's chain-function style.
+- **L3 (outcome-dependent).** If Q(r) is proven: the liveness bootstrap
+  R5 is first-order ring algebra (`Ann_S(ε^t) = ε^{2^r−t}S` + a finite
+  congruence iteration) — surprisingly Lean-friendly. If refuted: the
+  counterexample block as a `decide`-checked anti-instance, A10-style.
+
+## 7. Milestones, sequencing, kill criteria
+
+- **M0** (this session): plan committed; A12 §8 OQ1 gets a pointer.
+- **M1 = W1** (first work session, ~half day): adversarially verify
+  R2–R6 on paper; promote §3 to theorem-grade prose in this note or
+  demote what breaks. Includes the two soft spots: the A12-on-top-step
+  application (free ℤ₂ BB cover with the *same* `A,B`, base = level
+  `r−1` — check A12's hypotheses list verbatim) and the Λ-freeness
+  annihilator fact.
+- **M2** (~1 day): C0 + C1 core + C3 gross ladder. Decisive either way.
+- **M3** (branch point): hit ⟹ counterexample write-up + salvage
+  statement for the paper (T1 + T2 + T3 stand regardless; state Q(r) as
+  answered-negative with the failure stratum). No hit ⟹ M4.
+- **M4** (≤ 2 focused sessions — hard kill criterion): prove `(★)`.
+  Attack B first (one identity away if the pairing is perfect), Attack
+  A as fallback bookkeeping. If neither closes: **park** — record the
+  Ob-formalism as the sharpest known reduction in A12 §8/OQ1, ship
+  T1/T2/T3 for the paper, demote Q(r) to a stated open problem. Do not
+  let the general question block the family write-up.
+- **M5**: Lean L0 (+L2 if M4 succeeded); L1 as capacity allows.
+- **M6**: research_log entry (result-grade only), A12 §8 status update,
+  `gross-distance-extensibility.md` fold-in, paper text for
+  T1/T2/T3 (+T4 if it exists).
+
+## 8. Risks / notes
+
+- **Lift convention.** (R) is lift-sensitive (A12 §2). The tower uses
+  the canonical same-polynomial lift at every level — state this in
+  every external claim; C2 flags non-canonical strata separately.
+- **Hypothesis strength.** (R_r) is triviality of the *full-deck
+  generator* upstairs. The weaker "top-step generator only"
+  (`(σ^{2^{r-1}})_* = id`) gives R2 but not R4's
+  `ε̄·p_* = 0` — don't conflate them in statements or screens.
+- **X vs Z side.** All statements transpose via the antipode
+  (`ε ↦ σ⁻¹ε`, a unit multiple), so memberships and (R) agree on `H₁`
+  and `H¹`; one side suffices. Verify once in C0.
+- **Mixed towers.** The IBM family also moves the y-coordinate
+  (`d = 6(2r+b−1)` bookkeeping). K1/T1 cover any finite abelian deck;
+  the Ob-machinery is cyclic-2-specific. Scope A13 to the pure
+  x-doubling axis; note the abelian-product generalization as a
+  follow-up only if the paper needs it.
+- **OQ2 synergy.** C1 doubles as OQ2's "cheapest falsification path"
+  (the `g > 0` strata of `Z₈×Z₂`/`Z₄×Z₄` blocks, now swept at deck
+  order 4 too); R6's chain-block lemma is OQ2's wanted case lemma. Keep
+  the two ledgers separate but share the harness.
+- **Public/private split.** This note is lab-side (slated private);
+  T1–T3 statements, the Lean layer additions, and the extensibility-doc
+  updates are public-side.

--- a/experiments/bb_lab/scripts/a13_deck_tower_block_sweep.py
+++ b/experiments/bb_lab/scripts/a13_deck_tower_block_sweep.py
@@ -1,0 +1,473 @@
+"""A13 screens: deck-trivial <=> k-constant along Z_{2^r} doubling towers.
+
+Adversarial verification of the (draft) Theorem A13 and of every internal
+step of its proof, at the CRT-block level. Blocks T = S[P] (S = F_{2^d},
+P = 2-part of the tower-top group) with a deck element s in P of order
+N = 2^r >= 4, eps = 1 + s, so T is free over F2[eps]/(eps^N) and
+Ann(eps^j) = eps^(N-j) T.
+
+Per pair (A, B) in T^2 the script checks, with I = (A,B):
+
+  S1  (R) <=> eps in I            [(R) = eps * H1 = 0; the A13 endpoint]
+  S2  k-profile k_j = 2 dim T/(I + eps^{2^j}) monotone; k_r = k_0 <=> eps in I
+  S0  rank d2 = rank d1           [Lemma 0 / Frobenius, internal sanity]
+  S3  if eps not in I and 2 <= t* <= N-2 (t* = min t with eps^t in I):
+      the canonical violator z* = eps^{N-t*}(f,g)  [eps^{t*} = fA + gB]
+      is a cycle and eps z* is NOT a boundary      [proof mechanism]
+  S7  same regime: the divided class is eps-alive: eps(f,g) is NOT a
+      level-t* boundary                            [liveness bootstrap]
+  S4  if eps not in I and t* >= N-1: eps^{N/2} not in I and the top-step
+      deck eps^{N/2} acts nontrivially on H1       [A12 block regression]
+  S5  R3 divided-class lemma (heavy, subsampled): whenever eps^u in I
+      with witness (f,g), the level-u cycles are exactly
+      p(top cycles) + T*(f,g) + eps^u T^2
+  S6  if eps in I (subsampled): level-u divided class dies (Ob = 0)
+  S8  Lemma-0 at level u (heavy, subsampled): direct dim H1(level) agrees
+      with 2 dim T/(I + eps^u T)
+
+Any S1/S2/S0 violation is a counterexample to the theorem (or a bug in
+the derivation); S3/S7 violations break the proof mechanism even if the
+endpoint survives. Everything is expected ALL-PASS.
+
+Coverage: exhaustive for F2[Z4] (N=4), F2[Z8] (N=4 and N=8), F4[Z4]
+(N=4), F2[Z4xZ2] (N=4, both deck classes); sampled (uniform + a targeted
+stratum forcing eps^2 in I) for F2[Z8xZ2] (N=4, N=8), F2[Z4xZ4],
+F4[Z4xZ2]. F8 blocks remain out of scope (BlockAlgebra supports d<=2),
+same residual gap as the A12 sweep.
+
+Run: python3 scripts/a13_deck_tower_block_sweep.py   (from experiments/bb_lab)
+"""
+
+import itertools
+import os
+import random
+import sys
+import time
+from math import gcd
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from a12_bockstein_block_sweep import BlockAlgebra, nullspace, rref_add  # noqa: E402
+
+
+# ---------- small F2 helpers on top of the a12 machinery ----------
+
+def span_basis(vectors):
+    basis = []
+    for v in vectors:
+        rref_add(basis, v)
+    return basis
+
+
+def reduce_span(basis, v):
+    for b in basis:
+        v = min(v, v ^ b)
+    return v
+
+
+def in_span(basis, v):
+    return reduce_span(basis, v) == 0
+
+
+def apply_cols(cols, v):
+    """Apply the linear map with the given columns to the bitmask v."""
+    w = 0
+    while v:
+        b = v & -v
+        v ^= b
+        w ^= cols[b.bit_length() - 1]
+    return w
+
+
+def solve(cols, target):
+    """Solve sum_{j in combo} cols[j] = target; return combo mask or None.
+
+    Forward elimination; each pivot is reduced against all earlier pivots,
+    so its low bit never reappears (single reduction pass is sound)."""
+    piv = []
+    for j, c in enumerate(cols):
+        comb = 1 << j
+        for pv, pc in piv:
+            if c & (pv & -pv):
+                c ^= pv
+                comb ^= pc
+        if c:
+            piv.append((c, comb))
+    t, tc = target, 0
+    for pv, pc in piv:
+        if t & (pv & -pv):
+            t ^= pv
+            tc ^= pc
+    return tc if t == 0 else None
+
+
+def apply_eps_c1(eps_cols, n, v):
+    """eps acting blockwise on C1 = T^2 (v is a 2n-bit mask)."""
+    w = 0
+    low = v
+    while low:
+        b = low & -low
+        c = b.bit_length() - 1
+        low ^= b
+        if c < n:
+            w ^= eps_cols[c]
+        else:
+            w ^= eps_cols[c - n] << n
+    return w
+
+
+def elt_order(pa, pb, i, j):
+    oa = pa // gcd(i, pa) if i else 1
+    ob = pb // gcd(j, pb) if j else 1
+    return oa * ob // gcd(oa, ob)
+
+
+# ---------- per-pair battery ----------
+
+class DeckData:
+    """Precomputed data for (block algebra, deck element s of order N)."""
+
+    def __init__(self, alg, s_ij, N):
+        self.alg, self.s_ij, self.N = alg, s_ij, N
+        n = alg.n
+        one = 1 << alg.coord(0, alg.pidx(0, 0))
+        eps = one | (1 << alg.coord(0, alg.pidx(*s_ij)))
+        self.eps = eps
+        self.eps_cols = alg.elt_matrix(eps)
+        # eps powers as elements, eps_pow[0] = 1
+        self.eps_pow = [one]
+        for _ in range(N):
+            self.eps_pow.append(apply_cols(self.eps_cols, self.eps_pow[-1]))
+        assert self.eps_pow[N] == 0, "eps^N != 0: deck order wrong"
+        assert self.eps_pow[N - 1] != 0, "eps^(N-1) = 0: not free over Lambda"
+        # multiplication matrices of eps powers (for the violator check)
+        self.epow_mats = [alg.elt_matrix(self.eps_pow[t]) for t in range(N)]
+        # F2-span of eps^u T for each u (level subspaces W_u)
+        self.W = [span_basis(self.epow_mats[t]) for t in range(N)]
+
+    def r_of(self):
+        return self.N.bit_length() - 1
+
+
+class Tally:
+    def __init__(self):
+        self.pairs = 0
+        self.geography = {}          # (R, memb) -> count
+        self.tstar_hist = {}         # t* histogram over eps-not-in-I pairs
+        self.ob_alive = 0            # S7 confirmations
+        self.violator_fired = 0      # S3 confirmations
+        self.a12_regressions = 0     # S4 confirmations
+        self.heavy_r3 = 0
+        self.heavy_s6 = 0
+        self.heavy_s8 = 0
+        self.violations = []         # (tag, A, B, detail)
+
+
+def check_pair(dd, A, B, tally, heavy_budget):
+    alg, N = dd.alg, dd.N
+    n = alg.n
+    MA = alg.elt_matrix(A)
+    MB = alg.elt_matrix(B)
+    d1_cols = MA + MB
+
+    ideal = span_basis(d1_cols)
+    rank_d1 = len(ideal)
+    memb = in_span(ideal, dd.eps)
+
+    # t* = min t with eps^t in I  (eps^N = 0 is always in I)
+    tstar = N
+    for t in range(N):
+        if in_span(ideal, dd.eps_pow[t]):
+            tstar = t
+            break
+
+    # (R): eps kills H1
+    ker = nullspace(d1_cols, n)
+    im2 = []
+    for h in range(n):
+        rref_add(im2, MB[h] | (MA[h] << n))
+    rank_d2 = len(im2)
+    R_holds = True
+    for v in ker:
+        if not in_span(im2, apply_eps_c1(dd.eps_cols, n, v)):
+            R_holds = False
+            break
+
+    tally.pairs += 1
+    tally.geography[(R_holds, memb)] = \
+        tally.geography.get((R_holds, memb), 0) + 1
+
+    # S0: Lemma 0 (rank d2 = rank d1, Frobenius duality)
+    if rank_d2 != rank_d1:
+        tally.violations.append(("S0", A, B, f"rank d1={rank_d1} d2={rank_d2}"))
+
+    # S1: the A13 endpoint
+    if R_holds != memb:
+        tally.violations.append(
+            ("S1-COUNTEREXAMPLE", A, B, f"R={R_holds} memb={memb} t*={tstar}"))
+        return  # everything downstream is moot for this pair
+
+    # S2: k-profile via the counting lemma (Lemma 0 per level)
+    r = dd.r_of()
+    kprof = []
+    for j in range(r + 1):
+        u = min(1 << j, N)
+        lev = list(ideal)
+        for c in dd.epow_mats[u] if u < N else []:
+            rref_add(lev, c)
+        kprof.append(2 * (n - len(lev)))
+    if any(kprof[j] > kprof[j + 1] for j in range(r)):
+        tally.violations.append(("S2-monotone", A, B, str(kprof)))
+    if (kprof[r] == kprof[0]) != memb:
+        tally.violations.append(("S2-count", A, B, f"{kprof} memb={memb}"))
+
+    if not memb:
+        tally.tstar_hist[tstar] = tally.tstar_hist.get(tstar, 0) + 1
+
+    do_heavy = heavy_budget[0] > 0
+
+    if not memb and 2 <= tstar <= N - 2:
+        # witness eps^{t*} = fA + gB
+        combo = solve(d1_cols, dd.eps_pow[tstar])
+        assert combo is not None, "membership at t* has no witness (bug)"
+        f = combo & ((1 << n) - 1)
+        g = combo >> n
+        # S3: canonical violator z* = eps^{N-t*} (f, g)
+        z1 = apply_cols(dd.epow_mats[N - tstar], f)
+        z2 = apply_cols(dd.epow_mats[N - tstar], g)
+        zst = z1 | (z2 << n)
+        if apply_cols(d1_cols, zst) != 0:
+            tally.violations.append(("S3-notcycle", A, B, f"t*={tstar}"))
+        elif zst == 0:
+            # eps^{N-t*}(f,g) = 0 would make the mechanism vacuous; the
+            # proof still stands via s = eps^{N-t*} sigma, but flag it.
+            tally.violations.append(("S3-zerocycle", A, B, f"t*={tstar}"))
+        elif in_span(im2, apply_eps_c1(dd.eps_cols, n, zst)):
+            tally.violations.append(("S3-VIOLATOR-SILENT", A, B,
+                                     f"t*={tstar} (proof mechanism broken)"))
+        else:
+            tally.violator_fired += 1
+        # S7: liveness — eps(f,g) is not a level-t* boundary
+        efg = apply_eps_c1(dd.eps_cols, n,  f | (g << n))
+        lev_bd = list(im2)
+        for w in dd.W[tstar]:
+            rref_add(lev_bd, w)
+            rref_add(lev_bd, w << n)
+        if in_span(lev_bd, efg):
+            tally.violations.append(("S7-LIVENESS", A, B,
+                                     f"t*={tstar} Ob=0 but eps not in I"))
+        else:
+            tally.ob_alive += 1
+
+    if not memb and tstar >= N - 1:
+        # S4: A12 regression on the top step (deck eps^{N/2})
+        mu = dd.eps_pow[N // 2]
+        if in_span(ideal, mu):
+            tally.violations.append(("S4-mu-in-I", A, B, f"t*={tstar}"))
+        else:
+            mu_trivial = True
+            for v in ker:
+                w = 0
+                low = v
+                while low:
+                    b = low & -low
+                    c = b.bit_length() - 1
+                    low ^= b
+                    if c < n:
+                        w ^= dd.epow_mats[N // 2][c]
+                    else:
+                        w ^= dd.epow_mats[N // 2][c - n] << n
+                if not in_span(im2, w):
+                    mu_trivial = False
+                    break
+            if mu_trivial:
+                tally.violations.append(("S4-A12-REGRESSION", A, B,
+                                         f"mu trivial but mu not in I"))
+            else:
+                tally.a12_regressions += 1
+
+    # ---- heavy, subsampled checks ----
+    if not do_heavy:
+        return
+    # pick a level u with a witness: t* if 1 <= t* <= N-1, else skip
+    u = tstar if 1 <= tstar <= N - 1 else (N // 2 if memb else 0)
+    if memb:
+        u = 1  # eps itself is in I; use the sharpest level
+    if not (1 <= u <= N - 1):
+        return
+    combo = solve(d1_cols, dd.eps_pow[u])
+    if combo is None:
+        return
+    heavy_budget[0] -= 1
+    f = combo & ((1 << n) - 1)
+    g = combo >> n
+    Wu = dd.W[u]
+    W2 = []
+    for w in Wu:
+        rref_add(W2, w)
+        rref_add(W2, w << n)
+
+    # S5 / R3: level-u cycles = p(top cycles) + T*(f,g) + W^2
+    red_cols = [reduce_span(Wu, c) for c in d1_cols]
+    lev_ker = nullspace(red_cols, n)
+    lhs = span_basis(lev_ker + list(W2))
+    Mf = alg.elt_matrix(f)
+    Mg = alg.elt_matrix(g)
+    fg_mults = [Mf[c] | (Mg[c] << n) for c in range(n)]
+    rhs = span_basis(ker + fg_mults + list(W2))
+    union = span_basis(lhs + rhs)
+    if not (len(lhs) == len(rhs) == len(union)):
+        tally.violations.append(
+            ("S5-R3", A, B,
+             f"u={u} dims lhs={len(lhs)} rhs={len(rhs)} union={len(union)}"))
+    else:
+        tally.heavy_r3 += 1
+
+    # S6: membership case — divided class dies at level u
+    if memb:
+        lev_bd = list(im2)
+        for w in W2:
+            rref_add(lev_bd, w)
+        efg = apply_eps_c1(dd.eps_cols, n, f | (g << n))
+        if not in_span(lev_bd, efg):
+            tally.violations.append(("S6-Ob-alive-despite-memb", A, B,
+                                     f"u={u}"))
+        else:
+            tally.heavy_s6 += 1
+
+    # S8: Lemma 0 at level u
+    lev_bd = list(im2)
+    for w in W2:
+        rref_add(lev_bd, w)
+    dim_h1_direct = 2 * n - len(span_basis(red_cols)) - len(lev_bd)
+    lev_ideal = list(ideal)
+    for c in dd.epow_mats[u]:
+        rref_add(lev_ideal, c)
+    dim_h1_count = 2 * (n - len(lev_ideal))
+    if dim_h1_direct != dim_h1_count:
+        tally.violations.append(("S8-lemma0-level", A, B,
+                                 f"u={u} {dim_h1_direct}!={dim_h1_count}"))
+    else:
+        tally.heavy_s8 += 1
+
+
+# ---------- sweeps ----------
+
+def sweep(name, alg, s_ij, N, pairs_iter, label, heavy_cap=400):
+    dd = DeckData(alg, s_ij, N)
+    tally = Tally()
+    heavy_budget = [heavy_cap]
+    t0 = time.time()
+    for (A, B) in pairs_iter:
+        check_pair(dd, A, B, tally, heavy_budget)
+    dt = time.time() - t0
+    geo = {k: v for k, v in sorted(tally.geography.items())}
+    mixed = sum(v for (R, m), v in geo.items() if R != m)
+    status = "OK" if not tally.violations else \
+        f"{len(tally.violations)} VIOLATIONS"
+    print(f"{name:16s} s={s_ij} N={N} pairs={tally.pairs:>8d} "
+          f"R<->memb mismatches={mixed}  "
+          f"S3 fired={tally.violator_fired:>6d}  S7 alive={tally.ob_alive:>6d} "
+          f"S4={tally.a12_regressions:>5d}  "
+          f"heavy(R3/S6/S8)={tally.heavy_r3}/{tally.heavy_s6}/{tally.heavy_s8} "
+          f" {status}  [{label}, {dt:.1f}s]")
+    if tally.tstar_hist:
+        print(f"{'':16s} t* histogram (eps not in I): "
+              f"{dict(sorted(tally.tstar_hist.items()))}")
+    for v in tally.violations[:8]:
+        print(f"    !! {v[0]}: A={v[1]:#x} B={v[2]:#x}  {v[3]}")
+    return tally.violations
+
+
+def hand_sanity():
+    """The two hand-computed toy rows from the A13 planning session,
+    T = F2[Z4xZ2] = F2[t,u]/(t^4,u^2), t = 1+x, u = 1+y, eps = t."""
+    alg = BlockAlgebra(4, 2, 1)
+    dd = DeckData(alg, (1, 0), 4)
+    one = 1 << alg.coord(0, alg.pidx(0, 0))
+    y = 1 << alg.coord(0, alg.pidx(0, 1))
+    uu = one | y                       # u = 1 + y
+    t2 = one | (1 << alg.coord(0, alg.pidx(2, 0)))   # t^2 = 1 + x^2
+    assert dd.eps_pow[2] == t2, "eps^2 != 1+x^2"
+    # row 1: A = u, B = t^2 : t* = 2, eps not in I, (R) fails
+    tally = Tally()
+    check_pair(dd, uu, t2, tally, [10])
+    assert tally.geography.get((False, False), 0) == 1, "toy row 1: expected (R) fail + eps not in I"
+    assert tally.violator_fired == 1 and tally.ob_alive == 1
+    assert not tally.violations, tally.violations
+    # row 2: A = u, B = t*u : t* = 4 (residual regime), (R) fails via S4
+    tu = apply_cols(dd.eps_cols, uu)
+    tally = Tally()
+    check_pair(dd, uu, tu, tally, [10])
+    assert tally.geography.get((False, False), 0) == 1
+    assert tally.a12_regressions == 1
+    assert not tally.violations, tally.violations
+    print("hand-computed toy rows reproduced (A=u,B=t^2 and A=u,B=tu)")
+
+
+def main():
+    random.seed(20260702)
+    all_violations = []
+
+    hand_sanity()
+    print()
+
+    # exhaustive, N = 4 and N = 8
+    exhaustive = [
+        ("F2[Z4]",    BlockAlgebra(4, 1, 1),  (1, 0), 4),
+        ("F2[Z8]",    BlockAlgebra(8, 1, 1),  (2, 0), 4),
+        ("F2[Z8]",    BlockAlgebra(8, 1, 1),  (1, 0), 8),
+        ("F4[Z4]",    BlockAlgebra(4, 1, 2),  (1, 0), 4),
+        ("F2[Z4xZ2]", BlockAlgebra(4, 2, 1),  (1, 0), 4),
+        ("F2[Z4xZ2]", BlockAlgebra(4, 2, 1),  (1, 1), 4),
+    ]
+    for name, alg, s_ij, N in exhaustive:
+        assert elt_order(alg.pa, alg.pb, *s_ij) == N
+        n_elts = 1 << alg.n
+        pairs = itertools.product(range(n_elts), repeat=2)
+        all_violations += sweep(name, alg, s_ij, N, pairs, "exhaustive")
+
+    # sampled: uniform + targeted (B = eps^2 + c*A forces eps^2 in I)
+    SAMPLE = 20000
+    sampled = [
+        ("F2[Z8xZ2]", BlockAlgebra(8, 2, 1), (1, 0), 8),
+        ("F2[Z8xZ2]", BlockAlgebra(8, 2, 1), (2, 1), 4),
+        ("F2[Z4xZ4]", BlockAlgebra(4, 4, 1), (1, 0), 4),
+        ("F2[Z4xZ4]", BlockAlgebra(4, 4, 1), (1, 1), 4),
+        ("F4[Z4xZ2]", BlockAlgebra(4, 2, 2), (1, 0), 4),
+    ]
+    for name, alg, s_ij, N in sampled:
+        assert elt_order(alg.pa, alg.pb, *s_ij) == N
+        nbits = alg.n
+        dd_tmp = DeckData(alg, s_ij, N)
+        eps2 = dd_tmp.eps_pow[2]
+
+        def uniform():
+            for _ in range(SAMPLE):
+                yield random.getrandbits(nbits), random.getrandbits(nbits)
+
+        def targeted():
+            for _ in range(SAMPLE):
+                A = random.getrandbits(nbits)
+                c = random.getrandbits(nbits)
+                B = eps2 ^ apply_cols(alg.elt_matrix(A), c)
+                yield A, B
+
+        all_violations += sweep(name, alg, s_ij, N, uniform(),
+                                f"uniform {SAMPLE}")
+        all_violations += sweep(name, alg, s_ij, N, targeted(),
+                                f"targeted eps^2-in-I {SAMPLE}")
+
+    print()
+    if all_violations:
+        s1 = [v for v in all_violations if v[0].startswith("S1")]
+        print(f"FAIL: {len(all_violations)} violations total, "
+              f"{len(s1)} S1 counterexamples to Theorem A13.")
+        sys.exit(1)
+    print("ALL PASS: (R) <=> eps in (A,B) on every pair swept; the "
+          "canonical violator fires and the divided class is eps-alive "
+          "in every 2 <= t* <= N-2 pair; A12 top-step regression clean; "
+          "R3/S6/S8 structural checks clean on the heavy subsample.")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/bb_lab/scripts/a13_gross_ladder.py
+++ b/experiments/bb_lab/scripts/a13_gross_ladder.py
@@ -1,0 +1,155 @@
+"""A13 C3: the gross x-tower is certified uniformly in r (P0/T1), plus a
+cover-level r=2 spot sweep.
+
+Part 1 (the ladder): for L in {6, 12, 24, 48} (levels j = 0..3 of the
+gross x-tower Z_L x Z_6, same polynomials A = x^3+y+y^2, B = y^3+x+x^2):
+
+  W1: the witness identity (1+x^2) * B^2 = 1 + x^6 holds in F2[Z_L x Z_6]
+      (it only uses y^6 = 1, so it is level-free)
+  W2: 1 + x^6 lies in the principal ideal (B) — hence in (A,B) — at every
+      level (R0-shaped membership)
+  W3: k(level) = 12 at every level, via Lemma 0 (k = 2 dim T/(A,B)) and
+      via the direct H1 dimension, with rank d1 = rank d2 (Frobenius)
+  W4: the full deck acts trivially on H1 at every level:
+      (1+x^6) * Z1 <= B1 (deck-triviality, checked directly, not via K2)
+  W5: T1 k-profile inside each level ring: k_j = 2 dim T/((A,B) +
+      (1+x^{6*2^j})) equals 12 for every sub-level j (monotone, constant)
+
+Part 2 (cover-level r=2 spot sweep): Z_12 x Z_3 as a Z_4-tower over
+Z_3 x Z_3 (deck x^3, eps = 1+x^3, N = 4). Random weight-3 cover pairs
+run through the full A13 battery of a13_deck_tower_block_sweep.check_pair
+(S1 endpoint, S3 canonical violator, S7 liveness, S4 A12 regression,
+heavy R3/S8 subsample) — the same checks, now on genuine BB cover pairs
+rather than abstract block pairs.
+
+Run: python3 scripts/a13_gross_ladder.py   (from experiments/bb_lab)
+"""
+
+import os
+import random
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from a12_bockstein_block_sweep import BlockAlgebra, nullspace, rref_add  # noqa: E402
+from a13_deck_tower_block_sweep import (  # noqa: E402
+    DeckData, Tally, apply_cols, apply_eps_c1, check_pair, in_span,
+    span_basis)
+
+
+def gross_level(L):
+    """Run W1-W5 for the level ring F2[Z_L x Z_6]; return (k, report)."""
+    alg = BlockAlgebra(L, 6, 1)
+    n = alg.n
+
+    def mono(i, j):
+        return 1 << alg.coord(0, alg.pidx(i, j))
+
+    A = mono(3, 0) ^ mono(0, 1) ^ mono(0, 2)
+    B = mono(0, 3) ^ mono(1, 0) ^ mono(2, 0)
+    MA = alg.elt_matrix(A)
+    MB = alg.elt_matrix(B)
+    d1_cols = MA + MB
+
+    ideal = span_basis(d1_cols)
+    rank1 = len(ideal)
+    im2 = span_basis([MB[h] | (MA[h] << n) for h in range(n)])
+    assert len(im2) == rank1, f"L={L}: rank d2 != rank d1 (Lemma 0)"
+
+    k_lemma0 = 2 * (n - rank1)
+    ker = nullspace(d1_cols, n)
+    k_direct = len(ker) - rank1  # dim Z1 - dim B1 = (2n - rank1) - rank1
+    assert len(ker) == 2 * n - rank1
+    assert k_direct == k_lemma0 == 12, \
+        f"L={L}: k = {k_direct}/{k_lemma0}, expected 12"
+
+    eps = mono(0, 0) ^ (mono(6, 0) if 6 % L or L > 6 else 0)
+    if L == 6:
+        eps = 0  # x^6 = 1 at the base: the deck is trivial there
+    report = [f"k={k_direct}"]
+
+    if L > 6:
+        # W1: (1+x^2) * B^2 = 1 + x^6, level-free witness
+        B2 = apply_cols(MB, B)
+        lhs = apply_cols(alg.elt_matrix(mono(0, 0) ^ mono(2, 0)), B2)
+        assert lhs == eps, f"L={L}: witness identity fails"
+        # W2: R0-shaped membership 1+x^6 in (B), hence in (A,B)
+        assert in_span(span_basis(MB), eps), f"L={L}: eps not in (B)"
+        assert in_span(ideal, eps), f"L={L}: eps not in (A,B)"
+        # W4: full-deck triviality on H1, checked directly
+        eps_cols = alg.elt_matrix(eps)
+        for z in ker:
+            assert in_span(im2, apply_eps_c1(eps_cols, n, z)), \
+                f"L={L}: deck acts nontrivially on H1"
+        report.append("witness+membership+deck-trivial OK")
+
+    # W5: T1 k-profile inside this level ring
+    m = (L // 6).bit_length() - 1  # L = 6 * 2^m
+    kprof = []
+    for j in range(m + 1):
+        e = (6 * (1 << j)) % L
+        lev = list(ideal)
+        if e:
+            for c in alg.elt_matrix(mono(0, 0) ^ mono(e, 0)):
+                rref_add(lev, c)
+        kprof.append(2 * (n - len(lev)))
+    assert kprof == [12] * (m + 1), f"L={L}: k-profile {kprof}"
+    report.append(f"k-profile {kprof}")
+    return k_direct, "; ".join(report)
+
+
+def cover_r2_sweep(samples=15000, heavy_cap=150):
+    """Weight-3 cover pairs on Z12 x Z3 (deck x^3 of order 4)."""
+    alg = BlockAlgebra(12, 3, 1)
+    n = alg.n
+    dd = DeckData(alg, (3, 0), 4)
+    tally = Tally()
+    heavy_budget = [heavy_cap]
+    coords = [1 << c for c in range(n)]
+    t0 = time.time()
+    for _ in range(samples):
+        A = 0
+        for c in random.sample(coords, 3):
+            A ^= c
+        B = 0
+        for c in random.sample(coords, 3):
+            B ^= c
+        check_pair(dd, A, B, tally, heavy_budget)
+    dt = time.time() - t0
+    geo = dict(sorted(tally.geography.items()))
+    mixed = sum(v for (R, mb), v in geo.items() if R != mb)
+    print(f"Z12xZ3 weight-3 r=2 sweep: pairs={tally.pairs} "
+          f"geography={geo} R<->memb mismatches={mixed}")
+    print(f"  t* histogram (eps not in I): "
+          f"{dict(sorted(tally.tstar_hist.items()))}")
+    print(f"  S3 violator fired={tally.violator_fired} "
+          f"S7 divided-class alive={tally.ob_alive} "
+          f"S4 A12-regressions={tally.a12_regressions} "
+          f"heavy R3/S6/S8={tally.heavy_r3}/{tally.heavy_s6}/{tally.heavy_s8}"
+          f"  [{dt:.1f}s]")
+    return tally.violations
+
+
+def main():
+    random.seed(20260702)
+    print("Part 1: gross x-tower ladder, levels Z_L x Z_6")
+    for L in (6, 12, 24, 48):
+        t0 = time.time()
+        _, report = gross_level(L)
+        print(f"  L={L:>2d} ([[{2 * 6 * L},12,.]]): {report} "
+              f"[{time.time() - t0:.1f}s]")
+    print("Part 1 ALL PASS: k = 12 and full deck-triviality certified at "
+          "every level by the single level-free witness (1+x^2)B^2 = 1+x^6.")
+    print()
+    print("Part 2: cover-level r=2 battery on Z12 x Z3")
+    violations = cover_r2_sweep()
+    if violations:
+        for v in violations[:8]:
+            print(f"    !! {v[0]}: A={v[1]:#x} B={v[2]:#x}  {v[3]}")
+        print(f"FAIL: {len(violations)} violations")
+        sys.exit(1)
+    print("Part 2 ALL PASS.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/research_log.md
+++ b/pipeline/research_log.md
@@ -13,6 +13,33 @@ what was tried and why it didn't work.
 
 ## Entries
 
+- 2026-07-02 — deck-tower-descent (A13) — success —
+  **Deck-trivial ⟺ k constant along `ℤ_{2^r}` doubling towers (A12 OQ1),
+  answered YES.** For a free `ℤ_{2^r}` BB cover, `σ_* = id` on `H₁(top)`
+  forces `k(top) = k(base)` (`r ≥ 2`; `r = 1` is A12). The hard direction
+  is a completed elementary proof: A12 on the top `ℤ₂`-step gives the entry
+  `ε^{N/2} ∈ (A,B)`, then a **descent** — apply deck-triviality to the
+  canonical cycle `ε^{N-t}(f,g)`; the boundary coefficient satisfies
+  `ε^t z = 0`, so ε-freeness divides it (`z = ε^{N-t}u`), yielding
+  `ε ∈ (A,B) + ε^{N-t}S` — plus a ring-algebra tail-elimination. Simpler
+  than the planned Bockstein-SS / obstruction-class route (none needed).
+  **Lean payoff (public-side, axiom-clean):**
+  `QEC/Stabilizer/Framework/Homological/BBDeckTower.lean` —
+  `eps_mem_of_deckTrivial` (the ⟹), `descent`, `boost`/`iterate` over an
+  abstract char-2 ring with the `EpsFree`/`DeckTrivial` predicates; pairs
+  with the existing `BB.deckTrivial_of_bezout` (the ⟸) for the full ring
+  iff. Builds 1.4 s; axioms = standard three, no `sorry`/`native_decide`.
+  Screens (refutation-first, all clean):
+  `a13_deck_tower_block_sweep.py` (endpoint + mechanism + intermediate
+  identities, exhaustive to deck order 8) and `a13_gross_ladder.py` (gross
+  x-tower `k≡12` + full deck-triviality to `[[576,12,·]]` from the
+  level-free witness `(1+x²)B²=1+x⁶`; genuine `Z₁₂×Z₃` cover pairs).
+  Residual (paper-level, plan item L1): the `H₁ ↔ DeckTrivial` /
+  `𝔽₂[G]-free ↔ EpsFree` bridges. The family paper's k-row is now a
+  theorem (T1–T3 + A13); growing distance still lives in the safe floor
+  (condition 3), untouched here.
+  [plan+resolution](../experiments/bb_lab/notes/A13_deck_tower_plan.md)
+
 - 2026-07-02 — bb-pair72-packaging (S3.9) — success —
   **`pair72StabilizerCodeWithDistance : StabilizerCodeWithDistance 72 4 8`**
   (`Codes/BivariateBicycle/Z3Z6/StabilizerCode.lean`): the second doubling


### PR DESCRIPTION
Stacks on #53 (base = its head branch, so the diff is scoped to the A13 work). Retarget to `main` once #53 merges.

## What this resolves

Answers A12's open problem **OQ1** (the tour-de-gross tower question): for a free `ℤ_{2^r}` BB doubling tower, does `σ_* = id` on `H₁(top)` force `k(top) = k(base)`?

**Yes.** Full equivalence at the ring level:
> deck-trivial ⟺ `ε ∈ (A,B)` ⟺ `k(top) = k(base)` ⟺ deck acts trivially at every tower level  (`r ≥ 2`; `r = 1` is A12).

## The proof (simpler than planned — no spectral sequence, no obstruction class, no induction on r)

A12 on the top `ℤ₂`-step gives the entry `ε^{N/2} ∈ (A,B)`. Then a **descent**: apply deck-triviality to the canonical cycle `ε^{N-t}(f,g)` (where `ε^t = fA+gB`); the returned boundary coefficient `z` satisfies `ε^t·z = 0` by a two-line char-2 cancellation, so **ε-freeness divides it — `z = ε^{N-t}u`** (the step the plan was missing) — yielding `ε ∈ (A,B) + ε^{N-t}S`. A pure ring-algebra iteration eliminates the tail. One deck application on one cycle.

## Lean (public-side, axiom-clean)

`QEC/Stabilizer/Framework/Homological/BBDeckTower.lean` — builds in 1.4s; axioms = `propext, Classical.choice, Quot.sound` only; no `sorry`, no `native_decide`.

- `EpsFree`, `DeckTrivial` — the two geometric inputs as abstract char-2-ring predicates
- `descent` — the deck-application + division step (axioms `propext, Quot.sound`)
- `boost` / `iterate_aux` / `iterate` — tail elimination (char-independent)
- `eps_mem_of_deckTrivial` — the headline ⟹; entry `ε^m ∈ (A,B)` (`2 ≤ m ≤ N-2`) taken as hypothesis (= A12 top-step)

Pairs with the existing `BB.deckTrivial_of_bezout` (the ⟸) for the full ring iff. Wired into the `Homological` umbrella.

## Scope (honest)

The Lean theorem is the **ring-theoretic core**. Two bridges remain paper-level (plan item L1, not math gaps): (i) deriving `DeckTrivial`/`EpsFree` from the concrete `bbChainComplex` deck action and `𝔽₂[G]`-freeness over `𝔽₂[⟨σ⟩]`; (ii) the entry is imported as A12's top-step rather than re-proved. `k(top)=k(base) ⟺ ε∈(A,B)` is the counting lemma (A12 Lemma 0/1), paper-level here.

## Screens (refutation-first, all clean)

- `experiments/bb_lab/scripts/a13_deck_tower_block_sweep.py` — endpoint `(R) ⟺ ε∈(A,B)`, canonical-violator mechanism, divided-class liveness, A12 top-step regression, and the R3/S6/S8 identities; **exhaustive** on `𝔽₂[Z₄]`, `𝔽₂[Z₈]` (`N=4,8`), `𝔽₄[Z₄]`, `𝔽₂[Z₄×Z₂]`, **sampled** on the `|P|=16` blocks. Zero mismatches; `𝔽₈` out of scope.
- `experiments/bb_lab/scripts/a13_gross_ladder.py` — gross x-tower `k≡12` + full deck-triviality up to `[[576,12,·]]` from the level-free witness `(1+x²)B²=1+x⁶` (T3/P0), plus genuine `Z₁₂×Z₃` cover pairs.

## Notes

- `experiments/bb_lab/notes/A13_deck_tower_plan.md` — plan + §0★ resolution
- `experiments/bb_lab/notes/A12_deck_homotopy_R.md` — OQ1 pointer → RESOLVED
- `pipeline/research_log.md` — entry added

## Family-paper impact

Closes the **k-row** of the tour-de-gross family as a theorem (T1–T3 + A13); template condition 2 (homotopy R) is now the k-check at every level, not a per-instance certificate hunt. Growing distance is **not** touched — it lives in the safe floor (condition 3), and the pure x-tower is Bravyi–Terhal-capped by its fixed `Z_m` cross-section; growing `d` needs the 2D/twisted route, where each free-`ℤ₂` sub-step reuses this same equivalence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)