### PR TITLE
feat(a15): deficit-wall theorem + Lean layer — value = parity, mechanism = pushforward; 'exactly 2d−2' retracted

### DIFF
--- a/QEC/Stabilizer/Framework/Homological.lean
+++ b/QEC/Stabilizer/Framework/Homological.lean
@@ -15,4 +15,5 @@ import QEC.Stabilizer.Framework.Homological.BBEpsFree
 import QEC.Stabilizer.Framework.Homological.BBConvRing
 import QEC.Stabilizer.Framework.Homological.BBBocksteinRank
 import QEC.Stabilizer.Framework.Homological.BBTransferH1
+import QEC.Stabilizer.Framework.Homological.BBDeficitWall
 import QEC.Stabilizer.Framework.Homological.BBEpsFreeGroupAlgebra

--- a/QEC/Stabilizer/Framework/Homological/BBDeficitWall.lean
+++ b/QEC/Stabilizer/Framework/Homological/BBDeficitWall.lean
@@ -1,0 +1,386 @@
+/-
+# The deficit wall: parity, the seam transfer kernel, and the pushforward bound
+
+Lean layer for A15-P3 (`experiments/bb_lab/notes/A15_deficit_wall.md`): why
+the safe floor of a non-doubling BB cover fails by at least two.
+
+* **Parity (L1).** With odd-weight polynomials (`∑ A = ∑ B = 1` in
+  `ZMod 2`) every 1-cycle of a BB complex has even weight — the
+  augmentation `v ↦ ∑ v` is multiplicative on convolutions
+  (`sum_conv`), so `B⋆v_L = A⋆v_R` forces `∑ v_L = ∑ v_R`.
+  Consequently the seam-coset floor upgrades across odd values for
+  free: `SeamCosetFloor (m - 1) → SeamCosetFloor m` for even `m`
+  (`seamCosetFloor_of_even_of_pred`), i.e. **the maximal failing value
+  of an even target `m` is `m − 2` — the deficit wall.**  The same
+  holds for the cover-side `SafeFloor` (`safeFloor_of_even_of_pred`).
+
+* **The seam transfer kernel (L0).** A base 1-chain pulls back to a
+  cover *boundary* iff it lies in a seam coset:
+  `pull1 w ∈ boundaries(cover) ↔ ∃ ζ ∈ ker ∂₂, ∃ f, w = seamC ζ + ∂₂ f`
+  (`pull1_mem_boundaries_iff_seamCoset`).  The forward chase descends
+  the boundary witness through `liftC2_decomp`; the reverse is
+  `pull1_seamC : τ(seamC ζ) = liftStab ζ`.  This is the connecting-map
+  slot of the transfer LES (`im δ₂ = ker τ₁`), sibling to
+  `BBTransferH1.ker_pushH1_eq_range_pullH1`.
+
+* **The pushforward bound (T2).** Under the deck homotopy (R)
+  (`DeckTrivialOnH1`, e.g. from `deckTrivial_of_bezout`), the
+  pushforward of every cover 1-cycle lands in a seam coset
+  (`push1_mem_seamCoset_of_deckTrivial` — proof: `τ(p v) = v + σv` is a
+  boundary).  Hence a cover cycle of weight `< m` whose pushforward is
+  not a base boundary refutes `SeamCosetFloor m` outright
+  (`not_seamCosetFloor_of_light_cover_cycle`): **the safe floor
+  inherits the cover's safe-sector failure at no weight cost**
+  (`d_safe ≤ d̃_safe`).  This is the converse direction to
+  `safeFloor_of_seamCosetFloor`.
+-/
+
+import QEC.Stabilizer.Framework.Homological.BBDoubling
+
+namespace Quantum
+namespace Stabilizer
+namespace Homological
+namespace BB
+
+open scoped BigOperators
+
+-- Defeq checks through `coverComplex`/`baseComplex` projections unfold deep
+-- `Prod`/`ZMod` instance chains, exactly as in `BBCover.lean`.
+set_option maxRecDepth 4096
+
+/-! ## The augmentation is multiplicative on convolutions -/
+
+section Augmentation
+
+variable {G : Type} [Fintype G] [AddCommGroup G]
+
+/-- The augmentation of a convolution is the product of augmentations:
+`∑ (a ⋆ b) = (∑ a) · (∑ b)`. -/
+lemma sum_conv (a b : G → ZMod 2) :
+    ∑ g : G, conv a b g = (∑ g : G, a g) * (∑ g : G, b g) := by
+  simp only [conv_apply]
+  rw [Finset.sum_comm, Finset.sum_mul]
+  refine Finset.sum_congr rfl fun h _ => ?_
+  rw [← Finset.mul_sum]
+  congr 1
+  exact Equiv.sum_comp (Equiv.subRight h) b
+
+omit [AddCommGroup G] in
+/-- Over `ZMod 2`, the sum of a chain is its support parity: the cast of
+the support count equals `∑ v`. -/
+lemma natCast_card_support (v : G → ZMod 2) :
+    (((Finset.univ.filter fun g => v g ≠ 0).card : ℕ) : ZMod 2)
+      = ∑ g : G, v g := by
+  have hval : ∀ g : G, v g ≠ 0 → v g = 1 := by
+    intro g
+    generalize v g = x
+    decide +revert
+  rw [← Finset.sum_filter_ne_zero Finset.univ, Finset.card_eq_sum_ones,
+    Nat.cast_sum]
+  refine Finset.sum_congr rfl fun g hg => ?_
+  rw [Nat.cast_one]
+  exact (hval g (Finset.mem_filter.mp hg).2).symm
+
+end Augmentation
+
+/-! ## Parity (L1): cycles of odd-weight BB complexes have even weight -/
+
+section Parity
+
+variable {G : Type} [Fintype G] [AddCommGroup G]
+
+/-- **Parity (L1).** If both polynomials have odd weight
+(`∑ A = ∑ B = 1` in `ZMod 2`), every 1-cycle of the BB complex has even
+support: the augmentation applied to `B⋆v_L + A⋆v_R = 0` gives
+`∑ v_L = ∑ v_R`, so `∑ v = 0`. -/
+theorem cycle_support_even (A B : G → ZMod 2)
+    (hA : ∑ g : G, A g = 1) (hB : ∑ g : G, B g = 1)
+    {v : G × Fin 2 → ZMod 2} (hv : bbBoundary1Fn A B v = 0) :
+    Even ((Finset.univ.filter fun p : G × Fin 2 => v p ≠ 0).card) := by
+  classical
+  -- the total sum of the cycle vanishes
+  have hsum : ∑ p : G × Fin 2, v p = 0 := by
+    have h0 : ∑ g : G, bbBoundary1Fn A B v g = 0 := by
+      rw [hv]; exact Finset.sum_const_zero
+    have hexp : ∑ g : G, bbBoundary1Fn A B v g
+        = (∑ g : G, v (g, 0)) + (∑ g : G, v (g, 1)) := by
+      unfold bbBoundary1Fn
+      rw [Finset.sum_add_distrib, sum_conv, sum_conv, hA, hB, one_mul,
+        one_mul]
+      rfl
+    rw [Fintype.sum_prod_type, Finset.sum_comm]
+    rw [Fin.sum_univ_two]
+    rw [hexp] at h0
+    exact h0
+  -- support parity = total sum = 0
+  have hcast : (((Finset.univ.filter fun p : G × Fin 2 => v p ≠ 0).card : ℕ)
+      : ZMod 2) = 0 := by
+    rw [natCast_card_support (G := G × Fin 2) v]
+    exact hsum
+  exact ZMod.natCast_eq_zero_iff_even.mp hcast
+
+end Parity
+
+namespace XDoubleCoverData
+
+variable {G H : Type}
+  [Fintype G] [AddCommGroup G] [DecidableEq G]
+  [Fintype H] [AddCommGroup H] [DecidableEq H]
+  (D : XDoubleCoverData G H)
+
+/-! ## Parity instantiated on the cover bundle -/
+
+/-- The cover polynomials have the same augmentation as their descents
+(fiber summation preserves totals). -/
+lemma sum_cover_eq_sum_base (v : G → ZMod 2) :
+    ∑ g : G, v g = ∑ h : H, fiberSumFn (⇑D.proj) v h := by
+  classical
+  unfold fiberSumFn
+  rw [Finset.sum_comm]
+  refine Finset.sum_congr rfl fun g _ => ?_
+  rw [Finset.sum_ite_eq Finset.univ (D.proj g) (fun _ => v g)]
+  simp
+
+/-- Parity for base 1-cycles, from the odd-weight hypothesis on the base
+polynomials. -/
+theorem base_cycle_weight_even
+    (hA : ∑ h : H, D.Ab h = 1) (hB : ∑ h : H, D.Bb h = 1)
+    {u : H × Fin 2 → ZMod 2} (hu : u ∈ D.baseComplex.cycles) :
+    Even (D.baseComplex.chainWeight u) := by
+  rw [D.baseComplex_chainWeight_eq]
+  exact cycle_support_even D.Ab D.Bb hA hB hu
+
+/-- Parity for cover 1-cycles: the cover polynomial augmentations descend
+(`push_A`, `push_B`), so the same odd-weight hypotheses suffice. -/
+theorem cover_cycle_weight_even
+    (hA : ∑ h : H, D.Ab h = 1) (hB : ∑ h : H, D.Bb h = 1)
+    {v : G × Fin 2 → ZMod 2} (hv : v ∈ D.coverComplex.cycles) :
+    Even (D.coverComplex.chainWeight v) := by
+  have hAc : ∑ g : G, D.Ac g = 1 := by
+    rw [D.sum_cover_eq_sum_base D.Ac]
+    rw [show fiberSumFn (⇑D.proj) D.Ac = D.Ab from D.push_A]
+    exact hA
+  have hBc : ∑ g : G, D.Bc g = 1 := by
+    rw [D.sum_cover_eq_sum_base D.Bc]
+    rw [show fiberSumFn (⇑D.proj) D.Bc = D.Bb from D.push_B]
+    exact hB
+  rw [D.coverComplex_chainWeight_eq]
+  exact cycle_support_even D.Ac D.Bc hAc hBc hv
+
+/-! ## The seam transfer identity (L0, reverse direction) -/
+
+/-- **`τ(seamC ζ) = liftStab ζ`** for a base 2-cycle `ζ`: the pullback of
+the seam-crossing chain is the lifted stabilizer.  (Same chase as
+`seamC_mem_cycles`, keeping the pullback identity.) -/
+theorem pull1_seamC {ζ : H → ZMod 2}
+    (hζ : bbBoundary2Fn D.Ab D.Bb ζ = 0) :
+    D.pull1 (D.seamC ζ) = D.liftStab ζ := by
+  -- the lifted stabilizer pushes to `∂₂ ζ = 0`, so it is a pullback
+  have hpush : D.push1 (D.liftStab ζ) = 0 := by
+    rw [D.push1_liftStab]; exact hζ
+  obtain ⟨u, hu⟩ := (D.push1_eq_zero_iff _).mp hpush
+  -- its sheet 0 recovers `u`, and equals `seamN ζ` by definition
+  have hseamN : D.seamN ζ = u := by
+    change D.sheet0 (D.liftStab ζ) = u
+    rw [hu, D.sheet0_pull1]
+  -- char 2: `seamN ζ + seamC ζ = ∂₂ ζ = 0` forces `seamC ζ = seamN ζ`
+  have hseamC : D.seamC ζ = u := by
+    have hkey : ∀ a b : ZMod 2, a + b = 0 → b = a := by decide
+    funext j
+    have hsum := D.seamN_add_seamC ζ j
+    rw [hseamN, hζ, Pi.zero_apply] at hsum
+    exact hkey _ _ hsum
+  rw [hseamC, ← hu]
+
+/-- Easy direction of L0: every seam-coset element pulls back to a cover
+boundary. -/
+theorem pull1_seamCoset_mem_boundaries {ζ : H → ZMod 2}
+    (hζ : bbBoundary2Fn D.Ab D.Bb ζ = 0) (f : H → ZMod 2) :
+    D.pull1 (D.seamC ζ + bbBoundary2Fn D.Ab D.Bb f)
+      ∈ D.coverComplex.boundaries := by
+  rw [map_add, D.pull1_seamC hζ]
+  exact Submodule.add_mem _ (D.liftStab_mem_boundaries ζ)
+    (D.pull1_mem_boundaries ⟨f, rfl⟩)
+
+/-! ## The seam transfer kernel (L0, forward chase) -/
+
+/-- The deck orbit map on `C0`/`C2` indices has no fixed points. -/
+lemma deckSigma0_ne : ∀ g : G, g + D.deckS ≠ g := by
+  intro g hg
+  apply D.deckS_ne_zero
+  have h : g + D.deckS = g + 0 := by rw [add_zero]; exact hg
+  exact add_left_cancel h
+
+/-- Sheet-1 restriction also inverts the pullback (deck partner of
+`sheet0_pull1`). -/
+lemma sheet1_pull1 (u : H × Fin 2 → ZMod 2) :
+    D.sheet1 (D.pull1 u) = u := by
+  funext q
+  change u (Prod.map ⇑D.proj id (D.deckSigma1 (D.sec1 q))) = u q
+  have hproj : Prod.map ⇑D.proj id (D.deckSigma1 (D.sec1 q))
+      = Prod.map ⇑D.proj id (D.sec1 q) := by
+    change (D.proj ((D.sec1 q).1 + D.deckS), (D.sec1 q).2)
+      = (D.proj (D.sec1 q).1, (D.sec1 q).2)
+    rw [D.proj_add_deckS]
+  rw [hproj, D.proj_prodMap_sec1 q]
+
+/-- Fiber pair formula for the 0/2-chain pushforward:
+`(p₀ z)(proj g) = z g + z (g + deckS)`. -/
+lemma push0_pair (z : G → ZMod 2) (g : G) :
+    fiberSumFn (⇑D.proj) z (D.proj g) = z g + z (g + D.deckS) :=
+  fiberSumFn_pair D.deckSigma0_ne D.proj_fiber z g
+
+/-- The two 2-chain sheets sum to the pushforward. -/
+lemma sheetC2_0_add_sheetC2_1 (z : G → ZMod 2) (h : H) :
+    D.sheetC2_0 z h + D.sheetC2_1 z h = fiberSumFn (⇑D.proj) z h := by
+  have hp := D.push0_pair z (D.sec h)
+  rw [D.proj_sec h] at hp
+  exact hp.symm
+
+/-- **The seam transfer kernel, forward chase**: a base 1-chain whose
+pullback is a cover boundary lies in a seam coset.  Descend the boundary
+witness `c` through the sheet decomposition `liftC2_decomp`: with
+`ξ₀, ξ₁` its sheets and `ζ = ξ₀ + ξ₁`, taking `sheet1` of
+`τ w = ∂₂ᶜ c = liftStab ξ₀ + σ(liftStab ξ₁)` gives
+`w = seamC ξ₀ + seamN ξ₁ = seamC ζ + ∂₂ᵇ ξ₁` (char 2). -/
+theorem exists_seamCoset_of_pull1_mem_boundaries {w : H × Fin 2 → ZMod 2}
+    (hbd : D.pull1 w ∈ D.coverComplex.boundaries) :
+    ∃ ζ : H → ZMod 2, bbBoundary2Fn D.Ab D.Bb ζ = 0 ∧
+      ∃ f : H → ZMod 2, w = D.seamC ζ + bbBoundary2Fn D.Ab D.Bb f := by
+  obtain ⟨c, hc⟩ := hbd
+  -- `hc : bbBoundary2Fn Ac Bc c = pull1 w` (unfold the boundary map)
+  have hc' : bbBoundary2Fn D.Ac D.Bc c = D.pull1 w := hc
+  set ξ₀ : H → ZMod 2 := D.sheetC2_0 c with hξ₀
+  set ξ₁ : H → ZMod 2 := D.sheetC2_1 c with hξ₁
+  refine ⟨ξ₀ + ξ₁, ?_, ξ₁, ?_⟩
+  · -- `ξ₀ + ξ₁ = p₀ c` is a base 2-cycle: `∂₂ᵇ (p₀ c) = p₁ (∂₂ᶜ c)
+    --  = p₁ (τ w) = 0`
+    have hsum : ξ₀ + ξ₁ = fiberSumFn (⇑D.proj) c := by
+      funext h
+      rw [Pi.add_apply]
+      exact D.sheetC2_0_add_sheetC2_1 c h
+    have hcomm := D.push_boundary2_comm c
+    have hzero : D.push1 (D.pull1 w) = 0 := D.push1_pull1_eq_zero w
+    have hpush2 : D.baseComplex.boundary2 (D.push0 c) = 0 := by
+      rw [← hcomm]
+      change D.push1 (bbBoundary2Fn D.Ac D.Bc c) = 0
+      rw [hc']
+      exact hzero
+    rw [hsum]
+    exact hpush2
+  · -- decompose the boundary witness sheet-wise and take `sheet1`
+    have hdec := D.liftC2_decomp c
+    have hboundary : bbBoundary2Fn D.Ac D.Bc c
+        = D.liftStab ξ₀ + D.deckShift1 (D.liftStab ξ₁) := by
+      conv_lhs => rw [hdec]
+      rw [bbBoundary2Fn_add]
+      rw [D.liftStab_deckShift ξ₁]
+      rfl
+    -- apply `sheet1` to both sides of `τ w = liftStab ξ₀ + σ (liftStab ξ₁)`
+    have hs1 : D.sheet1 (D.pull1 w)
+        = D.sheet1 (D.liftStab ξ₀) + D.sheet1 (D.deckShift1 (D.liftStab ξ₁)) := by
+      rw [← hc', hboundary, D.sheet1_add]
+    rw [D.sheet1_pull1, D.sheet1_deckShift1] at hs1
+    -- `sheet1 (liftStab ξ₀) = seamC ξ₀`, `sheet0 (liftStab ξ₁) = seamN ξ₁`
+    have hs1' : w = D.seamC ξ₀ + D.seamN ξ₁ := hs1
+    -- char 2: `seamN ξ₁ = ∂₂ᵇ ξ₁ + seamC ξ₁`
+    have hseamN : D.seamN ξ₁ = bbBoundary2Fn D.Ab D.Bb ξ₁ + D.seamC ξ₁ := by
+      have hkey : ∀ a b c : ZMod 2, a + b = c → a = c + b := by decide
+      funext j
+      exact hkey _ _ _ (D.seamN_add_seamC ξ₁ j)
+    rw [hs1', hseamN, D.seamC_add]
+    abel
+
+/-- **The seam transfer kernel (L0, chain form)**: a base 1-chain pulls
+back to a cover boundary **iff** it lies in a seam coset.  This is the
+connecting-map slot `im δ₂ = ker τ₁` of the transfer LES at chain level
+(the H₁-quotient packaging of the reverse slot is
+`BBTransferH1.ker_pushH1_eq_range_pullH1`). -/
+theorem pull1_mem_boundaries_iff_seamCoset (w : H × Fin 2 → ZMod 2) :
+    D.pull1 w ∈ D.coverComplex.boundaries
+      ↔ ∃ ζ : H → ZMod 2, bbBoundary2Fn D.Ab D.Bb ζ = 0 ∧
+          ∃ f : H → ZMod 2, w = D.seamC ζ + bbBoundary2Fn D.Ab D.Bb f := by
+  constructor
+  · exact D.exists_seamCoset_of_pull1_mem_boundaries
+  · rintro ⟨ζ, hζ, f, rfl⟩
+    exact D.pull1_seamCoset_mem_boundaries hζ f
+
+/-! ## The pushforward bound (T2) -/
+
+/-- **T2, membership form**: under the deck homotopy (R), the pushforward
+of every cover 1-cycle lies in a seam coset — `τ(p v) = v + σv` is a
+cover boundary, so L0 applies. -/
+theorem push1_mem_seamCoset_of_deckTrivial (hR : D.DeckTrivialOnH1)
+    {v : G × Fin 2 → ZMod 2} (hv : v ∈ D.coverComplex.cycles) :
+    ∃ ζ : H → ZMod 2, bbBoundary2Fn D.Ab D.Bb ζ = 0 ∧
+      ∃ f : H → ZMod 2,
+        D.push1 v = D.seamC ζ + bbBoundary2Fn D.Ab D.Bb f := by
+  apply D.exists_seamCoset_of_pull1_mem_boundaries
+  rw [D.pull1_push1 v]
+  exact hR v hv
+
+/-- **T2, weight form (the wall inheritance)**: a cover 1-cycle of weight
+`< m` whose pushforward is not a base boundary refutes
+`SeamCosetFloor m` — the safe floor inherits the cover's safe-sector
+failure at no weight cost (`d_safe ≤ d̃_safe`).  Converse direction to
+`safeFloor_of_seamCosetFloor`. -/
+theorem not_seamCosetFloor_of_light_cover_cycle (hR : D.DeckTrivialOnH1)
+    {v : G × Fin 2 → ZMod 2} (hv : v ∈ D.coverComplex.cycles)
+    (hpush : D.push1 v ∉ D.baseComplex.boundaries)
+    {m : ℕ} (hm : D.coverComplex.chainWeight v < m) :
+    ¬ D.SeamCosetFloor m := by
+  intro hSF
+  obtain ⟨ζ, hζ, f, heq⟩ := D.push1_mem_seamCoset_of_deckTrivial hR hv
+  have hfloor := hSF ζ hζ f (heq ▸ hpush)
+  rw [← heq] at hfloor
+  exact absurd (le_trans hfloor (D.chainWeight_push_le v))
+    (not_le.mpr hm)
+
+/-! ## The deficit wall: odd-step upgrades of the floors -/
+
+/-- Every seam-coset element is a base 1-cycle. -/
+lemma seamCoset_mem_cycles {ζ : H → ZMod 2}
+    (hζ : bbBoundary2Fn D.Ab D.Bb ζ = 0) (f : H → ZMod 2) :
+    D.seamC ζ + bbBoundary2Fn D.Ab D.Bb f ∈ D.baseComplex.cycles :=
+  Submodule.add_mem _ (D.seamC_mem_cycles hζ)
+    (D.baseComplex.boundaries_le_cycles ⟨f, rfl⟩)
+
+/-- **The deficit wall (seam-coset form).** Under the parity hypothesis,
+the seam-coset floor at `m − 1` upgrades to `m` for even `m`: every
+coset element is a cycle, hence of even weight, so weight `≥ m − 1`
+forces weight `≥ m`.  Contrapositive: an SF-failing cell at even target
+`m` already fails at `m − 1`, i.e. **the maximal failing value is
+`m − 2`.** -/
+theorem seamCosetFloor_of_even_of_pred
+    (hA : ∑ h : H, D.Ab h = 1) (hB : ∑ h : H, D.Bb h = 1)
+    {m : ℕ} (hm : Even m)
+    (h : D.SeamCosetFloor (m - 1)) : D.SeamCosetFloor m := by
+  intro ζ hζ f hnb
+  have hfloor := h ζ hζ f hnb
+  have heven : Even (D.baseComplex.chainWeight
+      (D.seamC ζ + bbBoundary2Fn D.Ab D.Bb f)) :=
+    D.base_cycle_weight_even hA hB (D.seamCoset_mem_cycles hζ f)
+  obtain ⟨s, hs⟩ := hm
+  obtain ⟨t, ht⟩ := heven
+  omega
+
+/-- **The deficit wall (safe-floor form).** Same upgrade for the
+cover-side `SafeFloor`: safe-sector cover cycles have even weight. -/
+theorem safeFloor_of_even_of_pred
+    (hA : ∑ h : H, D.Ab h = 1) (hB : ∑ h : H, D.Bb h = 1)
+    {m : ℕ} (hm : Even m)
+    (h : D.SafeFloor (m - 1)) : D.SafeFloor m := by
+  intro v hv hpush
+  have hfloor := h v hv hpush
+  have heven : Even (D.coverComplex.chainWeight v) :=
+    D.cover_cycle_weight_even hA hB hv
+  obtain ⟨s, hs⟩ := hm
+  obtain ⟨t, ht⟩ := heven
+  omega
+
+end XDoubleCoverData
+
+end BB
+end Homological
+end Stabilizer
+end Quantum

--- a/experiments/bb_lab/data/a15/deficit_wall_checks.json
+++ b/experiments/bb_lab/data/a15/deficit_wall_checks.json
@@ -1,0 +1,316 @@
+{
+ "L0": {
+  "pair72-x": {
+   "dim_im_delta2": 2,
+   "dim_ker_tau1": 2,
+   "dim_union": 2,
+   "k": 4,
+   "k_cover": 4
+  },
+  "gross-x": {
+   "dim_im_delta2": 6,
+   "dim_ker_tau1": 6,
+   "dim_union": 6,
+   "k": 12,
+   "k_cover": 12
+  },
+  "hit3-y": {
+   "dim_im_delta2": 6,
+   "dim_ker_tau1": 6,
+   "dim_union": 6,
+   "k": 12,
+   "k_cover": 12
+  },
+  "bb90-x": {
+   "dim_im_delta2": 4,
+   "dim_ker_tau1": 4,
+   "dim_union": 4,
+   "k": 8,
+   "k_cover": 8
+  },
+  "bb90-y": {
+   "dim_im_delta2": 4,
+   "dim_ker_tau1": 4,
+   "dim_union": 4,
+   "k": 8,
+   "k_cover": 8
+  },
+  "bb108-y": {
+   "dim_im_delta2": 4,
+   "dim_ker_tau1": 4,
+   "dim_union": 4,
+   "k": 8,
+   "k_cover": 8
+  },
+  "bb108-u18": {
+   "dim_im_delta2": 4,
+   "dim_ker_tau1": 4,
+   "dim_union": 4,
+   "k": 8,
+   "k_cover": 8
+  },
+  "bb288-y": {
+   "dim_im_delta2": 6,
+   "dim_ker_tau1": 6,
+   "dim_union": 6,
+   "k": 12,
+   "k_cover": 12
+  },
+  "bb288-c48b": {
+   "dim_im_delta2": 6,
+   "dim_ker_tau1": 6,
+   "dim_union": 6,
+   "k": 12,
+   "k_cover": 12
+  }
+ },
+ "L1": {
+  "pair72-x": {
+   "seam_weights": [
+    12,
+    12
+   ]
+  },
+  "gross-x": {
+   "seam_weights": [
+    12,
+    12,
+    12,
+    14,
+    12,
+    12
+   ]
+  },
+  "bb90-y": {
+   "seam_weights": [
+    10,
+    10,
+    20,
+    20
+   ]
+  },
+  "bb108-y": {
+   "seam_weights": [
+    18,
+    18,
+    24,
+    24
+   ]
+  },
+  "bb108-u18": {
+   "seam_weights": [
+    26,
+    26,
+    28,
+    26
+   ]
+  },
+  "bb288-y": {
+   "seam_weights": [
+    56,
+    56,
+    60,
+    56,
+    60,
+    60
+   ]
+  }
+ },
+ "L2": {
+  "pair72-x": {
+   "n_min_logicals": 18,
+   "exhausted": true,
+   "kz_sizes": {
+    "6": 18
+   },
+   "stab0_sizes": {
+    "6": 18
+   },
+   "freeze": false,
+   "U": null
+  },
+  "gross-x": {
+   "n_min_logicals": 84,
+   "exhausted": true,
+   "kz_sizes": {
+    "1": 72,
+    "3": 12
+   },
+   "stab0_sizes": {
+    "1": 72,
+    "3": 12
+   },
+   "freeze": false,
+   "U": null
+  },
+  "hit3-y": {
+   "n_min_logicals": 84,
+   "exhausted": true,
+   "kz_sizes": {
+    "1": 72,
+    "3": 12
+   },
+   "stab0_sizes": {
+    "1": 72,
+    "3": 12
+   },
+   "freeze": false,
+   "U": null
+  },
+  "bb90-y": {
+   "n_min_logicals": 100,
+   "exhausted": false,
+   "kz_sizes": {
+    "5": 54,
+    "45": 19,
+    "15": 27
+   },
+   "stab0_sizes": {
+    "5": 100
+   },
+   "freeze": true,
+   "U": 10
+  },
+  "bb108-y": {
+   "n_min_logicals": 54,
+   "exhausted": true,
+   "kz_sizes": {
+    "6": 54
+   },
+   "stab0_sizes": {
+    "6": 54
+   },
+   "freeze": false,
+   "U": null
+  }
+ },
+ "T2": {
+  "bb108-y": {
+   "bound": 18,
+   "verdict": "SAT",
+   "time_s": 4.6,
+   "cover_weight": 18,
+   "push_weight": 18,
+   "push_nonzero": true,
+   "push_safe": true
+  },
+  "bb90-y": {
+   "bound": 10,
+   "verdict": "SAT",
+   "time_s": 0.0,
+   "cover_weight": 10,
+   "push_weight": 10,
+   "push_nonzero": true,
+   "push_safe": true
+  },
+  "bb90-x": {
+   "bound": 18,
+   "verdict": "SAT",
+   "time_s": 0.0,
+   "cover_weight": 18,
+   "push_weight": 12,
+   "push_nonzero": true,
+   "push_safe": true
+  },
+  "bb108-u18": {
+   "bound": 18,
+   "verdict": "SAT",
+   "time_s": 0.2,
+   "cover_weight": 16,
+   "push_weight": 16,
+   "push_nonzero": true,
+   "push_safe": true
+  },
+  "pair72-x": {
+   "bound": 8,
+   "verdict": "SAT",
+   "time_s": 0.0,
+   "cover_weight": 8,
+   "push_weight": 8,
+   "push_nonzero": true,
+   "push_safe": true
+  },
+  "gross-x": {
+   "bound": 12,
+   "verdict": "SAT",
+   "time_s": 0.3,
+   "cover_weight": 12,
+   "push_weight": 12,
+   "push_nonzero": true,
+   "push_safe": true
+  },
+  "hit3-y": {
+   "bound": 12,
+   "verdict": "SAT",
+   "time_s": 0.2,
+   "cover_weight": 12,
+   "push_weight": 12,
+   "push_nonzero": true,
+   "push_safe": true
+  }
+ },
+ "W": {
+  "bb90-y": {
+   "floor_minus_1": 9,
+   "status": "CERTIFIED",
+   "verdicts": [
+    {
+     "rep": 0,
+     "verdict": "UNSAT",
+     "weight": null
+    },
+    {
+     "rep": 1,
+     "verdict": "UNSAT",
+     "weight": null
+    },
+    {
+     "rep": 2,
+     "verdict": "UNSAT",
+     "weight": null
+    }
+   ],
+   "s0_min": 10
+  },
+  "bb108-y": {
+   "ladder": "upper",
+   "value": 14
+  },
+  "orbit_scan": [
+   {
+    "A": "y + y^2 + x^3",
+    "B": "1 + x^4 + x^5*y^3",
+    "axis": "x",
+    "ladder": "upper",
+    "value": 12
+   },
+   {
+    "A": "y + y^2 + x^3",
+    "B": "x + x^5 + x^6*y^3",
+    "axis": "x",
+    "ladder": "upper",
+    "value": 12
+   },
+   {
+    "A": "y + y^2 + x^3",
+    "B": "x^2 + x^6 + x^7*y^3",
+    "axis": "x",
+    "ladder": "upper",
+    "value": 12
+   },
+   {
+    "A": "y + y^2 + x^3",
+    "B": "x^3 + x^7 + x^8*y^3",
+    "axis": "x",
+    "ladder": "upper",
+    "value": 12
+   }
+  ]
+ },
+ "summary": {
+  "passed": 25,
+  "total": 25,
+  "failed": [],
+  "wall_s": 4675.3
+ }
+}

--- a/experiments/bb_lab/notes/A14_safe_floor_criterion_plan.md
+++ b/experiments/bb_lab/notes/A14_safe_floor_criterion_plan.md
@@ -673,6 +673,15 @@ safe-floor ceiling is 18 < 20**, matching the stored-y deficit-2 miss
 (and the actual weight-18 cover logical of §14). The rescue that saved
 hit3 (A11) does not materialize for bb_108 at this equivalence depth.
 
+> **A15 correction (2026-07-06).** The *rejection verdict* of every cell
+> stands (each certificate is a genuine coset element below the floor),
+> but the recorded refutation *weights* here and in §16 are first-found
+> SAT witness weights at the query bound — upper bounds, not minima —
+> and the "orbit ceiling 18" reading overstates the orbit: exact
+> descending ladders put the stored-y cell and every sampled finalist
+> strictly below 18. See `A15_deficit_wall.md` §8 for the corrected
+> exact values and the theorem that pins what the true ceiling can be.
+
 Structural readings:
 
 - **Condition 2 is strongly presentation-sensitive**: the stored
@@ -750,6 +759,25 @@ safe-floor minimum` to `2d − 2` for non-doubling BB codes? (Note
 `2d − 2 = 2(d − 1)` — suggestive of a weight-(d−1)-ish base object
 whose double-cover shadow lands in the safe sector; connects to the
 overlap-rescue math and the closed-form-S0 residue.)
+
+> **A15 resolution + correction (2026-07-06,
+> `A15_deficit_wall.md`).** Answered in corrected form. The *value* is
+> a theorem: with weight-3 polynomials every 1-cycle is even
+> (augmentation), and `d_safe = 2d ⟺ SF`, so `2d − 2` is the unique
+> maximal SF-failing value — parity is the whole "parity/duality
+> mechanism". The *mechanism* is a pushforward, not a base object:
+> under (R), `im p₁ = im δ₂` makes the projection of any
+> surviving-class cover logical a safe base logical
+> (`d_safe ≤ d̃_safe`), so a safe-sector failure upstairs is inherited
+> downstairs at no weight cost; the hypothesized `2(d−1)` base object
+> (two overlapping translates of a min-weight logical) is provably
+> *absent* on bb_108 — all 54 minimum-weight logicals have collision
+> group `K_z = Stab₀`. And the "stalls at *exactly* 2d − 2" premise
+> was a measurement artifact: these paragraphs' 18s and 34s are
+> first-found witness weights, not minima (exact ladders: stored-y
+> and all sampled finalists sit strictly lower). The honest residue
+> is the code invariant `maxSF ∈ {2d} ∪ {even ≤ 2d − 2}` and the
+> (M)-robustness conjecture. See A15 §§6–9.
 
 **Hunt verdict for d > 12 by literal-lift doubling of corpus codes:
 negative in every probed direction** — stored forms (§14), same-axis

--- a/experiments/bb_lab/notes/A15_deficit_wall.md
+++ b/experiments/bb_lab/notes/A15_deficit_wall.md
@@ -1,0 +1,386 @@
+# A15 — The deficit wall: theorem, mechanism, and a measurement correction
+
+**Status: theorem package PROVED and machine-validated (final battery
+25/25 green; the first run's two "failures" were the §8 discoveries);
+the A14 §16 OQ is answered in a corrected form.** The wall *value* is a
+theorem: under (R)
+and odd polynomial weights, `d_safe` is even and `d_safe = 2d` is
+equivalent to safe-half viability, so **`2d − 2` is the unique maximal
+SF-failing value** — nothing between `2d − 1` and viability is
+achievable. The wall *mechanism* is the pushforward: under (R) the
+projection of any cover logical with surviving class is itself a
+safe-sector base logical (`im p₁ = im δ₂`), so a cover that fails to
+double through its safe sector hands the safe floor a witness at no
+weight cost (`d_safe ≤ d̃_safe`). The empirical sharpening "the orbit
+maximum stalls at *exactly* `2d − 2`" is **retracted as a measurement
+artifact**: the §15/§16 "ceiling 18" readings were first-found SAT
+witness weights, not certified minima; exact ladders (this session) put
+the stored bb108-y cell at `d_safe = 14 = 2d − 6` — certified on both
+sides of the cover, with the T2 coupling tight at `14 = 14` — and every
+ladder-sampled orbit finalist at `≤ 12`; the corrected table is in §8.
+This note is **phase P3 of the A15 d≥7 doubling-hunt plan**
+(`A15_d7plus_doubling_hunt_plan.md`, drafted in a sibling worktree; the
+plan's "2(d−1) shadow hypothesis" is settled here — refuted as stated,
+replaced by the pushforward mechanism — and its P1 corpus battery
+should report S4 weights as "≤" bounds per §8).
+Branch: `claude/charming-euler-ef6879` (off `main` after PR #55).
+Script: [`a15_deficit_wall_checks.py`](../scripts/a15_deficit_wall_checks.py);
+data: `data/a15/deficit_wall_checks.json`.
+
+## 0. The question (A14 §16, verbatim)
+
+> **The recurring shape — a "deficit wall" just below 2d.** In every
+> probed direction, the orbit-maximum safe floor stalls a hair under the
+> target: bb_108 at 18 vs 20 (both decompositions, hundreds of
+> presentations), bb_288 at 32–34 vs 36 (strongest sampled cells). [...]
+> Candidate new OQ: is there a parity/duality mechanism pinning `max over
+> presentations of the safe-floor minimum` to `2d − 2` for non-doubling
+> BB codes? (Note `2d − 2 = 2(d − 1)` — suggestive of a
+> weight-(d−1)-ish base object whose double-cover shadow lands in the
+> safe sector; connects to the overlap-rescue math and the
+> closed-form-S0 residue.)
+
+Answer, in three parts. **(a) Yes — parity pins the value**, and it is a
+one-line theorem (L1 below): with weight-3 polynomials every 1-cycle has
+even weight, so an SF-failing cell can sit at `2d − 2` and no higher.
+**(b) The mechanism is a pushforward, not a base object**: the
+weight-`(2d−2)`-ish object whose "double-cover shadow lands in the safe
+sector" is really a *cover* logical whose *base shadow* is the safe
+element (T2 below); the natural base-side guess (two overlapping
+translates of a minimal logical — the difference-class mechanism T1) is
+provably available only under an index condition and is *measurably
+silent* on bb_108 (§7). **(c) The sharp empirical premise was an
+artifact**: the recorded 18s and 34s were solver witness weights (upper
+bounds), not minima; the corrected picture is in §8. What survives of
+the recurrence is exactly what the theorem forces: even values `≤ 2d−2`
+for every failing cell, `= 2d` for every viable one.
+
+## 1. Setting and the object
+
+Conventions of A12 §1 / A14 §1, with the doubled axis canonicalized to
+x: base `G = Z_ℓ × Z_m`, `R = F₂[G]`; `A, B ∈ R`; base Koszul complex
+
+```
+K̄ :  R --∂₂--> R² --∂₁--> R,   ∂₂ f = (Af, Bf),   ∂₁(u,v) = Bu + Av,
+```
+
+`H₁ = ker ∂₁ / im ∂₂`, `k = dim H₁`, `d = min{|w| : w ∈ ker ∂₁ \ im ∂₂}`.
+Cover `G̃ = Z_{2ℓ} × Z_m` with the same-exponent lifts `Ã, B̃`; complex
+`K`; `ε = 1 + x^ℓ`; transfer `τ = ε·lift : K̄ → K` and pushforward
+`p = mod-ε : K → K̄` give the SES `0 → K̄ →^τ K →^p K̄ → 0` and its LES.
+**(R)**: `ε ∈ (Ã, B̃)` ⟺ `k̃ = k` (A12). Under (R), Prop A14.1 gives
+`p₂ = 0`, `δ₂` injective, `dim im δ₂ = k/2`, `im p₁ = im δ₂`, and the
+seam-carry representatives `seamC ζ` for `δ₂[ζ]`.
+
+**Definition (safe sector, safe distance).** The safe sector is
+`S := im δ₂ ⊆ H₁(K̄)` and
+
+```
+d_safe := min{ |w| : w ∈ ker ∂₁,  [w] ∈ S \ 0 }.
+```
+
+By A14.1(3)+(5) this is exactly the quantity the lab measures (the
+minimum over `ζ ∈ ker ∂₂ \ 0` of the coset minima
+`min_f |seamC ζ + ∂₂ f|`), A14 §3's "imΔ-distance". The safe half of the
+doubling template is `SF ⟺ SeamCosetFloor (2d) ⟺ d_safe ≥ 2d`.
+
+Throughout, "the parity hypothesis" means `|A|` and `|B|` are both odd
+(all Bravyi-corpus BB pairs have weight 3+3).
+
+## 2. Lemma L0 (the safe sector is the transfer kernel)
+
+**Lemma.** `S = ker(τ₁ : H₁(K̄) → H₁(K))`. Concretely: a base logical
+class is safe **iff its transfer to the cover is a cover boundary** —
+`[w] ∈ S ⟺ ε·w̃ ∈ im ∂̃₂` for any lift `w̃`. (No hypothesis beyond the
+SES; under (R) the common dimension is `k/2`.)
+
+*Proof.* LES exactness at the `H₁(K̄)` slot between `δ₂` and `τ₁`:
+`im δ₂ = ker τ₁`. The chain-level transfer `τ(w) = ε·w̃` is independent
+of the lift (two lifts differ by an element of `ker p = εR̃`, killed by
+`ε` since `ε² = 0` on the free cover), and `τ₁[w] = [ε·w̃]`, which
+vanishes iff `ε·w̃ ∈ im ∂̃₂`. ∎
+
+This is the reframing everything below uses: **the safe floor is the
+minimum weight of a logical that dies in the double cover.** The battery
+check `L0/*` verifies span equality `im δ₂ = ker τ₁` (not just
+dimensions) on nine covers including both bb_288 presentations and the
+Z₁₈×Z₃ re-decomposition of bb_108.
+
+## 3. Lemma L1 (parity) — the wall value
+
+**Lemma.** Under the parity hypothesis, every 1-cycle of `K̄` *and* of
+`K` has even weight. Consequently `d`, `d̃ = d(cover)`, `d_safe`, and
+every safe-class coset minimum are even.
+
+*Proof.* The augmentation `η : F₂[H] → F₂`, `η(f) = |f| mod 2`, is a
+ring homomorphism for any finite abelian `H`. If `∂₁(u,v) = Bu + Av = 0`
+then `Bu = Av`, so `η(B)η(u) = η(A)η(v)`; with `η(A) = η(B) = 1` this
+gives `|u| ≡ |v| (mod 2)`, hence `|(u,v)| = |u| + |v|` even. The lifts
+have the same weights, so the same argument runs in `K`. ∎
+
+(The same augmentation step appears in A8 §4.2 to kill odd-weight
+stabilizers; the observation here is that it applies to *all cycles* of
+both complexes at once. The hypothesis is load-bearing: toric-type pairs
+with `|A| = |B| = 2` have odd-weight cycles — the vertical loop on an
+odd-`L` torus — and their freeze values can be odd.)
+
+**Corollary (the wall value).** Under (R) + parity, for every
+presentation cell exactly one of:
+
+- `d_safe = 2d` — but see §5's converse: this *is* safe-half viability
+  and forces the cover's safe sector to clear `2d`; or
+- `d_safe ≤ 2d − 2` — SF fails, and the failure value is even.
+
+There is no failing value in `{2d − 1}` and none above `2d` matters for
+the template, so **`2d − 2` is the unique maximal SF-failing value: the
+deficit wall.** (Values `> 2d` are not excluded by parity alone, but
+`d_safe > 2d` never occurs on any measured instance — the doublers all
+sit at exactly `2d` — and §5's T2 explains why: the cover's own
+tightness witnesses push down onto safe classes of weight ≤ 2d whenever
+the safe sector is achieved upstairs, which the battery verifies on
+every doubler tested.)
+
+## 4. Lemma L2 + Theorem T1 (collision subgroups and difference classes)
+
+For a base 1-cycle `z` put
+
+```
+Stab₀(z) = {g ∈ G : [gz] = [z]},     K_z = {g ∈ G : (1+g)[z] ∈ S}.
+```
+
+**Lemma L2.** `H₁` is an `R`-module and `S` an `R`-submodule;
+`Stab₀(z) ⊆ K_z` are subgroups of `G`; the map
+`gK_z ↦ [gz] + S` is a well-defined injection `G/K_z ↪ H₁/S`; and under
+(R), `[G : K_z] ≤ 2^{k/2}`.
+
+*Proof.* `S = ker τ₁` is a submodule because `τ₁` is `R`-linear:
+`τ₁(r·α) = r̃·τ₁(α)` for any lift `r̃` (well-defined — two lifts differ
+in `(ε)`, and `ε` kills `im τ₁`). Subgroup closure of `K_z`:
+`(1+gh)[z] = (1+g)[z] + g·((1+h)[z]) ∈ S + g·S = S`, and
+`(1+g⁻¹)[z] = g⁻¹·((1+g)[z]) ∈ S`; `Stab₀ ⊆ K_z` since `0 ∈ S`.
+Injectivity and well-definedness: `[gz] ≡ [g′z] (mod S)` ⟺
+`g·(1 + g⁻¹g′)[z] ∈ S` ⟺ `g⁻¹g′ ∈ K_z` (unit action preserves the
+submodule). The index bound: `G/K_z` injects into `H₁/S`, which has
+`2^{k − dim S} = 2^{k/2}` elements under (R). ∎
+
+**Theorem T1 (difference-class bound).** (R); `z` a minimum-weight
+logical. If `K_z ⊋ Stab₀(z)` — in particular whenever
+`[G : Stab₀(z)] > 2^{k/2}`, by the index bound — then for any
+`h ∈ K_z \ Stab₀(z)`,
+
+```
+0 ≠ (1+h)[z] ∈ S   and   d_safe ≤ |z + hz| = 2d − 2·|supp z ∩ supp hz| ≤ 2d.
+```
+
+*Proof.* Immediate from L2 and inclusion–exclusion on supports; the "in
+particular" holds because `[G:K_z] ≤ 2^{k/2} < [G:Stab₀]` forces the
+proper containment. ∎
+
+**Measured status (battery `L2/*`, `T1/*`).** The subgroup structure and
+index bound hold on every tested instance. But the mechanism *fires*
+only where `K_z ⊋ Stab₀`: on bb90-y (`|K_z| ∈ {15,45} ⊋ |Stab₀| = 5`,
+difference bound `U = 10`, tight at the freeze value) — while on
+pair72-x, gross-x, hit3-y, and **bb108-y the census gives `K_z = Stab₀`
+exactly for every minimum-weight logical** (18, 84, 84, 54 of them,
+exhaustively enumerated). So the natural base-side guess for the wall
+witness — two overlapping translates of a minimal logical, the
+`2(d−1)`-shaped object A14 §16 hypothesized — is **provably absent** on
+the very code that motivated the OQ. The wall needs T2.
+
+## 5. Theorem T2 (the pushforward mechanism)
+
+Write `d̃_safe := min{ |ṽ| : ṽ a cover logical with p₁[ṽ] ≠ 0 }` — the
+cover's **safe-sector minimum** (A8 §4's "safe sector" of the cover; its
+complement, `p₁[ṽ] = 0`, is the dangerous/diagonal sector handled by the
+template's other half).
+
+**Theorem T2.** Under (R): if `ṽ` is a cover 1-cycle with
+`p₁[ṽ] ≠ 0` and `|ṽ| ≤ W`, then `p(ṽ)` is a base logical with
+`[p(ṽ)] ∈ S \ 0` and `|p(ṽ)| ≤ |ṽ| ≤ W`. Hence
+
+```
+d_safe ≤ d̃_safe .
+```
+
+*Proof.* `p₁[ṽ] = [p(ṽ)] ∈ im p₁ = im δ₂ = S` by A14.1(2) (this is
+where (R) enters), and it is nonzero by hypothesis, so `p(ṽ)` is a
+cycle not in `im ∂₂`. The sheet inequality `|p(ṽ)| ≤ |ṽ|` is
+fiberwise: `p(ṽ) = ṽ₀ + ṽ₁` with `|ṽ₀ + ṽ₁| ≤ |ṽ₀| + |ṽ₁| = |ṽ|`. ∎
+
+**Corollary W (the wall, cell level).** (R) + parity.
+
+1. If the cover fails to double *through its safe sector*
+   (`d̃_safe < 2d`), then `d_safe ≤ d̃_safe ≤ 2d − 2`, with explicit
+   witness `p(ṽ)`: **the safe floor inherits the cover's failure at no
+   weight cost.**
+2. Conversely, if `d_safe ≥ 2d` (SF holds) then *every* cover logical
+   with surviving class weighs `≥ 2d`: `|ṽ| ≥ |p(ṽ)| ≥ d_safe ≥ 2d`.
+   So an SF-viable cell can only fail to double in the dangerous sector
+   (`p₁[ṽ] = 0`) — which is precisely the sector the template's
+   witness/(M) half floors. **SF + (M) ⟹ doubling** is the template,
+   re-derived; and "SF-true ⟹ doubles" (A11's empirical 111/111)
+   holds exactly when the dangerous sector never under-runs `2d` alone
+   (the (M)-robustness conjecture, §9).
+
+*Proof.* (1) T2 at `W = d̃_safe`; `d̃_safe` is even by L1 (its
+minimizers are cover cycles), so `< 2d` means `≤ 2d − 2`. (2) is the
+displayed inequality: the middle term is a representative of a nonzero
+class of `S`. ∎
+
+**Measured status (battery `T2/*`).** On the failing cells the safe
+sector is achieved upstairs at the wall: bb108-y has a weight-18 cover
+logical with `p₁ ≠ 0` pushing to a weight-18 safe base logical (3.2 s
+SAT; overlap-free, `|p(ṽ)| = |ṽ|`); bb90-y the same at weight 10 = d
+(the freeze, seen from above: the cover's light safe-sector logical *is*
+the undoubled-direction logical of A14 §13, and its shadow is the safe
+class); bb90-x at 18 → 12 (three overlapping fiber pairs); the
+re-decomposed bb108-u18 at 16 → 16. On the doublers the probe is SAT at
+exactly `2d` with `|p(ṽ)| = 2d` and safe (pair72-x 8→8, gross-x 12→12,
+hit3-y 12→12): their tight `d_safe = 2d` classes lift overlap-free, so
+`d̃_safe = 2d = d_safe` — **the coupling `d_safe ≤ d̃_safe` is tight in
+every measured instance, doublers and failers alike.**
+
+## 6. The deficit-wall theorem, assembled
+
+**Theorem (deficit wall).** Let `(A, B)` be a BB pair with `|A|, |B|`
+odd, `d = d(base) ≥ 2`, and consider any literal-lift `Z₂` cover
+satisfying (R). Then:
+
+1. `d_safe` is even, and `d_safe ≥ 2d ⟺ SF` (safe-half viability).
+2. If SF fails, `d_safe ≤ 2d − 2`: **the wall value `2d − 2` is the
+   unique maximal SF-failing value.**
+3. `d_safe ≤ d̃_safe` (pushforward); in particular a cell whose cover
+   has any light safe-sector logical fails SF at that weight or less,
+   and an SF-viable cell forces the cover's entire safe sector to
+   `≥ 2d`.
+4. Where `K_z ⊋ Stab₀(z)` for a minimum-weight `z` (guaranteed if
+   `[G : Stab₀(z)] > 2^{k/2}`), additionally
+   `d_safe ≤ 2d − 2·max{|supp z ∩ supp hz| : h ∈ K_z \ Stab₀}`.
+5. **Orbit form.** For a code none of whose presentation cells is
+   SF-viable, the orbit maximum of `d_safe` is an even number
+   `≤ 2d − 2`. Its exact value is a code-level invariant *not* pinned
+   by this theorem; §8 records the corrected measurements (the
+   previously reported "exactly `2d − 2`" readings were witness-weight
+   artifacts).
+
+All parts are proved above (1: L1+definition; 2: L1; 3: T2/W; 4: T1;
+5: 1–2 applied cell-wise).
+
+## 7. Validation battery
+
+`uv run python scripts/a15_deficit_wall_checks.py` (~minutes;
+SAT-witness ladders plus bounded UNSAT attempts; `--expensive`
+reproduces the 5-h cover certificate). The battery ran twice in this
+fork: the *first* run scored 23/25 with its two "failures" being the
+exactness pins written for the old "ceiling = 18" reading — they
+correctly refused to certify it (SAT@17 returned weight-16 witnesses;
+one finalist at 12), which is how §8's correction was discovered. The
+committed battery asserts the corrected claims and is green.
+
+| check | covers | result |
+|---|---|---|
+| L0 span equality `im δ₂ = ker τ₁`, dim `k/2` | pair72-x, gross-x, hit3-y, bb90-x/y, bb108-y, bb108-u18 (Z₁₈×Z₃), bb288-y, bb288-c48b | 9/9 PASS |
+| L1 parity (200 random cycles/complex + seams) | 6 covers | PASS (all seam weights even) |
+| L2 `K_z` subgroup + index ≤ `2^{k/2}` | 5 covers, exhaustive min-logical enumerations (18/84/84/≥100/54) | PASS |
+| T1 census | bb90-y fires (`U = 10`); pair72/gross/hit3/bb108-y: `K_z = Stab₀`, silent | as stated |
+| T2 gating | bb108-y @18 (18→18), bb90-y @10 (10→10) | PASS |
+| T2 probes | bb90-x 18→12; bb108-u18 16→16; pair72 8→8; gross 12→12; hit3 12→12 (all safe, all SAT) | recorded |
+| W ladders | bb90-y: `d_safe = 10 = d` **certified** (UNSAT@9 all reps + seam@10); bb108-y: descent lands < 18 (14 with the §8 certificates); 4-finalist sample: all even, ≤ 12 | PASS |
+
+Independent corroborations along the way: gross's 84 weight-6 logicals
+are exhaustively re-enumerated and none is safe (matches A_HANDOFF's
+"imΔ-distance 12 while d = 6"); hit3-y matches gross's `K_z` structure
+exactly (they share a base up to presentation); bb108-x's stored
+condition-2 death and the u-axis's zero k-gate failures reproduce §14/§16.
+
+## 8. The measurement correction (exact ladders)
+
+The §15/§16 sweep protocol recorded, per refuted cell, the weight of the
+*first extracted SAT certificate* at the query bound (`floor − 1` or
+similar). Those are upper bounds on `d_safe`, not minima — CaDiCaL
+returns any model under the cardinality bound, and nothing in the
+pipeline pressed below it. The A15 exactness pins exposed this
+(`SAT@17` on the stored bb108-y cell returned a weight-**16** witness
+where "18" had been recorded, and likewise on all eight scanned orbit
+finalists — one of them at **12**). Descending ladders (SAT at `w` ⟹
+retry at `w_found − 2`, by parity; terminate at UNSAT) give the
+corrected values:
+
+| cell | historical reading | corrected (this session) | grade |
+|---|---|---|---|
+| bb90-y stored (freeze) | raw seam 10 | **d_safe = 10 = d exactly** | UNSAT@9 all reps, certified |
+| bb108-y stored | "light class at 18" (§14) | **d_safe = 14 = 2d − 6 exactly** | base: UNSAT@12 on all orbit reps (20M-conflict budget, ≈69 min); cover: `d̃_safe = 14` **exactly** (SAT@14 pushing 14→14 overlap-free; UNSAT@12, ≈5 h CaDiCaL at n=216) — the T2 coupling is tight at 14 = 14 |
+| bb108 v1 x-finalists | "S4-refuted at 12–18", ceiling 18 | first witnesses ≤ 16 (one 12) on 8 cells; **full ladders descend all four sampled cells to ≤ 12 = 2d − 8** | witness-grade; every value even, `< 18` — the cells whose *cheap tiers* stalled at 20 have true minima at 12 |
+| bb108-u18 stored (Z₁₈×Z₃) | "16/18 again" (§16) | **≤ 16** (cover T2 witness 16→16) | witness-grade |
+| bb288-y stored | "witness weight 34" | **≤ 34**, exact unmeasured | n=288 base / n=576 cover UNSAT priced out (the 5-h n=216 certificate calibrates the wall-region hardness) |
+| gross-x / hit3/4/6-y / pair72-x (doublers) | floors tight at 2d | **= 2d exactly**, and the cover safe sector is achieved at 2d with overlap-free lifts (`d̃_safe = 2d = d_safe`) | Lean/MIm + a14 S4 + this battery |
+
+Corrected empirical picture:
+
+- **No measured instance attains the wall.** The theorem allows
+  SF-failing cells anywhere in `{even ≤ 2d − 2}`; the historical
+  readings suggested the maximum `2d − 2` recurred across codes; the
+  exact values show bb_108's stored-y cell at `14 = 2d − 6` (certified
+  both sides) — currently the *largest* certified value anywhere in the
+  orbit — and every ladder-sampled finalist at `≤ 12 = 2d − 8`. The
+  "recurrence at exactly `2d − 2`" was the query bound reflecting back
+  through first-found witnesses.
+- **The freeze value is exact where the freeze mechanism runs** (bb90-y
+  `= 10 = d`): when a minimum-weight class is itself safe, the ladder
+  bottoms out at `d` immediately — T1's difference classes and T2's
+  pushforward agree on it from both sides.
+- **The doubling side is rigid**: every viable cell measured sits at
+  exactly `2d`, with the coupling `d_safe = d̃_safe` tight in both
+  directions. Nothing observed contradicts `d_safe ≤ 2d`
+  unconditionally, but the theorem as proved needs the safe sector
+  achieved upstairs (T2) or a firing collision subgroup (T1) to force
+  it; the corner where both mechanisms are silent remains open (§9).
+- **Solver-hardness clusters at the wall region.** UNSAT certificates
+  two below the true minimum are seconds on 54-cell frames but hours at
+  n = 216 (and out of reach at n ≥ 288) — the same "value-carrying
+  lightness" OQ4 predicted, now with a measured hardness profile. The
+  practical protocol: witness ladders always; UNSAT pins only where the
+  frame is small or the claim is load-bearing.
+
+## 9. Consequences and residue
+
+- **OQ status (A14 §16).** Answered as corrected: the wall *value* is a
+  theorem (§3, §6.2), the *mechanism* is the pushforward (§5), the
+  "exactly `2d − 2` across codes" recurrence was a witness-weight
+  artifact (§8). What recurs for real is: every failing cell at an even
+  value `≤ 2d − 2`, every viable cell at exactly `2d`, and the tight
+  coupling `d_safe = d̃_safe` in all measurements.
+- **The (M)-robustness conjecture (new, sharp).** On the T1 corpus every
+  k-preserving short is SF-false (465/465) — no cover ever failed
+  *only* dangerously. Conjecture: for corpus-class BB pairs the
+  dangerous sector never under-runs `min(2d, d̃_safe)`. With §5.2 this
+  would make **SF ⟺ doubles** on k-preserving literal lifts a theorem,
+  and the wall statement unconditional. (A8 §4.2's data is consistent:
+  all `b ≠ 0` rungs clear the floor with margin, the binding rung is
+  the diagonal `b = 0`.)
+- **The attainment question, reopened correctly.** The code-level
+  invariant `maxSF(code) := max over orbit cells of d_safe` satisfies
+  `maxSF ∈ {2d} ∪ {even ≤ 2d − 2}`; bb_108's measured value is ≤ 16 on
+  every sampled cell (both decompositions' stored cells and 20/192 v1
+  finalists), i.e. the wall is not attained there and the pre-A15
+  "orbit ceiling 18" overstated the orbit by 2. What structural feature
+  sets `maxSF` (16-vs-18 for bb_108; the true value for bb_288) is the
+  honest residue of the deficit-wall OQ — now with the right definition
+  and tooling (`certify_dsafe` + descending ladders) to measure it.
+- **Hunt guidance.** The battery's screens are unaffected (screens only
+  ever claimed upper bounds — "necessity by construction" — and every
+  S0/S1/S2 rejection stands). But *reported refutation weights* from S4
+  should never be read as floors; `a14_s4_ladder.coset_query` callers
+  that log `weight` now have a documented descending-ladder recipe for
+  exact values.
+- **Lean package (queued; small).** `BBTransferH1.lean` already proves
+  the sibling LES slot `ker_pushH1_eq_range_pullH1`
+  (`ker p₁ = im τ₁`, both inclusions by the same mapQ/exactness-chase
+  idiom); L0 is the connecting-map slot `ker τ₁ = im δ₂` with `δ₂`
+  induced by the existing `BBCover.seamC`, and T2's input
+  `im p₁ = im δ₂` (A14.1(2), already the queued A14 Phase-3 target)
+  composes the two. L1 is the augmentation homomorphism plus two
+  rewrites. L2/T1 are finite group/module algebra over the existing
+  `H₁` quotient. The sheet inequality `|p(v)| ≤ |v|` is already the
+  `chainWeight`-level step inside `safeFloor_of_seamCosetFloor`
+  (`BBDoubling.lean`). None of it needs new native_decide content.

--- a/experiments/bb_lab/notes/A15_deficit_wall.md
+++ b/experiments/bb_lab/notes/A15_deficit_wall.md
@@ -373,14 +373,36 @@ Corrected empirical picture:
   should never be read as floors; `a14_s4_ladder.coset_query` callers
   that log `weight` now have a documented descending-ladder recipe for
   exact values.
-- **Lean package (queued; small).** `BBTransferH1.lean` already proves
-  the sibling LES slot `ker_pushH1_eq_range_pullH1`
-  (`ker p₁ = im τ₁`, both inclusions by the same mapQ/exactness-chase
-  idiom); L0 is the connecting-map slot `ker τ₁ = im δ₂` with `δ₂`
-  induced by the existing `BBCover.seamC`, and T2's input
-  `im p₁ = im δ₂` (A14.1(2), already the queued A14 Phase-3 target)
-  composes the two. L1 is the augmentation homomorphism plus two
-  rewrites. L2/T1 are finite group/module algebra over the existing
-  `H₁` quotient. The sheet inequality `|p(v)| ≤ |v|` is already the
-  `chainWeight`-level step inside `safeFloor_of_seamCosetFloor`
-  (`BBDoubling.lean`). None of it needs new native_decide content.
+- **Lean package: LANDED (same session), axiom-clean.**
+  `QEC/Stabilizer/Framework/Homological/BBDeficitWall.lean` (new module,
+  wired into the `Homological` umbrella; builds green with zero
+  warnings; flagship theorems check to the standard three axioms — no
+  `sorry`, no `native_decide`):
+  - **L1**: `sum_conv` (the augmentation is multiplicative on
+    convolutions), `cycle_support_even` (generic: odd-weight `A, B` ⟹
+    every 1-cycle has even support), instantiated as
+    `base_cycle_weight_even` / `cover_cycle_weight_even` (the cover
+    hypotheses *descend* through `push_A`/`push_B` — only the base
+    sums are assumed).
+  - **L0**: `pull1_seamC` (`τ(seamC ζ) = liftStab ζ`) and
+    `pull1_mem_boundaries_iff_seamCoset` — a base 1-chain pulls back
+    to a cover boundary **iff** it lies in a seam coset; the forward
+    chase descends the boundary witness through `liftC2_decomp` and
+    takes `sheet1`.  This is the connecting-map slot `im δ₂ = ker τ₁`
+    at chain level, sibling to `BBTransferH1.ker_pushH1_eq_range_pullH1`.
+  - **T2**: `push1_mem_seamCoset_of_deckTrivial` (under
+    `DeckTrivialOnH1`, i.e. from any `deckTrivial_of_bezout` witness,
+    every cover cycle's pushforward lies in a seam coset — proof:
+    `τ(p v) = v + σv` is a boundary) and
+    `not_seamCosetFloor_of_light_cover_cycle` (a cover cycle of weight
+    `< m` with non-boundary pushforward refutes `SeamCosetFloor m`) —
+    `d_safe ≤ d̃_safe` in the repo's own predicates, the converse
+    direction to `safeFloor_of_seamCosetFloor`.
+  - **The wall**: `seamCosetFloor_of_even_of_pred` and
+    `safeFloor_of_even_of_pred` — for even `m`, the floors at `m − 1`
+    upgrade to `m` for free, so **the unique maximal failing value of
+    an even target is `m − 2`**.
+  Not formalized (follow-up if ever needed): L2/T1 collision
+  subgroups (the mechanism is measurably silent on the codes that
+  matter), and A14.1(2)'s dimension count (T2 deliberately routes
+  around it via deck-triviality).

--- a/experiments/bb_lab/scripts/a15_deficit_wall_checks.py
+++ b/experiments/bb_lab/scripts/a15_deficit_wall_checks.py
@@ -1,0 +1,574 @@
+"""A15 deficit wall: validation battery for the theorem package.
+
+Companion to `notes/A15_deficit_wall.md` (the deficit-wall theorem: why the
+orbit-maximum safe floor of a non-doubling BB code stalls at exactly
+2d(base) - 2).  Check IDs below mirror the note's statement numbers.
+
+  L0  (transfer kernel)   im delta2 = ker tau1 on H1(base) — the safe sector
+      is exactly the set of classes killed by the transfer to the cover.
+  L1  (parity)            |A|, |B| odd  =>  every 1-cycle of base and cover
+      has even weight (augmentation argument); d, d~, d_safe all even.
+  L2  (collision group)   K_z = {g : (1+g)[z] in ker tau1} is a subgroup of
+      index <= 2^(k/2) containing Stab0(z) = {g : [gz] = [z]}.
+  T1  (difference bound)  where K_z properly contains Stab0, the light safe
+      difference classes (1+g)[z] bound d_safe <= 2d - 2*overlap.
+  T2  (pushforward)       a cover 1-cycle v with p1[v] != 0 and |v| <= W
+      pushes to a safe base logical of weight <= W (im p1 = im delta2 under
+      (R)), so d_safe <= W.  The wall value is the shadow of the failing
+      cover's light safe-sector logical.
+  W   (wall pins)         exact d_safe certificates by DESCENDING LADDER
+      (SAT at w -> retry at wt_found - 2, by parity; terminate at UNSAT).
+      bb90-y = 10 = d exactly (freeze); stored bb108-y: witness descent to
+      14 with a bounded UNSAT attempt at 12 (the historical §14/§15
+      readings of "18" were first-found witness weights, not minima — see
+      A15 note §8); orbit-finalist sample: all exact values even and
+      <= 2d - 2, strictly below the previously reported ceiling.
+
+The one *expensive* certificate — the bb108-y COVER's safe-sector minimum
+d~_safe = 14 exactly (SAT@14 pushing 14->14, UNSAT@12) — took ~5 h of
+CaDiCaL at n = 216 and is not re-run by default; pass --expensive to
+reproduce it. Its result is recorded in the note and consumed here only
+as documentation.
+
+Run from `experiments/bb_lab/`:
+    uv run python scripts/a15_deficit_wall_checks.py [--expensive]
+Output: `data/a15/deficit_wall_checks.json`; ~1 h default
+(SAT-witness ladders; UNSAT attempts are bounded at 2M conflicts and may
+report "upper" — the load-bearing exact certificates, with their real
+costs, are recorded in the note's §8 table).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from pysat.card import CardEnc, EncType  # noqa: E402
+from pysat.formula import IDPool  # noqa: E402
+from pysat.solvers import Cadical153  # noqa: E402
+
+from a14_s4_ladder import coset_query, orbit_reps  # noqa: E402
+from a14_safe_floor_screens import (  # noqa: E402
+    XCover, canonical_row, h1_dim, parse_poly,
+)
+from bb_lab.linalg import nullspace_f2, rank_f2  # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[1]
+OUT = ROOT / "data" / "a15"
+OUT.mkdir(parents=True, exist_ok=True)
+
+CHECKS: list[tuple[str, bool]] = []
+RESULTS: dict = {}
+
+
+def check(name: str, ok: bool, detail: str = "") -> None:
+    CHECKS.append((name, ok))
+    print(f"  [{'PASS' if ok else 'FAIL'}] {name}" + (f"  ({detail})" if detail else ""))
+
+
+def dim_mod(S: np.ndarray, Bnd: np.ndarray) -> int:
+    if S.shape[0] == 0:
+        return 0
+    return rank_f2(np.vstack([S, Bnd])) - rank_f2(Bnd)
+
+
+# --------------------------------------------------------------- chain maps
+
+
+def transfer1(cov: XCover) -> np.ndarray:
+    """tau = eps.lift on 1-chains: base cell (x,y) -> cover cells (x,y), (x+l,y)."""
+    l, m, nb = cov.l, cov.m, cov.nb
+    nc = 2 * nb
+    T = np.zeros((2 * nc, 2 * nb), dtype=np.uint8)
+    for j in (0, 1):
+        for x in range(l):
+            for y in range(m):
+                col = j * nb + x * m + y
+                T[j * nc + x * m + y, col] = 1
+                T[j * nc + (x + l) * m + y, col] = 1
+    return T
+
+
+def push1(cov: XCover) -> np.ndarray:
+    """p = fiber sum on 1-chains: cover cell (x,y) -> base cell (x mod l, y)."""
+    l, m, nb = cov.l, cov.m, cov.nb
+    nc = 2 * nb
+    P = np.zeros((2 * nb, 2 * nc), dtype=np.uint8)
+    for j in (0, 1):
+        for x in range(2 * l):
+            for y in range(m):
+                P[j * nb + (x % l) * m + y, j * nc + x * m + y] ^= 1
+    return P
+
+
+def translate1_all(cov: XCover, z: np.ndarray) -> np.ndarray:
+    """All |G| diagonal translates of a base 1-chain, rows indexed gx*m+gy."""
+    l, m, nb = cov.l, cov.m, cov.nb
+    u = z[:nb].reshape(l, m)
+    v = z[nb:].reshape(l, m)
+    out = np.zeros((l * m, 2 * nb), np.uint8)
+    i = 0
+    for gx in range(l):
+        for gy in range(m):
+            out[i, :nb] = np.roll(np.roll(u, gx, 0), gy, 1).reshape(-1)
+            out[i, nb:] = np.roll(np.roll(v, gx, 0), gy, 1).reshape(-1)
+            i += 1
+    return out
+
+
+class Cell:
+    """One presentation cell (A, B, l, m, axis) with its safe-sector data."""
+
+    def __init__(self, name, A, B, l, m, axis, d):
+        self.name, self.d = name, d
+        Ac, Bc, lc, mc = canonical_row(parse_poly(A), parse_poly(B), l, m, axis)
+        self.cov = XCover(Ac, Bc, lc, mc)
+        self.G = lc * mc
+        self.Bnd = self.cov.d2b.T
+        self.ker2 = nullspace_f2(self.cov.d2b)
+        self.seams = np.vstack([self.cov.seam(z) for z in self.ker2])
+        self.k = h1_dim(self.cov.d2b, self.cov.d1b)
+        self.kc = h1_dim(self.cov.d2c, self.cov.d1c)
+        # functionals: w (a cycle) is a boundary iff Qzero @ w = 0;
+        # w's class lies in im delta2 iff Qsafe @ w = 0.
+        self.Qsafe = nullspace_f2(np.vstack([self.seams, self.Bnd]))
+        self.Qzero = nullspace_f2(self.Bnd)
+
+
+# ------------------------------------------------------------ SAT: logicals
+
+
+def _xor_chain(pool, clauses, lits):
+    cur = None
+    for v in lits:
+        if cur is None:
+            cur = v
+        else:
+            t = pool.id(("t", cur, v))
+            clauses.extend([[-t, cur, v], [-t, -cur, -v], [t, -cur, v], [t, cur, -v]])
+            cur = t
+    return cur
+
+
+def _detector_rows(d1: np.ndarray, d2: np.ndarray, k: int) -> np.ndarray:
+    """k functionals whose OR detects a nontrivial class among cycles."""
+    Lam = nullspace_f2(d2.T)
+    cyc = nullspace_f2(d1)
+    Mdet = (Lam @ cyc.T) & 1
+    keep: list[int] = []
+    acc = np.zeros((0, Mdet.shape[1]), np.uint8)
+    for i in range(Lam.shape[0]):
+        if rank_f2(np.vstack([acc, Mdet[i]])) > acc.shape[0]:
+            acc = np.vstack([acc, Mdet[i]])
+            keep.append(i)
+        if acc.shape[0] == k:
+            break
+    return Lam[keep]
+
+
+def safe_sector_cover_logical(cell: Cell, w: int, conf_budget: int = 30_000_000):
+    """One cover 1-cycle v with |v| <= w and p1[v] != 0, or UNSAT/UNKNOWN.
+
+    The nonzero-pushforward-class constraint is compiled in directly: base
+    detectors composed with the pushforward.  p1[v] != 0 implies [v] != 0,
+    so no separate cover-nontriviality constraint is needed.
+    """
+    cov = cell.cov
+    n1 = 2 * (2 * cov.nb)
+    Lam = _detector_rows(cov.d1b, cov.d2b, cell.k)
+    Mdet = (Lam @ push1(cov)) & 1  # detectors on the pushed-down chain
+    pool = IDPool()
+    wvar = [pool.id(("w", i)) for i in range(n1)]
+    clauses: list[list[int]] = []
+    for i in range(cov.d1c.shape[0]):
+        cur = _xor_chain(pool, clauses,
+                         [wvar[j] for j in np.flatnonzero(cov.d1c[i])])
+        if cur is not None:
+            clauses.append([-cur])
+    dets = []
+    for i in range(Mdet.shape[0]):
+        cur = _xor_chain(pool, clauses,
+                         [wvar[j] for j in np.flatnonzero(Mdet[i])])
+        if cur is not None:
+            dets.append(cur)
+    clauses.append(dets)
+    card = CardEnc.atmost(lits=wvar, bound=w, vpool=pool,
+                          encoding=EncType.seqcounter)
+    with Cadical153(bootstrap_with=clauses + card.clauses) as solver:
+        solver.conf_budget(conf_budget)
+        res = solver.solve_limited()
+        if res is None:
+            return "UNKNOWN", None
+        if not res:
+            return "UNSAT", None
+        model = set(solver.get_model())
+        v = np.array([1 if wvar[i] in model else 0 for i in range(n1)], np.uint8)
+        assert not ((cov.d1c @ v) & 1).any(), "not a cover cycle"
+        assert ((Mdet @ v) & 1).any(), "pushforward class is zero"
+        return "SAT", v
+
+
+def min_logicals(cell: Cell, w: int, cap: int, conf_budget: int = 10_000_000):
+    """Up to `cap` distinct base logicals of weight <= w; (list, exhausted?)."""
+    cov = cell.cov
+    n1 = 2 * cov.nb
+    Lam = _detector_rows(cov.d1b, cov.d2b, cell.k)
+    pool = IDPool()
+    wvar = [pool.id(("w", i)) for i in range(n1)]
+    clauses: list[list[int]] = []
+    for i in range(cov.d1b.shape[0]):
+        cur = _xor_chain(pool, clauses,
+                         [wvar[j] for j in np.flatnonzero(cov.d1b[i])])
+        if cur is not None:
+            clauses.append([-cur])
+    dets = []
+    for i in range(Lam.shape[0]):
+        cur = _xor_chain(pool, clauses,
+                         [wvar[j] for j in np.flatnonzero(Lam[i])])
+        if cur is not None:
+            dets.append(cur)
+    clauses.append(dets)
+    card = CardEnc.atmost(lits=wvar, bound=w, vpool=pool,
+                          encoding=EncType.seqcounter)
+    sols: list[np.ndarray] = []
+    with Cadical153(bootstrap_with=clauses + card.clauses) as solver:
+        while len(sols) < cap:
+            solver.conf_budget(conf_budget)
+            res = solver.solve_limited()
+            if res is None:
+                return sols, False
+            if not res:
+                return sols, True
+            model = set(solver.get_model())
+            z = np.array([1 if wvar[i] in model else 0 for i in range(n1)],
+                         np.uint8)
+            assert not ((cov.d1b @ z) & 1).any() and ((Lam @ z) & 1).any()
+            sols.append(z)
+            solver.add_clause([(-wvar[i] if z[i] else wvar[i])
+                               for i in range(n1)])
+    return sols, False
+
+
+# ----------------------------------------------------------------- L0 / L1
+
+
+def check_L0(cell: Cell) -> dict:
+    """im delta2 = ker tau1 on H1 (spans and dimensions)."""
+    cov = cell.cov
+    cycles = nullspace_f2(cov.d1b)
+    T1 = transfer1(cov)
+    Qc = nullspace_f2(cov.d2c.T)          # functionals killing im d2(cover)
+    Mc = (((Qc @ T1) & 1) @ cycles.T) & 1
+    sol = nullspace_f2(Mc)
+    kertau = (sol @ cycles) & 1 if sol.shape[0] else np.zeros((0, 2 * cov.nb),
+                                                              np.uint8)
+    d_seam = dim_mod(cell.seams, cell.Bnd)
+    d_ker = dim_mod(kertau, cell.Bnd)
+    d_union = dim_mod(np.vstack([kertau, cell.seams]), cell.Bnd)
+    ok = d_seam == d_ker == d_union == cell.k // 2
+    check(f"L0/{cell.name}: im delta2 = ker tau1, dim k/2", ok,
+          f"dims {d_seam}/{d_ker}/{d_union}, k={cell.k}, k~={cell.kc}")
+    return {"dim_im_delta2": d_seam, "dim_ker_tau1": d_ker,
+            "dim_union": d_union, "k": cell.k, "k_cover": cell.kc}
+
+
+def check_L1(cell: Cell, n_samples: int = 200, seed: int = 15) -> dict:
+    """Random base and cover cycles all have even weight; seams even."""
+    rng = np.random.default_rng(seed)
+    ok = True
+    for d1 in (cell.cov.d1b, cell.cov.d1c):
+        cyc = nullspace_f2(d1)
+        for _ in range(n_samples):
+            mask = rng.integers(0, 2, cyc.shape[0]).astype(np.uint8)
+            w = int(((mask @ cyc) & 1).sum())
+            if w % 2:
+                ok = False
+    seam_wts = [int(cell.cov.seam(z).sum()) for z in cell.ker2]
+    ok = ok and all(w % 2 == 0 for w in seam_wts)
+    check(f"L1/{cell.name}: cycle weights even (base+cover+seams)", ok,
+          f"seam weights {sorted(set(seam_wts))}")
+    return {"seam_weights": seam_wts}
+
+
+# ------------------------------------------------------------------ L2 / T1
+
+
+def check_L2_T1(cell: Cell, cap: int) -> dict:
+    """K_z census: subgroup, index bound, Stab0, difference-class bound."""
+    zs, exhausted = min_logicals(cell, cell.d, cap)
+    kz_sizes, st_sizes, U_per_z = [], [], []
+    freeze = False
+    subgroup_ok = True
+    for z in zs:
+        T = translate1_all(cell.cov, z)
+        if not ((cell.Qsafe @ z) & 1).any():
+            freeze = True
+        diffs = T ^ z[None, :]
+        safe = ~(((cell.Qsafe @ diffs.T) & 1).any(axis=0))
+        zero = ~(((cell.Qzero @ diffs.T) & 1).any(axis=0))
+        ov = (T & z[None, :]).sum(axis=1)
+        # subgroup closure of K_z (indices as (gx, gy) pairs)
+        l, m = cell.cov.l, cell.cov.m
+        members = {(i // m, i % m) for i in np.flatnonzero(safe)}
+        for (a, b) in list(members)[:12]:
+            for (c, e) in list(members)[:12]:
+                if ((a + c) % l, (b + e) % m) not in members:
+                    subgroup_ok = False
+        kz_sizes.append(int(safe.sum()))
+        st_sizes.append(int(zero.sum()))
+        good = safe & ~zero
+        if good.any():
+            U_per_z.append(int((2 * cell.d - 2 * ov[good]).min()))
+    idx_ok = all(cell.G // s <= 2 ** (cell.k // 2) for s in kz_sizes)
+    check(f"L2/{cell.name}: K_z subgroup + index <= 2^(k/2)",
+          subgroup_ok and idx_ok,
+          f"|K_z| {dict(Counter(kz_sizes))}, |Stab0| {dict(Counter(st_sizes))}, "
+          f"{'=' if exhausted else '>='}{len(zs)} min-logicals")
+    U = min(U_per_z) if U_per_z else None
+    print(f"       T1/{cell.name}: freeze={freeze}, difference bound U={U}"
+          + (f", U histogram {dict(Counter(U_per_z))}" if U_per_z else ""))
+    return {"n_min_logicals": len(zs), "exhausted": exhausted,
+            "kz_sizes": dict(Counter(kz_sizes)),
+            "stab0_sizes": dict(Counter(st_sizes)),
+            "freeze": freeze, "U": U}
+
+
+# ---------------------------------------------------------------------- T2
+
+
+def check_T2(cell: Cell, w: int, expect: str) -> dict:
+    """Safe-sector cover logical at <= w; pushforward is a safe base logical."""
+    t0 = time.time()
+    verdict, v = safe_sector_cover_logical(cell, w)
+    dt = time.time() - t0
+    rec: dict = {"bound": w, "verdict": verdict, "time_s": round(dt, 1)}
+    if verdict == "SAT":
+        pv = (push1(cell.cov) @ v) & 1
+        wv, wpv = int(v.sum()), int(pv.sum())
+        is_cycle = not ((cell.cov.d1b @ pv) & 1).any()
+        nonzero = bool(((cell.Qzero @ pv) & 1).any())
+        safe = not ((cell.Qsafe @ pv) & 1).any()
+        ok = is_cycle and nonzero and safe and wpv <= wv <= w
+        rec.update({"cover_weight": wv, "push_weight": wpv,
+                    "push_nonzero": nonzero, "push_safe": safe})
+        check(f"T2/{cell.name}: cover logical @<={w} pushes to safe base logical",
+              ok and expect == "SAT",
+              f"|v|={wv} -> |p(v)|={wpv}, {dt:.1f}s")
+    else:
+        check(f"T2/{cell.name}: safe sector @<={w} is {verdict}",
+              verdict == expect, f"{dt:.1f}s")
+    return rec
+
+
+# ------------------------------------------------------------- W: wall pins
+
+
+def certify_dsafe(cell: Cell, floor_minus_1: int,
+                  conf_budget: int = 30_000_000) -> tuple[str, list]:
+    """UNSAT@floor-1 on every G-orbit rep => d_safe >= floor (A14.1(4))."""
+    reps = orbit_reps(cell.cov, cell.ker2)
+    verdicts = []
+    for i, z in enumerate(reps):
+        v, wt = coset_query(cell.cov, cell.cov.seam(z), floor_minus_1,
+                            conf_budget)
+        verdicts.append({"rep": i, "verdict": v, "weight": wt})
+        if v != "UNSAT":
+            break
+    status = ("CERTIFIED" if all(r["verdict"] == "UNSAT" for r in verdicts)
+              and len(verdicts) == len(reps) else "FAILED")
+    return status, verdicts
+
+
+def ladder_dsafe(cell: Cell, start_w: int, sat_conf: int = 3_000_000,
+                 unsat_conf: int = 2_000_000) -> tuple[str, int]:
+    """Exact-or-upper d_safe by descending ladder over all orbit reps.
+
+    Pass 1 descends by witnesses (cheap); pass 2 makes one bounded UNSAT
+    attempt at best-2 per rep. Returns ("exact"|"upper", value): "upper"
+    means some UNSAT attempt hit the conflict budget (value is still a
+    certified upper bound via its witness)."""
+    reps = orbit_reps(cell.cov, cell.ker2)
+    seams = [cell.cov.seam(z) for z in reps]
+    best = None
+    for seam in seams:
+        w = min(start_w, int(seam.sum()) - 1)
+        cur = int(seam.sum())
+        while True:
+            v, wt = coset_query(cell.cov, seam, w, sat_conf)
+            if v == "SAT":
+                cur = wt
+                w = wt - 2
+            else:
+                break
+        best = cur if best is None else min(best, cur)
+    certified = True
+    for seam in seams:
+        v, wt = coset_query(cell.cov, seam, best - 2, unsat_conf)
+        if v == "SAT":  # a deeper element the cheap pass missed: restart
+            return ladder_dsafe(cell, wt, sat_conf, unsat_conf)
+        if v != "UNSAT":
+            certified = False
+            break
+    return ("exact" if certified else "upper"), best
+
+
+def main() -> None:
+    t_start = time.time()
+
+    print("== cells ==")
+    cells = {
+        "pair72-x": Cell("pair72-x", "x^2 + y + y^3", "1 + x + y^2",
+                         3, 6, "x", 4),
+        "gross-x": Cell("gross-x", "x^3 + y + y^2", "y^3 + x + x^2",
+                        6, 6, "x", 6),
+        "hit3-y": Cell("hit3-y", "y^3 + x + x^2", "y + x*y^2 + x^2",
+                       6, 6, "y", 6),
+        "bb90-x": Cell("bb90-x", "x^9 + y + y^2", "1 + x^2 + x^7",
+                       15, 3, "x", 10),
+        "bb90-y": Cell("bb90-y", "x^9 + y + y^2", "1 + x^2 + x^7",
+                       15, 3, "y", 10),
+        "bb108-y": Cell("bb108-y", "x^3 + y + y^2", "y^3 + x + x^2",
+                        9, 6, "y", 10),
+        "bb108-u18": Cell("bb108-u18", "x^12 + x^9*y + y^2",
+                          "x^2 + x^9 + x^10", 18, 3, "x", 10),
+        "bb288-y": Cell("bb288-y", "x^3 + y^2 + y^7", "y^3 + x + x^2",
+                        12, 12, "y", 18),
+        "bb288-c48b": Cell("bb288-c48b", "1 + x^3*y^2 + x^3*y^7",
+                           "x*y^3 + x^3 + x^8", 12, 12, "x", 18),
+    }
+    for c in cells.values():
+        print(f"  {c.name}: |G|={c.G}, k={c.k}, k~={c.kc}, d={c.d}")
+
+    print("\n== L0: the safe sector is the transfer kernel ==")
+    RESULTS["L0"] = {n: check_L0(c) for n, c in cells.items()}
+
+    print("\n== L1: parity ==")
+    RESULTS["L1"] = {n: check_L1(c) for n, c in cells.items()
+                     if n in ("pair72-x", "gross-x", "bb90-y", "bb108-y",
+                              "bb108-u18", "bb288-y")}
+
+    print("\n== L2/T1: collision subgroups and difference classes ==")
+    RESULTS["L2"] = {}
+    for n, cap in [("pair72-x", 30), ("gross-x", 100), ("hit3-y", 100),
+                   ("bb90-y", 100), ("bb108-y", 60)]:
+        RESULTS["L2"][n] = check_L2_T1(cells[n], cap)
+
+    print("\n== T2: the pushforward mechanism ==")
+    RESULTS["T2"] = {}
+    # failing cells: the wall value is achieved in the cover's safe sector
+    # (gating: verified in the session smoke tests, now re-certified)
+    RESULTS["T2"]["bb108-y"] = check_T2(cells["bb108-y"], 18, "SAT")
+    RESULTS["T2"]["bb90-y"] = check_T2(cells["bb90-y"], 10, "SAT")
+
+    def t2_probe(cell: Cell, w: int, conf: int = 30_000_000) -> dict:
+        """Non-gating: SAT gives d_safe <= w via T2; UNSAT/UNKNOWN says the
+        safe sector is not (cheaply) achieved at w upstairs — the theorem is
+        one-directional, so either verdict is consistent."""
+        t0 = time.time()
+        verdict, v = safe_sector_cover_logical(cell, w, conf_budget=conf)
+        rec = {"bound": w, "verdict": verdict,
+               "time_s": round(time.time() - t0, 1)}
+        if verdict == "SAT":
+            pv = (push1(cell.cov) @ v) & 1
+            nonzero = bool(((cell.Qzero @ pv) & 1).any())
+            safe = not ((cell.Qsafe @ pv) & 1).any()
+            rec.update({"cover_weight": int(v.sum()),
+                        "push_weight": int(pv.sum()),
+                        "push_nonzero": nonzero, "push_safe": safe})
+        print(f"       T2-probe/{cell.name} @<= {w}: {verdict} "
+              + (f"|v|={rec.get('cover_weight')} -> |p(v)|="
+                 f"{rec.get('push_weight')} safe={rec.get('push_safe')}"
+                 if verdict == "SAT" else "")
+              + f" [{rec['time_s']}s]")
+        return rec
+
+    RESULTS["T2"]["bb90-x"] = t2_probe(cells["bb90-x"], 18)
+    RESULTS["T2"]["bb108-u18"] = t2_probe(cells["bb108-u18"], 18)
+    # doublers: probe at 2d (SAT means the safe sector is achieved at 2d,
+    # i.e. the tight d_safe = 2d has an overlap-free lift; UNSAT means the
+    # cover's 2d tightness witness is diagonal-only)
+    for n in ("pair72-x", "gross-x", "hit3-y"):
+        RESULTS["T2"][n] = t2_probe(cells[n], 2 * cells[n].d)
+
+    if "--expensive" in sys.argv:
+        # d~_safe(bb108-y) exactly: SAT@16, SAT@14 (each pushing k->k,
+        # overlap-free), UNSAT@12. The UNSAT took ~5 h of CaDiCaL at
+        # n = 216 when first run (2026-07-06); budget accordingly.
+        print("\n== T2-expensive: bb108-y cover safe-sector minimum ==")
+        for w in (16, 14, 12):
+            rec = t2_probe(cells["bb108-y"], w, conf=2_000_000_000)
+            RESULTS["T2"][f"bb108-y-cover@{w}"] = rec
+            if rec["verdict"] != "SAT":
+                break
+
+    print("\n== W: wall pins (exact d_safe by descending ladder) ==")
+    RESULTS["W"] = {}
+
+    status, verd = certify_dsafe(cells["bb90-y"], 9)
+    s0 = min(int(cells["bb90-y"].cov.seam(z).sum())
+             for z in orbit_reps(cells["bb90-y"].cov, cells["bb90-y"].ker2))
+    check("W/bb90-y: d_safe = 10 = d exactly (freeze; UNSAT@9 all reps, seam@10)",
+          status == "CERTIFIED" and s0 == 10,
+          f"{len(verd)} reps, raw seam min {s0}")
+    RESULTS["W"]["bb90-y"] = {"floor_minus_1": 9, "status": status,
+                              "verdicts": verd, "s0_min": s0}
+
+    st, val = ladder_dsafe(cells["bb108-y"], 17)
+    # the correction: the historical "18" reading was a witness weight;
+    # the true minimum is strictly below (and even, and <= 2d-2 = 18)
+    check("W/bb108-y: exact ladder lands strictly below the historical 18, "
+          "even, <= 2d-2", val < 18 and val % 2 == 0,
+          f"d_safe {'=' if st == 'exact' else '<='} {val}")
+    RESULTS["W"]["bb108-y"] = {"ladder": st, "value": val}
+
+    print("\n== W: orbit-finalist sample (bb_108 v1 x-sweep) ==")
+    sweep = json.load(open(ROOT / "data/a14/bb108_orbit_sweep.json"))
+    finalists = [s for s in sweep["survivors"] if not s["cheap_reject"]]
+    print(f"  {len(finalists)} finalists (cheap tiers stalled at 20); "
+          "exact ladders on the first 4:")
+    scan_log = []
+    for s in finalists[:4]:
+        cell = Cell(f"orbit[{s['A']} | {s['B']}]", s["A"], s["B"], 9, 6,
+                    s["axis"], 10)
+        if cell.k != 8 or cell.kc != 8:
+            scan_log.append({"A": s["A"], "B": s["B"], "skip": "k-gate"})
+            continue
+        st, val = ladder_dsafe(cell, 17)
+        scan_log.append({"A": s["A"], "B": s["B"], "axis": s["axis"],
+                         "ladder": st, "value": val})
+        print(f"    A={s['A']:<20} B={s['B']:<20} d_safe "
+              f"{'=' if st == 'exact' else '<='} {val}")
+    vals = [r["value"] for r in scan_log if "value" in r]
+    check("W/orbit-sample: all exact values even, <= 2d-2, and strictly "
+          "below the reported ceiling 18",
+          bool(vals) and all(v % 2 == 0 and v <= 16 for v in vals),
+          f"values {sorted(set(vals))}")
+    RESULTS["W"]["orbit_scan"] = scan_log
+
+    # ----------------------------------------------------------- summary
+    fails = [n for n, ok in CHECKS if not ok]
+    RESULTS["summary"] = {"passed": len(CHECKS) - len(fails),
+                          "total": len(CHECKS), "failed": fails,
+                          "wall_s": round(time.time() - t_start, 1)}
+    with open(OUT / "deficit_wall_checks.json", "w") as fh:
+        json.dump(RESULTS, fh, indent=1, default=str)
+    print(f"\n{len(CHECKS) - len(fails)}/{len(CHECKS)} checks passed "
+          f"({time.time() - t_start:.0f}s). Output: data/a15/deficit_wall_checks.json")
+    if fails:
+        print("FAILED:")
+        for n in fails:
+            print(f"  - {n}")
+        sys.exit(1)
+    print("ALL CHECKS PASS — A15 deficit-wall battery green.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/research_log.md
+++ b/pipeline/research_log.md
@@ -13,6 +13,53 @@ what was tried and why it didn't work.
 
 ## Entries
 
+- 2026-07-06 — deficit-wall (A15-P3) — success (theorem + a correction) —
+  **A14 §16's deficit-wall OQ answered: the wall *value* is a theorem,
+  the *mechanism* is a pushforward, and the "stalls at exactly 2d − 2"
+  premise is retracted as a measurement artifact.** Math
+  (`notes/A15_deficit_wall.md`, machine-validated by
+  `a15_deficit_wall_checks.py`): **(L0)** the safe sector is the
+  transfer kernel — `im δ₂ = ker τ₁` (LES; span-verified on 9 covers
+  incl. both bb_288 presentations and the Z₁₈×Z₃ re-decomposition), so
+  `d_safe` = min weight of a base logical whose class *dies in the
+  double cover*; **(L1, parity)** with |A|, |B| odd every base and
+  cover 1-cycle has even weight (augmentation ring hom), so `d`, `d̃`,
+  `d_safe` are all even and — since `d_safe ≥ 2d ⟺ SF` — **`2d − 2`
+  is the unique maximal SF-failing value**: that is the whole
+  "parity/duality mechanism" §16 asked for; **(L2/T1)** the collision
+  sets `K_z = {g : (1+g)[z] safe} ⊇ Stab₀(z)` are subgroups with
+  `[G : K_z] ≤ 2^{k/2}`, and where the containment is proper the
+  difference classes give `d_safe ≤ 2d − 2·overlap` — fires on bb90-y
+  (bound 10, tight at the freeze), **provably silent on bb108-y** (all
+  54 min-weight logicals have `K_z = Stab₀`, exhausted by SAT — the
+  hypothesized "2(d−1) base object" does not exist there); **(T2, the
+  load-bearing mechanism)** under (R) `im p₁ = im δ₂` makes the
+  pushforward of any surviving-class cover logical a safe base logical:
+  `d_safe ≤ d̃_safe`, so a cover failing through its safe sector hands
+  the safe floor its witness at no weight cost, and conversely SF
+  forces the cover's whole safe sector to `≥ 2d` (the template
+  re-derived; "SF-true ⟹ doubles", A11's 111/111, reduces to the new
+  **(M)-robustness conjecture**: the dangerous sector never binds
+  alone). Coupling observed tight everywhere: doublers at `2d = 2d`
+  with overlap-free lifts; bb108-y at `14 = 14`. **The correction:**
+  §15/§16's "orbit ceiling 18" and bb_288's "32–34" were *first-found
+  SAT witness weights at the query bound, not minima* — exact
+  descending ladders put stored bb108-y at **`d_safe = 14 = 2d − 6`
+  exactly, certified both sides** (base UNSAT@12 on all orbit reps;
+  cover `d̃_safe = 14` exactly, its UNSAT@12 ≈5 h of CaDiCaL at
+  n = 216 — T2's coupling tight at 14 = 14), every ladder-sampled
+  v1 finalist at `≤ 12` (first witnesses 16), while bb90-y's freeze value
+  **= 10 = d exactly** (UNSAT@9, certified) — no measured instance
+  attains the wall;
+  correction blocks added to A14 §§15–16. Residue: the code invariant
+  `maxSF ∈ {2d} ∪ {even ≤ 2d − 2}` (true value per code now measurable
+  by ladders; A15-P1's corpus battery must report S4 weights as "≤"),
+  the (M)-robustness conjecture, the T1/T2-both-silent corner of the
+  `≤ 2d` ceiling, and the small Lean package (L0/T2 slot into
+  `BBTransferH1`'s exactness chase next to
+  `ker_pushH1_eq_range_pullH1`; L1 is augmentation-trivial).
+  [theorem+battery](../experiments/bb_lab/notes/A15_deficit_wall.md)
+
 - 2026-07-04 — safe-floor-screens (A14) — success —
   **A12's OQ4 answered in its own terms: the safe sector is canonical
   under (R), and a certified necessary-screen battery now decides

--- a/pipeline/research_log.md
+++ b/pipeline/research_log.md
@@ -54,10 +54,19 @@ what was tried and why it didn't work.
   correction blocks added to A14 §§15–16. Residue: the code invariant
   `maxSF ∈ {2d} ∪ {even ≤ 2d − 2}` (true value per code now measurable
   by ladders; A15-P1's corpus battery must report S4 weights as "≤"),
-  the (M)-robustness conjecture, the T1/T2-both-silent corner of the
-  `≤ 2d` ceiling, and the small Lean package (L0/T2 slot into
-  `BBTransferH1`'s exactness chase next to
-  `ker_pushH1_eq_range_pullH1`; L1 is augmentation-trivial).
+  the (M)-robustness conjecture, and the T1/T2-both-silent corner of
+  the `≤ 2d` ceiling. **Lean layer LANDED (same session, axiom-clean,
+  zero warnings): `Framework/Homological/BBDeficitWall.lean`** — L1
+  parity (`sum_conv`, `cycle_support_even`, base+cover instantiations
+  with descending hypotheses), L0 as the chain-level iff
+  `pull1_mem_boundaries_iff_seamCoset` (sibling to
+  `ker_pushH1_eq_range_pullH1`), T2 as
+  `push1_mem_seamCoset_of_deckTrivial` +
+  `not_seamCosetFloor_of_light_cover_cycle` (`d_safe ≤ d̃_safe`
+  against the repo's own `SeamCosetFloor`/`DeckTrivialOnH1`,
+  deliberately routing around A14.1(2)'s dimension count via
+  deck-triviality), and the wall as the even-step upgrades
+  `seamCosetFloor_of_even_of_pred` / `safeFloor_of_even_of_pred`.
   [theorem+battery](../experiments/bb_lab/notes/A15_deficit_wall.md)
 
 - 2026-07-04 — safe-floor-screens (A14) — success —


### PR DESCRIPTION
A14 §16's deficit-wall OQ ("orbit-max safe floor stalls at exactly 2d−2 across unrelated codes") answered in corrected form: the wall **value** is a theorem, the **mechanism** is a pushforward, and the "exactly 2d−2" premise is retracted as a measurement artifact. Full write-up: `experiments/bb_lab/notes/A15_deficit_wall.md` (phase P3 of the A15 d≥7 hunt plan).

## The theorem package (machine-validated, 25/25 battery)

- **L0 (transfer kernel):** the safe sector is exactly the transfer kernel, `im δ₂ = ker τ₁` — `d_safe` = min weight of a base logical whose class *dies in the double cover*. Span-verified on 9 covers incl. both bb_288 presentations and the Z₁₈×Z₃ re-decomposition.
- **L1 (parity):** with weight-3 polynomials every base and cover 1-cycle has even weight (augmentation ring hom), so `d_safe` is even and `d_safe ≥ 2d ⟺ SF` makes **2d−2 the unique maximal SF-failing value** — the wall value is pinned by parity alone.
- **L2/T1 (collision subgroups):** `K_z = {g : (1+g)[z] safe} ⊇ Stab₀(z)` are subgroups of index ≤ 2^{k/2}; where the containment is proper, difference classes give `d_safe ≤ 2d − 2·overlap` — fires on bb90-y (tight at the freeze), **provably silent on bb108-y** (all 54 min-weight logicals exhausted by SAT: `K_z = Stab₀`; A14's hypothesized "2(d−1) base object" does not exist there).
- **T2 (pushforward, load-bearing):** under (R), `im p₁ = im δ₂` makes the pushforward of any surviving-class cover logical a safe base logical: `d_safe ≤ d̃_safe` — a cover failing through its safe sector hands the safe floor its witness at no weight cost. Converse: SF floors the cover's whole safe sector at 2d (the doubling template re-derived; A11's empirical "SF-true ⟹ doubles" 111/111 reduces to the new **(M)-robustness conjecture**: the dangerous sector never binds alone).

## The correction

§15/§16's "orbit ceiling 18" (bb_108) and "32–34" (bb_288) were **first-found SAT witness weights at the query bound, not minima**. Exact descending ladders: stored bb108-y `d_safe = 14 = 2d−6` **exactly, certified both sides** (base UNSAT@12 on all orbit reps; cover `d̃_safe = 14` exactly — its UNSAT@12 took ≈5 h of CaDiCaL at n=216 — with the T2 coupling tight at 14=14); every ladder-sampled v1 finalist ≤ 12; bb90-y freeze = 10 = d exactly. **No measured instance attains the wall.** Correction blocks added to A14 §§15–16; S4 refutation weights must be reported as "≤" bounds going forward (A15-P1 corpus battery included).

## Lean layer (axiom-clean, zero warnings)

New `QEC/Stabilizer/Framework/Homological/BBDeficitWall.lean`, wired into the Homological umbrella:
- L1: `sum_conv`, `cycle_support_even`, `base/cover_cycle_weight_even` (the cover hypotheses descend through `push_A`/`push_B` — only base polynomial parities assumed);
- L0: `pull1_seamC` (`τ(seamC ζ) = liftStab ζ`), `pull1_mem_boundaries_iff_seamCoset` (sibling slot to `BBTransferH1.ker_pushH1_eq_range_pullH1`; forward chase via `liftC2_decomp` + `sheet1`);
- T2: `push1_mem_seamCoset_of_deckTrivial`, `not_seamCosetFloor_of_light_cover_cycle` (`d_safe ≤ d̃_safe` against the repo's own `SeamCosetFloor`/`DeckTrivialOnH1`; deliberately routes around the A14.1(2) dimension count via deck-triviality, so no finrank machinery);
- the wall: `seamCosetFloor_of_even_of_pred` / `safeFloor_of_even_of_pred` — even-target floors upgrade from m−1 to m for free.

Flagship theorems verify to the standard three axioms; no `sorry`, no `native_decide`. Build gate: `lake build` of `QEC.Stabilizer.Framework` + both umbrella-importing `ChainComplex` modules (3397 jobs, green; the module adds no instances, so downstream elaboration is unaffected — full cold build of the Y-floor native modules deliberately not re-run in the worktree).

## Reviewer notes

- The validation battery (`experiments/bb_lab/scripts/a15_deficit_wall_checks.py`, committed data under `data/a15/`) ran twice by design: the first run's two "failures" were the exactness pins for the old "ceiling 18" reading — they correctly refused to certify it, which is how the correction was discovered. The committed battery asserts the corrected claims (25/25).
- The 5-hour cover-side UNSAT@12 certificate is documented in the note §8 and reproducible via the script's `--expensive` flag; it is not re-run by default.
- Residue (note §9): the code invariant `maxSF ∈ {2d} ∪ {even ≤ 2d−2}` per code (bb_108 ∈ [14,16]; bb_288 ≤ 34, exact priced out at n≥288), the (M)-robustness conjecture, and the T1/T2-both-silent corner of the `≤ 2d` ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)