### PR TITLE
fix(dashboard): strip stray tool-call tags breaking Pages deploy

### DIFF
--- a/pipeline/attempts/concat_css_general/gap_audit.md
+++ b/pipeline/attempts/concat_css_general/gap_audit.md
@@ -106,4 +106,3 @@ discharged per-instance (`native_decide` at n=49 via `rowsLinearIndependent_iff_
    and its phase bookkeeping.
 4. **A general `weight_ge_of_blocks_ge` / block-superadditivity** lemma (M1) may
    be promotable to `Foundations` if a second block-structured code appears.
-</content>

--- a/pipeline/attempts/concat_css_general/informal_spec.md
+++ b/pipeline/attempts/concat_css_general/informal_spec.md
@@ -180,4 +180,3 @@ structural proof above is mandatory, not a convenience.
 | `Framework/Core/Logical/LogicalOperators.lean` | phase/Y-agnostic operator-part lemmas; `LogicalQubitOps` target |
 | `Framework/Core/CSS/CSSPredicates.lean` | `IsXTypeElement`/`IsZTypeElement` for typed promotion |
 | `Codes/_TEMPLATE.lean` | canonical §1–§14 structure for the constructor file |
-</content>

--- a/pipeline/attempts/concat_css_general/plan.md
+++ b/pipeline/attempts/concat_css_general/plan.md
@@ -304,4 +304,3 @@ are the deeper, higher-risk deliverable and can be a follow-on.
 | — | M7 Steane⊗Steane | ~80 | |
 
 Total **~1560–1740 LOC**. Realistic schedule risk concentrated in M4.
-</content>

--- a/pipeline/attempts/concat_css_general/reuse_audit.md
+++ b/pipeline/attempts/concat_css_general/reuse_audit.md
@@ -114,4 +114,3 @@ See `gap_audit.md` for detail. Summary:
   the existing `SymplecticSpan` bridge).
 - **`restrictBlock` + `inducedOuter` correspondence** (M5) — concatenation-specific.
 - **`concatenate` constructor** and **`concat_hasCodeDistance`** (M3, M6).
-</content>

--- a/pipeline/attempts/concat_css_general/state.yaml
+++ b/pipeline/attempts/concat_css_general/state.yaml
@@ -38,5 +38,3 @@ notes: |
   needed for the long-pole M4 already exists (SymplecticSpan.lean), so M4 is reuse
   not author-from-scratch; (2) phase/Y-agnostic operator-part lemmas already exist
   (LogicalOperators.lean, NQubitElement.lean), fixing the distance-critic's R4.
-</content>
-</invoke>


### PR DESCRIPTION
## Problem

The **Deploy dashboard to GitHub Pages** workflow has failed on every push to `main` since PR #50 (June 17; last green run was PR #48). The `python3 dashboard/build.py` step aborts with:

```
yaml.scanner.ScannerError: while scanning a simple key
  in ".../pipeline/attempts/concat_css_general/state.yaml", line 41
```

## Root cause

When the `concat_css_general` skeleton landed (PR #50), tool-call serialization fragments were accidentally committed into the files — trailing `</content>` / `</invoke>` tags at the end of `state.yaml` and a stray `</content>` in `reuse_audit.md`, `informal_spec.md`, `gap_audit.md`, and `plan.md`.

`state.yaml` is the only YAML parsed by the build, so those two tags after the `notes:` block scalar broke `yaml.safe_load` and failed the entire build. The `.md` tags rendered as literal text in the dashboard pages.

## Fix

Removed the trailing junk from all five files (6 lines total). Verified locally:

- `state.yaml` parses cleanly (`status = pr-ready`)
- no stray tags remain anywhere under `pipeline/` or `catalog/`
- `dashboard/build.py` runs end-to-end → **271 HTML files generated**

Once merged, the push to `main` (touching `pipeline/`) re-triggers the deploy and Pages goes green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)