### PR TITLE
Add QECLight target and hosted environments

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+# Mirrors mathlib4's devcontainer image: a plain Ubuntu devcontainer base with
+# elan installed but no toolchain baked in. The toolchain is resolved from the
+# repo's `lean-toolchain` on first `lake` invocation, so this image does not go
+# stale when the project bumps Lean.
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
+
+USER vscode
+WORKDIR /home/vscode
+
+RUN curl https://elan.lean-lang.org/elan-init.sh -sSf | sh -s -- -y --default-toolchain none
+
+ENV PATH="/home/vscode/.elan/bin:${PATH}"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+{
+  "name": "QECLean",
+  "build": { "dockerfile": "Dockerfile" },
+  "remoteUser": "vscode",
+
+  // 4 cores / 8 GB is the smallest machine that gets through `QECLight`.
+  // Do not drop to 2 cores: the remaining `native_decide` checks
+  // (FiveQubit_5_1_3, RotatedSurface/Three, Steane7Distance) get tight.
+  "hostRequirements": { "cpus": 4, "memory": "8gb", "storage": "32gb" },
+
+  "customizations": {
+    "vscode": {
+      "extensions": ["leanprover.lean4"],
+      "settings": {
+        "lean4.alwaysShowTitleBarMenu": true
+      }
+    }
+  },
+
+  // Runs while the container is still being created, and is the step a
+  // Codespaces prebuild captures — with prebuilds on, this is already done
+  // before anyone opens the repo.
+  "onCreateCommand": ".devcontainer/setup.sh",
+  "waitFor": "onCreateCommand",
+
+  "postAttachCommand": {
+    "open-playground": "code Playground.lean || true"
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,10 +3,11 @@
   "build": { "dockerfile": "Dockerfile" },
   "remoteUser": "vscode",
 
-  // 4 cores / 8 GB is the smallest machine that gets through `QECLight`.
-  // Do not drop to 2 cores: the remaining `native_decide` checks
-  // (FiveQubit_5_1_3, RotatedSurface/Three, Steane7Distance) get tight.
-  "hostRequirements": { "cpus": 4, "memory": "8gb", "storage": "32gb" },
+  // Measured on a GitHub runner: `lake build QECLight` peaks at ~5.7 GB RSS
+  // and takes ~7 min with a warm mathlib cache. That does not fit comfortably
+  // in the 2-core/8 GB tier, so ask for 4 cores — which in Codespaces comes
+  // with 16 GB, leaving real headroom.
+  "hostRequirements": { "cpus": 4, "memory": "16gb", "storage": "32gb" },
 
   "customizations": {
     "vscode": {

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Devcontainer / Codespace provisioning for QECLean.
+#
+# Three steps, in this order for a reason:
+#   1. install the toolchain pinned in `lean-toolchain`
+#   2. pull mathlib's prebuilt oleans from the cache (never build mathlib)
+#   3. build `QECLight`, the library minus the BivariateBicycle leaves
+#
+# Step 3 is the one that would OOM if it were a plain `lake build`: the
+# gross-code safe-floor leaves peak ~3.75 GB each under `native_decide` and CI
+# only survives them by adding 12 GB of swap. See QECLight.lean.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+echo "==> Installing Lean toolchain ($(cat lean-toolchain))"
+elan toolchain install "$(cat lean-toolchain)"
+elan override set "$(cat lean-toolchain)"
+
+echo "==> Fetching mathlib cache"
+# `cache` ships with mathlib; lake builds that one small exe first, then this
+# downloads mathlib's oleans instead of compiling them (~hours saved).
+lake exe cache get
+
+echo "==> Building QECLight"
+lake build QECLight
+
+echo "==> Ready. Open Playground.lean to begin."

--- a/.github/workflows/hosted-env.yml
+++ b/.github/workflows/hosted-env.yml
@@ -1,0 +1,62 @@
+name: Hosted environments
+
+# Guards `QECLight` and the environments built on it (.devcontainer/, deploy/).
+#
+# The thing that can silently break is `QECLight.lean`: it re-lists the `Codes`
+# umbrella minus BivariateBicycle, so a module added under
+# `QEC/Stabilizer/Codes/` is not picked up automatically the way
+# `scripts/check-umbrellas.sh` would catch it inside `QEC/`.
+#
+# Note the absence of the 12 GB swap step that `lean_action_ci.yml` needs.
+# That is the point: if this job starts OOM-ing, something heavy has leaked
+# into `QECLight` and every hosted environment would fail too.
+
+on:
+  push:
+    paths:
+      - 'QEC/**'
+      - 'QECLight.lean'
+      - 'Playground.lean'
+      - 'lakefile.toml'
+      - 'lean-toolchain'
+      - '.devcontainer/**'
+      - '.github/workflows/hosted-env.yml'
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: hosted-env-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install elan
+        run: |
+          curl https://elan.lean-lang.org/elan-init.sh -sSf | sh -s -- -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+
+      - name: Fetch mathlib cache
+        run: lake exe cache get
+
+      - name: Build QECLight
+        run: |
+          set -o pipefail
+          /usr/bin/time -v lake build QECLight 2>&1 | tee build.log
+
+      - name: Report peak memory
+        if: always()
+        run: |
+          {
+            echo "### QECLight build"
+            echo
+            grep -E 'Maximum resident set size|Elapsed \(wall clock\)' build.log || true
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Playground.lean is in no `lean_lib`, so `lake build` never sees it.
+      # Elaborate it explicitly — it is the first file anyone opens.
+      - name: Check Playground.lean elaborates
+        run: lake env lean Playground.lean

--- a/Playground.lean
+++ b/Playground.lean
@@ -26,8 +26,9 @@ open Quantum.StabilizerGroup
 -- concatenated code.
 #check Steane7.steaneConcatCodeWithDistance
 
--- The parametric toric code, for every `L ≥ 2`.
-#check @toricHomologicalCode
+-- The parametric toric code, for every `L ≥ 2`. (It lives under
+-- `Quantum.Stabilizer.Lattice`, not the `Quantum.StabilizerGroup` opened above.)
+#check @Quantum.Stabilizer.Lattice.toricHomologicalCode
 
 /-
 Your turn. For example:

--- a/Playground.lean
+++ b/Playground.lean
@@ -1,0 +1,36 @@
+import QECLight
+
+/-!
+# Playground
+
+A scratch file for trying things against QECLean. Edit freely — nothing here
+is part of the library, and no `lean_lib` builds it.
+
+It imports `QECLight`, which is the library minus the bivariate-bicycle code
+family (too memory-hungry for a container or a shared session; see
+`QECLight.lean`). For the gross-code results, use `import QEC` in a local
+checkout with the memory to spare.
+
+Put your cursor at the end of a line to see the goal state in the InfoView.
+-/
+
+open Quantum.StabilizerGroup
+
+-- The two central definitions: an `[[n, k]]` stabilizer code, and one whose
+-- distance has been proved.
+#check @StabilizerCode
+#check @StabilizerCodeWithDistance
+#check @HasCodeDistance
+
+-- A worked result to inspect: Steane ⊗ Steane, an unconditional `[[49, 1, 9]]`
+-- concatenated code.
+#check Steane7.steaneConcatCodeWithDistance
+
+-- The parametric toric code, for every `L ≥ 2`.
+#check @toricHomologicalCode
+
+/-
+Your turn. For example:
+
+example : 2 + 2 = 4 := by decide
+-/

--- a/QECLight.lean
+++ b/QECLight.lean
@@ -1,0 +1,52 @@
+import QEC.Foundations.Foundations
+import QEC.RepetitionCode.RepetitionCode
+import QEC.Stabilizer.Foundations
+import QEC.Stabilizer.Geometry
+import QEC.Stabilizer.Framework
+import QEC.Stabilizer.Codes.Toric
+import QEC.Stabilizer.Codes.RotatedSurface
+import QEC.Stabilizer.Codes.Repetition
+import QEC.Stabilizer.Codes.Iceberg
+import QEC.Stabilizer.Codes.Small
+import QEC.Stabilizer.Codes.Concat
+
+/-!
+# QECLight — the library minus the memory-heavy code families
+
+An import surface for environments that cannot afford the full build:
+Codespaces, the hosted web editor (see `deploy/`), a laptop with 8 GB, or
+anyone who wants to explore the stabilizer development without waiting on the
+bivariate-bicycle proofs.
+
+`QEC.lean` remains the umbrella that imports everything. This is a strict
+subset, not a replacement, and it is deliberately absent from `defaultTargets`
+so `lake build` still means the whole library.
+
+## What is left out, and why
+
+`import QEC` transitively pulls in `QEC.Stabilizer.Codes.BivariateBicycle`,
+whose gross-code safe-floor leaves (`MImFloorY0/Y1/Y4`) each peak around
+3.75 GB under `native_decide` — `.github/workflows/lean_action_ci.yml` has to
+add 12 GB of swap to get through them. That is a reasonable price for a
+release build on a dedicated runner, and prohibitive for a 4-core container or
+a shared server hosting many concurrent sessions.
+
+`BivariateBicycle` is a leaf: outside its own directory, the only module that
+imports it is the `QEC.Stabilizer.Codes` umbrella. So this file re-lists that
+umbrella without it (and without `_TEMPLATE`, which is scaffolding rather than
+content). That drops 47 of the library's 59 `native_decide` files.
+
+Everything else is here: the Pauli and binary-symplectic layer, the stabilizer
+and homological framework, the toric and rotated-surface families, Steane,
+Shor, `[[5,1,3]]`, and the concatenation instances.
+
+## Keeping this in sync
+
+`scripts/check-umbrellas.sh` only walks directories under `QEC/`, so this
+root-level file is outside its remit and will not be flagged if it drifts from
+the `Codes` umbrella. The `hosted-env` workflow builds this target on every
+change under `QEC/`, which is what catches a module added to `Codes/` but not
+reflected here.
+
+If a new code family turns out to be similarly expensive, exclude it here too.
+-/

--- a/README.md
+++ b/README.md
@@ -9,6 +9,18 @@ This project formalizes foundational concepts in quantum error correction using 
 
 Along the way, it develops definitions and lemmas for reasoning about qubits, quantum states, and unitary operations, contributing toward a verified foundation for quantum computing and fault tolerance in Lean.
 
+## Try it without installing anything
+
+[**Open in GitHub Codespaces**](https://codespaces.new/Stavan-Jain/QECLean) — a full Lean 4 environment with mathlib cached and the library prebuilt, in the browser. It opens on [`Playground.lean`](Playground.lean).
+
+Both that and the self-hosted [web editor](deploy/README.md) build [`QECLight`](QECLight.lean), which is the library minus the bivariate-bicycle code family: those proofs peak around 3.75 GB per `native_decide` leaf, more than a small container or a shared session can carry. Everything else — the Pauli and binary-symplectic layer, the stabilizer framework, toric, rotated surface, Steane, Shor, `[[5,1,3]]`, concatenation — is available. `QECLight` is also a fast way to build the library locally on a modest machine:
+
+```bash
+lake exe cache get && lake build QECLight
+```
+
+See [`deploy/README.md`](deploy/README.md) for running your own instance.
+
 ## Overview
 
 Modules are written in Lean 4 and rely on [mathlib](https://github.com/leanprover-community/mathlib4) for linear algebra and other foundations. Import everything via `QEC`, or use `QEC.Foundations.Foundations`, `QEC.RepetitionCode.RepetitionCode`, or `QEC.Stabilizer.Stabilizer` for a subset.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -8,10 +8,14 @@ bivariate-bicycle safe-floor leaves peak around 3.75 GB each under
 4-core container nor a shared server can. Everything else in the library is
 available.
 
+Measured on a GitHub runner with a warm mathlib cache, `lake build QECLight`
+takes **~7 minutes** and peaks at **~5.7 GB** RSS. A full `lake build` is the
+thing that needs 12 GB of swap.
+
 | | Codespaces | lean4web |
 |---|---|---|
 | User needs | a GitHub account | nothing |
-| Startup | seconds with a prebuild, ~15–40 min without | instant |
+| Startup | seconds with a prebuild; otherwise the mathlib cache download plus ~7 min | instant |
 | Editor | full VS Code + InfoView | single-file web editor |
 | Runs on | GitHub's machines, billed per user | a box you run |
 | Good for | anyone wanting to develop against the library | a link people can click |
@@ -33,7 +37,7 @@ mathlib's prebuilt oleans, and builds `QECLight`. The container opens on
 ### Prebuilds
 
 Without a prebuild, the first open costs the full `lake exe cache get` plus the
-`QECLight` build — on the order of 15–40 minutes. With one, it is seconds.
+`QECLight` build (~7 min once the cache is down). With one, it is seconds.
 Prebuilds are configured in the GitHub UI, not in a file:
 
 **Settings → Codespaces → Set up prebuild**, with branch `main`, configuration

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,104 @@
+# Hosted environments
+
+Two ways to run QECLean without installing anything locally.
+
+Both build [`QECLight`](../QECLight.lean) rather than the default target: the
+bivariate-bicycle safe-floor leaves peak around 3.75 GB each under
+`native_decide`, and CI only survives them by adding 12 GB of swap. Neither a
+4-core container nor a shared server can. Everything else in the library is
+available.
+
+| | Codespaces | lean4web |
+|---|---|---|
+| User needs | a GitHub account | nothing |
+| Startup | seconds with a prebuild, ~15–40 min without | instant |
+| Editor | full VS Code + InfoView | single-file web editor |
+| Runs on | GitHub's machines, billed per user | a box you run |
+| Good for | anyone wanting to develop against the library | a link people can click |
+
+---
+
+## Codespaces
+
+Everything needed is in [`.devcontainer/`](../.devcontainer):
+
+```
+https://codespaces.new/Stavan-Jain/QECLean
+```
+
+`setup.sh` installs the pinned toolchain, runs `lake exe cache get` for
+mathlib's prebuilt oleans, and builds `QECLight`. The container opens on
+[`Playground.lean`](../Playground.lean).
+
+### Prebuilds
+
+Without a prebuild, the first open costs the full `lake exe cache get` plus the
+`QECLight` build — on the order of 15–40 minutes. With one, it is seconds.
+Prebuilds are configured in the GitHub UI, not in a file:
+
+**Settings → Codespaces → Set up prebuild**, with branch `main`, configuration
+`.devcontainer/devcontainer.json`, trigger *on push*, and a 4-core machine
+matching `hostRequirements`. Prebuild storage bills to the repo owner.
+
+Worth turning on before pointing a group of people at the link, and turning
+off again afterwards.
+
+---
+
+## Self-hosted lean4web
+
+[`lean4web/install.sh`](lean4web/install.sh) provisions a **Ubuntu 22.04** box
+(the only OS lean4web claims to support):
+
+```bash
+DOMAIN=lean.example.org ./install.sh
+```
+
+It installs Node, elan, and bubblewrap; clones lean4web; clones QECLean into
+`Projects/QEC` (the folder name must be exactly `QEC` — lean4web requires the
+folder name and its root `.lean` file to match); copies in
+[`leanweb-config.json`](lean4web/leanweb-config.json) and
+[`leanweb-build.sh`](lean4web/leanweb-build.sh); and runs `npm run build`.
+
+Then:
+
+```bash
+cd ~/lean4web && npx pm2 start ecosystem.config.cjs
+```
+
+Visitors land on QECLean, since `leanweb-config.json` sets `"default": true`.
+It is also reachable explicitly at `#project=QEC`.
+
+### Sizing — measure this, do not trust the table
+
+Each concurrent user gets their own Lean server process, and a mathlib-scale
+project is not cheap per session. **These are estimates, not measurements:**
+
+| Concurrent users | Rough RAM | Notes |
+|---|---|---|
+| ~10 | 16 GB | comfortable |
+| ~25 | 32 GB | plausible for a class or workshop |
+| ~50 | 64 GB+ | consider pointing people at Codespaces instead |
+
+Disk: budget 25–30 GB for mathlib's oleans plus the toolchain.
+
+Get a real number before committing to a box — open the editor, type an
+`example`, and watch one session:
+
+```bash
+ps -o rss=,comm= -C lean | sort -rn | head
+```
+
+Multiply steady-state RSS by expected concurrency and add headroom. lean4web's
+own README notes that larger projects are considered out of scope, so treat
+high concurrency as something to load-test rather than assume.
+
+### Operating notes
+
+- lean4web runs Lean under bubblewrap by default. Do not set `NO_BWRAP=true`
+  on a public instance — that runs visitor-supplied code uncontained.
+- Depending on where the box lives, GDPR may require filling in
+  `serverCountry` and `contactDetails` in `client/config/config.tsx`.
+- Rehearse a cold start on the real box before relying on it for an event.
+- If the instance is only needed for a fixed window, snapshot or destroy the
+  box afterwards rather than leaving an unattended public Lean server running.

--- a/deploy/lean4web/install.sh
+++ b/deploy/lean4web/install.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# One-shot provisioning of a lean4web instance serving QECLean.
+#
+# Target: a fresh Ubuntu 22.04 LTS box (the only OS lean4web claims to
+# support). Run as a sudo-capable non-root user. Idempotent enough to re-run.
+#
+# Usage:
+#   ./install.sh                       # build + install, no TLS
+#   DOMAIN=lean.example.org ./install.sh   # also request a Let's Encrypt cert
+#
+# What it does NOT do: provision the server, point DNS, or open the firewall.
+# See README.md in this directory for the full runbook.
+set -euo pipefail
+
+DOMAIN="${DOMAIN:-}"
+QECLEAN_REF="${QECLEAN_REF:-main}"
+ROOT="${ROOT:-$HOME/lean4web}"
+
+echo "==> Installing system packages"
+sudo apt-get update
+sudo apt-get install -y git curl bubblewrap build-essential
+
+if ! command -v node >/dev/null; then
+  echo "==> Installing Node.js 20"
+  curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+  sudo apt-get install -y nodejs
+fi
+
+if ! command -v elan >/dev/null; then
+  echo "==> Installing elan"
+  curl https://elan.lean-lang.org/elan-init.sh -sSf | sh -s -- -y --default-toolchain none
+  export PATH="$HOME/.elan/bin:$PATH"
+fi
+
+echo "==> Cloning lean4web into $ROOT"
+if [ ! -d "$ROOT" ]; then
+  git clone --recurse-submodules https://github.com/leanprover-community/lean4web.git "$ROOT"
+fi
+cd "$ROOT"
+
+echo "==> Adding QECLean as a project"
+# lean4web requires the project folder name and its root .lean file to match.
+# QECLean's root module is QEC.lean, so the folder must be named exactly QEC.
+if [ ! -d Projects/QEC ]; then
+  git clone --branch "$QECLEAN_REF" https://github.com/Stavan-Jain/QECLean.git Projects/QEC
+else
+  git -C Projects/QEC fetch origin "$QECLEAN_REF" && git -C Projects/QEC checkout "$QECLEAN_REF" && git -C Projects/QEC pull
+fi
+
+cp Projects/QEC/deploy/lean4web/leanweb-config.json Projects/QEC/leanweb-config.json
+cp Projects/QEC/deploy/lean4web/leanweb-build.sh   Projects/QEC/leanweb-build.sh
+chmod +x Projects/QEC/leanweb-build.sh
+
+echo "==> Installing npm dependencies"
+npm install
+
+echo "==> Building server + projects (this compiles QECLight; expect a while)"
+npm run build
+
+if [ -n "$DOMAIN" ]; then
+  echo "==> Requesting TLS certificate for $DOMAIN"
+  sudo apt-get install -y certbot
+  sudo certbot certonly --standalone -d "$DOMAIN" --agree-tos -n \
+    -m "${CERT_EMAIL:-admin@$DOMAIN}"
+  # lean4web reads the cert paths from the environment; pm2 picks these up
+  # from ecosystem.config.cjs, so patch them in there rather than exporting.
+  echo
+  echo "Set these in $ROOT/ecosystem.config.cjs before starting:"
+  echo "  SSL_CRT_FILE: '/etc/letsencrypt/live/$DOMAIN/fullchain.pem'"
+  echo "  SSL_KEY_FILE: '/etc/letsencrypt/live/$DOMAIN/privkey.pem'"
+  echo "  PORT: 443"
+fi
+
+echo
+echo "==> Done. Start it with:"
+echo "      cd $ROOT && npx pm2 start ecosystem.config.cjs"
+echo "    and check it with:"
+echo "      npx pm2 logs lean4web"

--- a/deploy/lean4web/leanweb-build.sh
+++ b/deploy/lean4web/leanweb-build.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Invoked by lean4web's `npm run build:server` for this project.
+#
+# Builds ONLY `QECLight`, never the default target: a plain `lake build` would
+# pull in the BivariateBicycle safe-floor leaves (~3.75 GB each under
+# `native_decide`) and take the box down. See QECLight.lean.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+elan toolchain install "$(cat lean-toolchain)"
+lake exe cache get
+lake build QECLight

--- a/deploy/lean4web/leanweb-config.json
+++ b/deploy/lean4web/leanweb-config.json
@@ -1,0 +1,11 @@
+{
+  "name": "QECLean",
+  "default": true,
+  "sortOrder": 0,
+  "examples": [
+    {
+      "file": "Playground.lean",
+      "name": "Start here"
+    }
+  ]
+}

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -17,6 +17,13 @@ scope = "leanprover-community"
 [[lean_lib]]
 name = "QEC"
 
+# Light import surface for memory-constrained environments; excludes the
+# BivariateBicycle leaves, which need more than a 4-core container or a shared
+# web-editor session has. Deliberately not in `defaultTargets` — `lake build`
+# still means the full library. See `QECLight.lean`.
+[[lean_lib]]
+name = "QECLight"
+
 [[lean_lib]]
 name = "Foundations"
 srcDir = "QEC"


### PR DESCRIPTION
Two ways to run QECLean without a local install: a devcontainer for Codespaces, and a deploy kit for a self-hosted [lean4web](https://github.com/leanprover-community/lean4web) instance. Both rest on a new `QECLight` target, which is independently useful.

## `QECLight`

`import QEC` transitively reaches `QEC.Stabilizer.Codes.BivariateBicycle`, whose gross-code safe-floor leaves (`MImFloorY0/Y1/Y4`) peak around 3.75 GB each under `native_decide`. `lean_action_ci.yml` already adds 12 GB of swap to get through them. A 4-core container, or a server hosting many concurrent sessions, cannot.

`BivariateBicycle` is a leaf — outside its own directory, the only module importing it is the `QEC.Stabilizer.Codes` umbrella. So `QECLight.lean` re-lists that umbrella minus `BivariateBicycle` (and minus `_TEMPLATE`, which is scaffolding). That drops **47 of the library's 59 `native_decide` files**. Reach is otherwise unchanged: Pauli + binary-symplectic layer, stabilizer and homological framework, toric, rotated surface, Steane, Shor, `[[5,1,3]]`, concatenation instances.

It is **not** in `defaultTargets` — `lake build` still means the full library. Beyond the hosted environments it is a fast local build on a modest machine:

```bash
lake exe cache get && lake build QECLight
```

## What's here

- `QECLight.lean` + a `lean_lib` entry
- `Playground.lean` — scratch file, in no `lean_lib`, sorry-free
- `.devcontainer/` — Codespaces: pinned toolchain, `lake exe cache get`, then `lake build QECLight`
- `deploy/` — runbook for both routes, plus `install.sh` for a lean4web box on Ubuntu 22.04
- `.github/workflows/hosted-env.yml` — builds `QECLight` **without** the swap step, so a regression that would break a hosted environment fails here first; also elaborates `Playground.lean`, which no `lean_lib` covers
- a README section pointing at all of the above

## Review notes

- `scripts/check-umbrellas.sh` only walks `QEC/`, so it cannot catch drift in `QECLight.lean` — a new module under `Codes/` will not be picked up automatically. The new workflow is the guard; it runs on any change under `QEC/`.
- Sizing numbers in `deploy/README.md` are explicitly marked as estimates, with a command to measure real per-session RSS. Worth load-testing before relying on a box for a group.
- Codespaces prebuilds are UI-only (Settings → Codespaces) and make the difference between a ~15–40 min first open and a few seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)