### PR TITLE
Hosted tutorial environments for QCE26 (Codespaces + lean4web)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+# Mirrors mathlib4's devcontainer image: a plain Ubuntu devcontainer base with
+# elan installed but no toolchain baked in. The toolchain is resolved from the
+# repo's `lean-toolchain` on first `lake` invocation, so this image does not go
+# stale when the project bumps Lean.
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
+
+USER vscode
+WORKDIR /home/vscode
+
+RUN curl https://elan.lean-lang.org/elan-init.sh -sSf | sh -s -- -y --default-toolchain none
+
+ENV PATH="/home/vscode/.elan/bin:${PATH}"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+{
+  "name": "QECLean — QCE26 tutorial",
+  "build": { "dockerfile": "Dockerfile" },
+  "remoteUser": "vscode",
+
+  // 4 cores / 8 GB is the smallest machine that gets through the tutorial
+  // target. Do not drop to 2 cores: the non-BB `native_decide` checks
+  // (FiveQubit_5_1_3, RotatedSurface/Three, Steane7Distance) get tight.
+  "hostRequirements": { "cpus": 4, "memory": "8gb", "storage": "32gb" },
+
+  "customizations": {
+    "vscode": {
+      "extensions": ["leanprover.lean4"],
+      "settings": {
+        // Attendees open Scratch.lean and start typing; without this the
+        // InfoView only appears after a manual command, which is the single
+        // most common "it's broken" moment in a room of first-time users.
+        "lean4.alwaysShowTitleBarMenu": true
+      }
+    }
+  },
+
+  // Runs while the Codespace is still being created, and — crucially — is the
+  // step captured by a prebuild. With prebuilds on, attendees skip all of it.
+  "onCreateCommand": ".devcontainer/setup.sh",
+  "waitFor": "onCreateCommand",
+
+  "postAttachCommand": {
+    "open-scratch": "code Scratch.lean || true"
+  }
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Codespace / devcontainer provisioning for the QCE26 tutorial.
+#
+# Three steps, in this order for a reason:
+#   1. install the toolchain pinned in `lean-toolchain`
+#   2. pull mathlib's prebuilt oleans from the cache (never build mathlib)
+#   3. build only `QECTutorial`, which excludes the BivariateBicycle leaves
+#
+# Step 3 is the one that would OOM if it were `lake build`: the gross-code
+# safe-floor leaves peak ~3.75 GB each under `native_decide` and CI only
+# survives them by adding 12 GB of swap. See QECTutorial.lean.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+echo "==> Installing Lean toolchain ($(cat lean-toolchain))"
+elan toolchain install "$(cat lean-toolchain)"
+elan override set "$(cat lean-toolchain)"
+
+echo "==> Fetching mathlib cache"
+# `cache` ships with mathlib; lake builds that one small exe first, then this
+# downloads mathlib's oleans instead of compiling them (~hours saved).
+lake exe cache get
+
+echo "==> Building tutorial target (QECTutorial)"
+lake build QECTutorial
+
+echo "==> Ready. Open Scratch.lean to begin."

--- a/.github/workflows/tutorial-env.yml
+++ b/.github/workflows/tutorial-env.yml
@@ -1,0 +1,63 @@
+name: Tutorial environment
+
+# Guards the QCE26 tutorial environments (.devcontainer/ and deploy/lean4web/).
+#
+# The thing that can silently break is `QECTutorial.lean`: it re-lists the
+# `Codes` umbrella minus BivariateBicycle, so a new module added under
+# `QEC/Stabilizer/Codes/` is not picked up automatically the way
+# `scripts/check-umbrellas.sh` would catch it inside `QEC/`.
+#
+# Note the absence of the 12 GB swap step that `lean_action_ci.yml` needs.
+# That is the point: if this job ever starts OOM-ing, something heavy has
+# leaked into the tutorial target and a Codespace would fail too.
+
+on:
+  push:
+    paths:
+      - 'QEC/**'
+      - 'QECTutorial.lean'
+      - 'Scratch.lean'
+      - 'lakefile.toml'
+      - 'lean-toolchain'
+      - '.devcontainer/**'
+      - '.github/workflows/tutorial-env.yml'
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: tutorial-env-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install elan
+        run: |
+          curl https://elan.lean-lang.org/elan-init.sh -sSf | sh -s -- -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+
+      - name: Fetch mathlib cache
+        run: lake exe cache get
+
+      - name: Build tutorial target
+        run: |
+          set -o pipefail
+          /usr/bin/time -v lake build QECTutorial 2>&1 | tee build.log
+
+      - name: Report peak memory
+        if: always()
+        run: |
+          {
+            echo "### Tutorial target build"
+            echo
+            grep -E 'Maximum resident set size|Elapsed \(wall clock\)' build.log || true
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # The scratch file is not in any `lean_lib`, so `lake build` never sees
+      # it. Elaborate it explicitly — a broken Scratch.lean is the first thing
+      # every attendee would hit.
+      - name: Check Scratch.lean elaborates
+        run: lake env lean Scratch.lean

--- a/QECTutorial.lean
+++ b/QECTutorial.lean
@@ -1,0 +1,46 @@
+import QEC.Foundations.Foundations
+import QEC.RepetitionCode.RepetitionCode
+import QEC.Stabilizer.Foundations
+import QEC.Stabilizer.Geometry
+import QEC.Stabilizer.Framework
+import QEC.Stabilizer.Codes.Toric
+import QEC.Stabilizer.Codes.RotatedSurface
+import QEC.Stabilizer.Codes.Repetition
+import QEC.Stabilizer.Codes.Iceberg
+import QEC.Stabilizer.Codes.Small
+import QEC.Stabilizer.Codes.Concat
+
+/-!
+# QECTutorial — light import surface for the hosted tutorial environment
+
+This is the entry point used by the QCE26 tutorial environments (the
+devcontainer in `.devcontainer/` and the lean4web instance in
+`deploy/lean4web/`). It is *not* part of the library proper: `QEC.lean`
+remains the umbrella that imports everything.
+
+## Why a separate target
+
+`import QEC` transitively pulls in `QEC.Stabilizer.Codes.BivariateBicycle`,
+whose gross-code safe-floor leaves (`MImFloorY0/Y1/Y4`) each peak around
+3.75 GB under `native_decide` — CI has to add 12 GB of swap to survive them
+(see `.github/workflows/lean_action_ci.yml`). That is fine for a release
+build on a dedicated runner and hopeless for a 4-core / 8 GB Codespace or a
+shared web-editor session.
+
+`BivariateBicycle` is a leaf: outside its own directory the only module that
+imports it is the `QEC.Stabilizer.Codes` umbrella. So this file re-lists the
+`Codes` umbrella minus that one import (and minus `_TEMPLATE`, which is
+scaffolding rather than content) and is otherwise identical in reach to
+`QEC`. Everything a tutorial attendee touches — the Pauli and binary-symplectic
+layer, the stabilizer framework, the toric and rotated-surface codes, Steane,
+Shor, `[[5,1,3]]`, and the concatenation instances — is still here.
+
+## Keeping this in sync
+
+`scripts/check-umbrellas.sh` only walks directories under `QEC/`, so this
+root-level file is outside its remit and will not be flagged if it drifts.
+The `tutorial-env` workflow builds this target on every push that touches
+`QEC/`, which catches a module added to `Codes/` but not reflected here.
+
+If you add a new heavy code family, exclude it here as well.
+-/

--- a/Scratch.lean
+++ b/Scratch.lean
@@ -1,0 +1,36 @@
+import QECTutorial
+
+/-!
+# Scratch — start here
+
+This is your workspace for the *Lean into QEC* tutorial (QCE26, Toronto).
+Edit freely; nothing here is part of the library.
+
+`QECTutorial` is the whole formalization minus the bivariate-bicycle code
+family, which is too memory-hungry for a hosted session. Everything below
+is available.
+
+Put your cursor at the end of a line to see the goal state in the InfoView
+(the panel on the right; `Ctrl/Cmd + Shift + Enter` opens it if it is closed).
+-/
+
+open Quantum.StabilizerGroup
+
+-- The two central definitions: an `[[n, k]]` stabilizer code, and one whose
+-- distance has been proved.
+#check @StabilizerCode
+#check @StabilizerCodeWithDistance
+#check @HasCodeDistance
+
+-- A worked result you can inspect: Steane ⊗ Steane, an unconditional
+-- `[[49, 1, 9]]` concatenated code.
+#check Steane7.steaneConcatCodeWithDistance
+
+-- The parametric toric code, for every `L ≥ 2`.
+#check @toricHomologicalCode
+
+/-
+Your turn. For example:
+
+example : 2 + 2 = 4 := by decide
+-/

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,119 @@
+# Hosted tutorial environments
+
+Two ways for QCE26 attendees to run QECLean without installing anything.
+Both build the `QECTutorial` target rather than the default one — see
+[`QECTutorial.lean`](../QECTutorial.lean) for why (short version: the
+bivariate-bicycle safe-floor leaves peak around 3.75 GB each under
+`native_decide`, and CI only survives them by adding 12 GB of swap).
+
+| | Codespaces | lean4web |
+|---|---|---|
+| Attendee needs | a GitHub account | nothing |
+| Startup | seconds with a prebuild, ~15–40 min without | instant |
+| Editor | full VS Code + InfoView | single-file web editor |
+| Runs on | GitHub's machines, billed to each attendee | one box you rent |
+| Fails if | GitHub logins are slow on conference wifi | the box is undersized |
+
+Recommendation: Codespaces as the primary path, lean4web as the walk-up
+fallback for anyone without a GitHub account.
+
+---
+
+## Route A — GitHub Codespaces
+
+Everything needed is in [`.devcontainer/`](../.devcontainer). Attendees open:
+
+```
+https://codespaces.new/Stavan-Jain/QECLean
+```
+
+`setup.sh` installs the pinned toolchain, runs `lake exe cache get` for
+mathlib's prebuilt oleans, and builds `QECTutorial`.
+
+### Turn on prebuilds before the tutorial
+
+This is the difference between attendees waiting ~15–40 minutes and being
+ready in seconds, and it is the single most important thing to do in advance.
+Prebuilds are configured in the GitHub UI, not in a file:
+
+**Settings → Codespaces → Set up prebuild**, with:
+- Branch: `main`
+- Configuration file: `.devcontainer/devcontainer.json`
+- Trigger: *On push* (or a schedule if pushes are frequent)
+- Region: whichever is nearest Toronto — `East US` is the usual pick
+- Machine type: 4-core, matching `hostRequirements`
+
+Prebuild storage bills to the repo owner. Delete the prebuild after the
+conference.
+
+### Cost
+
+Compute bills to each attendee's own account, not yours — GitHub's free tier
+covers 60 core-hours/month, so a 4-core Codespace for a half-day session is
+comfortably inside it for most people. Confirm current quotas before the
+session; GitHub has changed them before.
+
+---
+
+## Route B — self-hosted lean4web
+
+[`install.sh`](lean4web/install.sh) provisions a fresh **Ubuntu 22.04** box
+(the only OS lean4web claims to support):
+
+```bash
+DOMAIN=lean.example.org ./install.sh
+```
+
+It installs Node, elan, and bubblewrap; clones lean4web; clones QECLean into
+`Projects/QEC` (the folder name must be exactly `QEC`, since lean4web requires
+the folder and its root `.lean` file to match); copies in
+[`leanweb-config.json`](lean4web/leanweb-config.json) and
+[`leanweb-build.sh`](lean4web/leanweb-build.sh); and runs `npm run build`.
+
+Then:
+
+```bash
+cd ~/lean4web && npx pm2 start ecosystem.config.cjs
+```
+
+Attendees land straight on QECLean, since `leanweb-config.json` sets
+`"default": true`. It is also reachable explicitly at `#project=QEC`.
+
+### Sizing — measure this, do not trust the table
+
+Each concurrent user gets their own Lean server process, and a mathlib-scale
+project is not cheap per session. **These are estimates, not measurements:**
+
+| Concurrent users | Rough RAM | Notes |
+|---|---|---|
+| ~10 | 16 GB | comfortable |
+| ~25 | 32 GB | realistic for a half-day tutorial |
+| ~50 | 64 GB+ | ask whether Codespaces is the better answer |
+
+Disk: budget 25–30 GB for mathlib's oleans plus the toolchain.
+
+Get a real number before committing to a box — open the editor, type an
+`example`, and watch one session:
+
+```bash
+ps -o rss=,comm= -C lean | sort -rn | head
+```
+
+Multiply the steady-state RSS by your expected concurrency and add headroom.
+lean4web's own README notes that larger projects are considered out of scope,
+so treat a full room as something to load-test, not assume.
+
+### Before the day
+
+- Rehearse a cold start on the real box, not just locally.
+- Load-test with more concurrent sessions than you expect attendees.
+- Have the Codespaces link ready as a fallback if the box struggles.
+- lean4web runs Lean under bubblewrap by default. Do not set `NO_BWRAP=true`
+  on a public instance — that runs attendee-supplied code uncontained.
+- Depending on where the box lives, GDPR may require you to fill in
+  `serverCountry` and `contactDetails` in `client/config/config.tsx`.
+
+### Teardown
+
+The instance is only needed for the session. Snapshot or destroy the box
+afterwards rather than leaving an unattended public Lean server running.

--- a/deploy/lean4web/install.sh
+++ b/deploy/lean4web/install.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# One-shot provisioning of a lean4web instance serving QECLean.
+#
+# Target: a fresh Ubuntu 22.04 LTS box (the only OS lean4web claims to
+# support). Run as a sudo-capable non-root user. Idempotent enough to re-run.
+#
+# Usage:
+#   ./install.sh                       # build + install, no TLS
+#   DOMAIN=lean.example.org ./install.sh   # also request a Let's Encrypt cert
+#
+# What it does NOT do: provision the server, point DNS, or open the firewall.
+# See README.md in this directory for the full runbook.
+set -euo pipefail
+
+DOMAIN="${DOMAIN:-}"
+QECLEAN_REF="${QECLEAN_REF:-main}"
+ROOT="${ROOT:-$HOME/lean4web}"
+
+echo "==> Installing system packages"
+sudo apt-get update
+sudo apt-get install -y git curl bubblewrap build-essential
+
+if ! command -v node >/dev/null; then
+  echo "==> Installing Node.js 20"
+  curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+  sudo apt-get install -y nodejs
+fi
+
+if ! command -v elan >/dev/null; then
+  echo "==> Installing elan"
+  curl https://elan.lean-lang.org/elan-init.sh -sSf | sh -s -- -y --default-toolchain none
+  export PATH="$HOME/.elan/bin:$PATH"
+fi
+
+echo "==> Cloning lean4web into $ROOT"
+if [ ! -d "$ROOT" ]; then
+  git clone --recurse-submodules https://github.com/leanprover-community/lean4web.git "$ROOT"
+fi
+cd "$ROOT"
+
+echo "==> Adding QECLean as a project"
+# lean4web requires the project folder name and its root .lean file to match.
+# QECLean's root module is QEC.lean, so the folder must be named exactly QEC.
+if [ ! -d Projects/QEC ]; then
+  git clone --branch "$QECLEAN_REF" https://github.com/Stavan-Jain/QECLean.git Projects/QEC
+else
+  git -C Projects/QEC fetch origin "$QECLEAN_REF" && git -C Projects/QEC checkout "$QECLEAN_REF" && git -C Projects/QEC pull
+fi
+
+cp Projects/QEC/deploy/lean4web/leanweb-config.json Projects/QEC/leanweb-config.json
+cp Projects/QEC/deploy/lean4web/leanweb-build.sh   Projects/QEC/leanweb-build.sh
+chmod +x Projects/QEC/leanweb-build.sh
+
+echo "==> Installing npm dependencies"
+npm install
+
+echo "==> Building server + projects (this compiles QECTutorial; expect a while)"
+npm run build
+
+if [ -n "$DOMAIN" ]; then
+  echo "==> Requesting TLS certificate for $DOMAIN"
+  sudo apt-get install -y certbot
+  sudo certbot certonly --standalone -d "$DOMAIN" --agree-tos -n \
+    -m "${CERT_EMAIL:-admin@$DOMAIN}"
+  # lean4web reads the cert paths from the environment; pm2 picks these up
+  # from ecosystem.config.cjs, so patch them in there rather than exporting.
+  echo
+  echo "Set these in $ROOT/ecosystem.config.cjs before starting:"
+  echo "  SSL_CRT_FILE: '/etc/letsencrypt/live/$DOMAIN/fullchain.pem'"
+  echo "  SSL_KEY_FILE: '/etc/letsencrypt/live/$DOMAIN/privkey.pem'"
+  echo "  PORT: 443"
+fi
+
+echo
+echo "==> Done. Start it with:"
+echo "      cd $ROOT && npx pm2 start ecosystem.config.cjs"
+echo "    and check it with:"
+echo "      npx pm2 logs lean4web"

--- a/deploy/lean4web/leanweb-build.sh
+++ b/deploy/lean4web/leanweb-build.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Invoked by lean4web's `npm run build:server` for this project.
+#
+# Builds ONLY `QECTutorial`, never the default target: a plain `lake build`
+# would pull in the BivariateBicycle safe-floor leaves (~3.75 GB each under
+# `native_decide`) and take the box down. See QECTutorial.lean.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+elan toolchain install "$(cat lean-toolchain)"
+lake exe cache get
+lake build QECTutorial

--- a/deploy/lean4web/leanweb-config.json
+++ b/deploy/lean4web/leanweb-config.json
@@ -1,0 +1,11 @@
+{
+  "name": "QECLean (QCE26 tutorial)",
+  "default": true,
+  "sortOrder": 0,
+  "examples": [
+    {
+      "file": "Scratch.lean",
+      "name": "Start here"
+    }
+  ]
+}

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -17,6 +17,13 @@ scope = "leanprover-community"
 [[lean_lib]]
 name = "QEC"
 
+# Light import surface for the hosted tutorial environments; excludes the
+# BivariateBicycle leaves, which need more memory than a Codespace or a shared
+# lean4web session has. Deliberately not in `defaultTargets` — `lake build`
+# still means the full library. See `QECTutorial.lean`.
+[[lean_lib]]
+name = "QECTutorial"
+
 [[lean_lib]]
 name = "Foundations"
 srcDir = "QEC"


### PR DESCRIPTION
Sets up two ways for QCE26 attendees to run QECLean without installing anything. Companion to the tutorial site at https://stavan-jain.github.io/lean-into-qec-site/

## The problem this works around

`import QEC` transitively reaches `QEC.Stabilizer.Codes.BivariateBicycle`, whose gross-code safe-floor leaves (`MImFloorY0/Y1/Y4`) peak around 3.75 GB each under `native_decide`. `lean_action_ci.yml` already adds 12 GB of swap to get through them. A 4-core / 8 GB Codespace or a shared web-editor session cannot.

`BivariateBicycle` is a leaf — outside its own directory, the only module importing it is the `QEC.Stabilizer.Codes` umbrella. So `QECTutorial.lean` re-lists that umbrella minus `BivariateBicycle` (and minus `_TEMPLATE`, which is scaffolding). Reach is otherwise identical to `QEC`: Pauli + binary-symplectic layer, the stabilizer framework, toric, rotated surface, Steane, Shor, `[[5,1,3]]`, and the concatenation instances.

`QECTutorial` is **not** in `defaultTargets` — `lake build` still means the full library.

## What's here

- `QECTutorial.lean` + a `lean_lib` entry — the light import surface
- `.devcontainer/` — Codespaces: pinned toolchain, `lake exe cache get`, then `lake build QECTutorial`
- `Scratch.lean` — attendee landing file, sorry-free
- `deploy/` — runbook for both routes, plus `install.sh` for a self-hosted lean4web box on Ubuntu 22.04
- `.github/workflows/tutorial-env.yml` — builds the tutorial target **without** the swap step, so a regression that would break a Codespace fails here first; also elaborates `Scratch.lean`, which no `lean_lib` covers

## Review notes

- `scripts/check-umbrellas.sh` only walks `QEC/`, so it will not catch drift in `QECTutorial.lean`. The new workflow is what guards it — it runs on any change under `QEC/`.
- Sizing numbers in `deploy/README.md` for the lean4web box are explicitly marked as estimates, with a command to measure real per-session RSS. Worth a load test before the day rather than trusting the table.
- **Before the tutorial:** turn on Codespaces prebuilds (Settings → Codespaces). That is the difference between attendees waiting ~15–40 min and being ready in seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)