### PR TITLE
docs(foundations): document every declaration; drop in-proof comments

### DIFF
--- a/QEC/Foundations/Basic.lean
+++ b/QEC/Foundations/Basic.lean
@@ -37,9 +37,11 @@ variable {α : Type*} [Fintype α] [DecidableEq α]
 /-- Complex amplitude vector over basis `α` (not necessarily normalized). -/
 abbrev Vector (α : Type*) [Fintype α] [DecidableEq α] := α → ℂ
 
+/-- Euclidean norm of an amplitude vector: `√(∑ᵢ ‖v i‖²)`. -/
 noncomputable def norm (v : Vector α) :=
   Real.sqrt (∑ i, ‖v i‖^2)
 
+/-- Unfold `norm` into the square root of the sum of squared magnitudes. -/
 @[simp] lemma norm_def {v : Vector α} : norm v = Real.sqrt (∑ i, ‖v i‖^2) := rfl
 
 /-- The norm is always non-negative. -/
@@ -113,6 +115,8 @@ This is isomorphic to `NQubitBasis 2` but uses tuples for convenience with
 pattern matching and tensor products. Use `TwoQubitBasis.toNQubitBasis` to convert.
 -/
 abbrev TwoQubitBasis : Type := QubitBasis × QubitBasis
+
+/-- Normalized 2-qubit state. -/
 abbrev TwoQubitState : Type := QuantumState TwoQubitBasis
 
 /-- Basis type for 3-qubit systems using tuple representation.
@@ -121,7 +125,11 @@ This is isomorphic to `NQubitBasis 3` but uses tuples for convenience with
 pattern matching and tensor products. Use `ThreeQubitBasis.toNQubitBasis` to convert.
 -/
 abbrev ThreeQubitBasis := QubitBasis × QubitBasis × QubitBasis
+
+/-- Unnormalized 3-qubit amplitudes (same as `Vector ThreeQubitBasis`). -/
 abbrev ThreeQubitVec := ThreeQubitBasis → ℂ
+
+/-- Normalized 3-qubit state. -/
 abbrev ThreeQubitState := QuantumState ThreeQubitBasis
 
 /-!
@@ -164,17 +172,19 @@ This is a convenience constructor that makes it easier to work with n-qubit basi
 -/
 def nQubitBasisOf (n : ℕ) (f : Fin n → QubitBasis) : NQubitBasis n := f
 
-/-- Convert a tuple representation to function representation for small n.
+/-- Convert the tuple representation `(a, b) : QubitBasis × QubitBasis` to the
+function representation `NQubitBasis 2`.
 
-For n=2, converts `(a, b) : QubitBasis × QubitBasis` to `NQubitBasis 2`.
-For n=3, converts `(a, b, c) : QubitBasis × QubitBasis × QubitBasis` to `NQubitBasis 3`.
-
-These are useful for connecting the existing tuple-based basis types with
-the new function-based n-qubit basis type.
+Useful for connecting the tuple-based basis types with the function-based
+n-qubit basis type.
 -/
 def TwoQubitBasis.toNQubitBasis (b : TwoQubitBasis) : NQubitBasis 2 :=
   fun i => if i = 0 then b.1 else b.2
 
+/-- Convert the tuple representation
+`(a, b, c) : QubitBasis × QubitBasis × QubitBasis` to the function
+representation `NQubitBasis 3`.
+-/
 def ThreeQubitBasis.toNQubitBasis (b : ThreeQubitBasis) : NQubitBasis 3 :=
   fun i => if i = 0 then b.1 else if i = 1 then b.2.1 else b.2.2
 
@@ -201,14 +211,17 @@ def nQubitBasisZeros (n : ℕ) : NQubitBasis n :=
 def nQubitBasisOnes (n : ℕ) : NQubitBasis n :=
   nQubitBasisAll n 1
 
--- The "constructor" for basis vectors
+/-- The computational basis vector concentrated at `i0`: amplitude `1` at `i0`
+and `0` elsewhere. -/
 noncomputable def basisVec (i0 : α) : Vector α :=
   fun i => if i = i0 then (1 : ℂ) else 0
 
+/-- Pointwise value of a basis vector. -/
 @[simp] lemma basisVec_apply {α : Type*} [DecidableEq α] [Fintype α] (a x : α) :
   basisVec a x = (if x = a then 1 else 0) :=
 by simp[basisVec]
 
+/-- Dotting a vector against a basis vector reads off the corresponding component. -/
 @[simp] lemma dot_basisVec_left
   {α} [Fintype α] [DecidableEq α] (v : α → ℂ) (i : α) :
   (v ⬝ᵥ basisVec i) = v i := by
@@ -218,6 +231,7 @@ by simp[basisVec]
 
 open scoped BigOperators
 
+/-- Basis vectors are normalized. -/
 lemma norm_basisVec {α : Type*} [Fintype α] [DecidableEq α] (i0 : α) :
   norm (basisVec i0 : α → ℂ) = 1 := by
   classical
@@ -247,22 +261,27 @@ This creates a quantum state corresponding to a computational basis vector.
 noncomputable def nQubitKet (n : ℕ) (b : NQubitBasis n) : NQubitState n :=
   ⟨nQubitBasisVec n b, by simpa using norm_basisVec b⟩
 
+/-- Two-qubit computational basis state |00⟩. -/
 noncomputable def ket00 : TwoQubitState :=
   ⟨ basisVec ((0, 0) : TwoQubitBasis),
     by simpa using norm_basisVec ((0, 0) : TwoQubitBasis) ⟩
 
+/-- Two-qubit computational basis state |01⟩. -/
 noncomputable def ket01 : TwoQubitState :=
   ⟨ basisVec ((0, 1) : TwoQubitBasis),
     by simpa using norm_basisVec ((0, 1) : TwoQubitBasis) ⟩
 
+/-- Two-qubit computational basis state |10⟩. -/
 noncomputable def ket10 : TwoQubitState :=
   ⟨ basisVec ((1, 0) : TwoQubitBasis),
     by simpa using norm_basisVec ((1, 0) : TwoQubitBasis) ⟩
 
+/-- Two-qubit computational basis state |11⟩. -/
 noncomputable def ket11 : TwoQubitState :=
   ⟨ basisVec ((1, 1) : TwoQubitBasis),
     by simpa using norm_basisVec ((1, 1) : TwoQubitBasis) ⟩
 
+/-- The `|+⟩` amplitude vector `(1/√2, 1/√2)` has unit norm. -/
 lemma ketPlusNorm1 : norm (![1 / (Real.sqrt 2), 1 / (Real.sqrt 2)]) = 1 := by
   have h : (2⁻¹ : ℝ) + 2⁻¹ = 1 := by norm_num
   simp
@@ -271,6 +290,7 @@ lemma ketPlusNorm1 : norm (![1 / (Real.sqrt 2), 1 / (Real.sqrt 2)]) = 1 := by
 /-- Hadamard-basis ket |+⟩ = (|0⟩ + |1⟩)/√2. -/
 noncomputable def ketPlus : Qubit := ⟨(![1 / (Real.sqrt 2), 1 / (Real.sqrt 2)]), ketPlusNorm1⟩
 
+/-- The `|−⟩` amplitude vector `(1/√2, -1/√2)` has unit norm. -/
 lemma ketMinusNorm1 : norm (![1 / (Real.sqrt 2), -(1 / (Real.sqrt 2))]) = 1 := by
   norm_num [norm_def, Fin.sum_univ_two]
 
@@ -278,53 +298,69 @@ lemma ketMinusNorm1 : norm (![1 / (Real.sqrt 2), -(1 / (Real.sqrt 2))]) = 1 := b
 noncomputable def ketMinus : Qubit :=
   ⟨(![1 / (Real.sqrt 2), -(1 / (Real.sqrt 2))]), ketMinusNorm1⟩
 
+/-- Three-qubit computational basis state |000⟩. -/
 noncomputable def ket000 : ThreeQubitState :=
   ⟨basisVec (0, 0, 0), by
     simpa using
       (norm_basisVec (α := ThreeQubitBasis) (i0 := (0, 0, 0)))⟩
 
+/-- Three-qubit computational basis state |001⟩. -/
 noncomputable def ket001 : ThreeQubitState :=
   ⟨basisVec (0, 0, 1), by
     simpa using
       (norm_basisVec (α := ThreeQubitBasis) (i0 := (0, 0, 1)))⟩
 
+/-- Three-qubit computational basis state |010⟩. -/
 noncomputable def ket010 : ThreeQubitState :=
   ⟨basisVec (0, 1, 0), by
     simpa using
       (norm_basisVec (α := ThreeQubitBasis) (i0 := (0, 1, 0)))⟩
 
+/-- Three-qubit computational basis state |011⟩. -/
 noncomputable def ket011 : ThreeQubitState :=
   ⟨basisVec (0, 1, 1), by
     simpa using
       (norm_basisVec (α := ThreeQubitBasis) (i0 := (0, 1, 1)))⟩
 
+/-- Three-qubit computational basis state |100⟩. -/
 noncomputable def ket100 : ThreeQubitState :=
   ⟨basisVec (1, 0, 0), by
     simpa using
       (norm_basisVec (α := ThreeQubitBasis) (i0 := (1, 0, 0)))⟩
 
+/-- Three-qubit computational basis state |101⟩. -/
 noncomputable def ket101 : ThreeQubitState :=
   ⟨basisVec (1, 0, 1), by
     simpa using
       (norm_basisVec (α := ThreeQubitBasis) (i0 := (1, 0, 1)))⟩
 
+/-- Three-qubit computational basis state |110⟩. -/
 noncomputable def ket110 : ThreeQubitState :=
   ⟨basisVec (1, 1, 0), by
     simpa using
       (norm_basisVec (α := ThreeQubitBasis) (i0 := (1, 1, 0)))⟩
 
+/-- Three-qubit computational basis state |111⟩. -/
 noncomputable def ket111 : ThreeQubitState :=
   ⟨basisVec (1, 1, 1), by
     simpa using
       (norm_basisVec (α := ThreeQubitBasis) (i0 := (1, 1, 1)))⟩
 
+/-- Amplitude vector underlying `ket000`. -/
 @[simp] lemma ket000_val : (ket000 : ThreeQubitVec) = basisVec (0, 0, 0) := rfl
+/-- Amplitude vector underlying `ket001`. -/
 @[simp] lemma ket001_val : (ket001 : ThreeQubitVec) = basisVec (0, 0, 1) := rfl
+/-- Amplitude vector underlying `ket010`. -/
 @[simp] lemma ket010_val : (ket010 : ThreeQubitVec) = basisVec (0, 1, 0) := rfl
+/-- Amplitude vector underlying `ket011`. -/
 @[simp] lemma ket011_val : (ket011 : ThreeQubitVec) = basisVec (0, 1, 1) := rfl
+/-- Amplitude vector underlying `ket100`. -/
 @[simp] lemma ket100_val : (ket100 : ThreeQubitVec) = basisVec (1, 0, 0) := rfl
+/-- Amplitude vector underlying `ket101`. -/
 @[simp] lemma ket101_val : (ket101 : ThreeQubitVec) = basisVec (1, 0, 1) := rfl
+/-- Amplitude vector underlying `ket110`. -/
 @[simp] lemma ket110_val : (ket110 : ThreeQubitVec) = basisVec (1, 1, 0) := rfl
+/-- Amplitude vector underlying `ket111`. -/
 @[simp] lemma ket111_val : (ket111 : ThreeQubitVec) = basisVec (1, 1, 1) := rfl
 
 /-!

--- a/QEC/Foundations/Gates.lean
+++ b/QEC/Foundations/Gates.lean
@@ -50,13 +50,14 @@ abbrev ThreeQubitGate : Type := QuantumGate ThreeQubitBasis
 /-- Gate type for n-qubit systems (indexed by NQubitBasis n). -/
 abbrev NQubitGate (n : ℕ) : Type := QuantumGate (NQubitBasis n)
 
+/-- The matrix underlying the inverse of a gate is the conjugate transpose. -/
 @[simp] lemma gate_inv_val
   {α : Type*} [Fintype α] [DecidableEq α]
   (G : QuantumGate α) :
   (G⁻¹ : QuantumGate α).val = star G.val := by
   rfl
 
--- Inverse-related lemmas (API stubs, proofs later)
+/-- The matrix inverse of a unitary gate's matrix is its conjugate transpose. -/
 @[simp] lemma gate_val_inv
   {α : Type*} [Fintype α] [DecidableEq α]
   (G : QuantumGate α) :
@@ -70,6 +71,7 @@ abbrev NQubitGate (n : ℕ) : Type := QuantumGate (NQubitBasis n)
     _ = 1 * star G.val := by rw [nonsing_inv_mul _ h_unit]
     _ = star G.val := by rw [one_mul]
 
+/-- A gate times its inverse is the identity matrix. -/
 @[simp] lemma gate_val_mul_inv
   {α : Type*} [Fintype α] [DecidableEq α]
   (G : QuantumGate α) :
@@ -77,6 +79,7 @@ abbrev NQubitGate (n : ℕ) : Type := QuantumGate (NQubitBasis n)
   rw [gate_inv_val]
   exact Matrix.mem_unitaryGroup_iff.1 G.2
 
+/-- A gate's inverse times the gate is the identity matrix. -/
 @[simp] lemma gate_val_inv_mul
   {α : Type*} [Fintype α] [DecidableEq α]
   (G : QuantumGate α) :
@@ -90,7 +93,7 @@ abbrev NQubitGate (n : ℕ) : Type := QuantumGate (NQubitBasis n)
   (G₁ G₂ : QuantumGate α) :
   (G₁ * G₂).val = G₁.val * G₂.val := rfl
 
-/-- The identity gate. -/
+/-- The matrix underlying the identity gate is the identity matrix. -/
 @[simp] lemma gate_one_val
 {α : Type*} [Fintype α] [DecidableEq α] :
   (1 : QuantumGate α).val = (1 : Matrix α α ℂ) := rfl
@@ -190,6 +193,7 @@ def conjByGate
 /-- The type of unit complex numbers (those with absolute value 1). -/
 def UnitComplex : Type := {z : ℂ // z * star z = 1}
 
+/-- Coerce a unit complex number to its underlying complex number. -/
 instance : Coe UnitComplex ℂ := ⟨Subtype.val⟩
 
 /-- Construct a unit complex number from a complex number and a proof that it
@@ -208,9 +212,13 @@ def UnitComplex.one : UnitComplex := ⟨1, by simp⟩
 /-- The complex number `-1` as a unit complex number. -/
 def UnitComplex.negOne : UnitComplex := ⟨-1, by simp⟩
 
+/-- `UnitComplex.one` coerces to the complex number `1`. -/
 @[simp] lemma UnitComplex.one_coe : (UnitComplex.one : ℂ) = 1 := rfl
+/-- `UnitComplex.negOne` coerces to the complex number `-1`. -/
 @[simp] lemma UnitComplex.negOne_coe : (UnitComplex.negOne : ℂ) = -1 := rfl
+/-- `UnitComplex.I` coerces to the complex number `i`. -/
 @[simp] lemma UnitComplex.I_coe : (UnitComplex.I : ℂ) = Complex.I := rfl
+/-- `UnitComplex.negI` coerces to the complex number `-i`. -/
 @[simp] lemma UnitComplex.negI_coe : (UnitComplex.negI : ℂ) = -Complex.I := rfl
 
 /-- Scalar multiplication of a gate by a unit complex number.
@@ -232,6 +240,7 @@ noncomputable instance smul_UnitComplex_QuantumGate
     simp only [h_unit, h_G, one_smul]
     }
 
+/-- The matrix underlying a phase-scaled gate is the scaled matrix. -/
 @[simp] lemma smul_UnitComplex_gate_val
   {α : Type*} [Fintype α] [DecidableEq α]
   (c : UnitComplex) (G : QuantumGate α) :
@@ -281,7 +290,6 @@ macro_rules
   | `(tactic| vec_expand) => `(
     tactic| (
       ext i
-      -- If the index is a pair, split it and case-split each component.
       first
         | (rcases i with ⟨i₁, i₂⟩
            <;> fin_cases i₁
@@ -309,35 +317,34 @@ macro_rules
     ))
 
 
+/-- Apply a matrix to a raw function `α → ℂ` (matrix-vector product). -/
 noncomputable abbrev applyMatrixVec' {α : Type*}
   [Fintype α] [DecidableEq α] :
   Matrix α α ℂ → (α → ℂ) → (α → ℂ) :=
   Matrix.mulVec
 
+/-- Apply a matrix to an amplitude `Vector α` (matrix-vector product). -/
 noncomputable abbrev applyMatrixVec
   {α : Type*} [Fintype α] [DecidableEq α] :
   Matrix α α ℂ → Vector α → Vector α :=
   Matrix.mulVec
 
 
+/-- Unitary gates are norm-preserving: `‖Uv‖ = ‖v‖` for every amplitude vector `v`. -/
 lemma gate_preserves_norm
   {α : Type*} [Fintype α] [DecidableEq α]
   (G : QuantumGate α) :
   ∀ v : Vector α, norm (Matrix.mulVec (G.val) v) = norm v :=
 by
   have h_unitary : ∀ (v : Quantum.Vector α), (star G.val).mulVec (G.val.mulVec v) = v := by
-    -- Since $G$ is unitary, we have $G.val * star G.val = 1$, which implies
-    -- that $(star G.val) * G.val = 1$ as well.
     have h_unitary : (star G.val) * G.val = 1 := by
       convert mul_eq_one_comm.mp ( G.2.2 ) using 1;
     exact fun v => by rw [ Matrix.mulVec_mulVec, h_unitary, Matrix.one_mulVec ] ;
-  -- By definition of norm, we have that ‖Gv‖^2 = ⟨Gv, Gv⟩.
   have h_norm_sq : ∀ (v : Quantum.Vector α),
       (Quantum.norm (G.val.mulVec v))^2 =
       ∑ i, (G.val.mulVec v i) * star (G.val.mulVec v i) := by
     simp +decide [ Quantum.norm, Complex.mul_conj, Complex.normSq_eq_norm_sq ];
     norm_cast ; norm_num [ Real.sq_sqrt ( Finset.sum_nonneg fun _ _ => sq_nonneg _ ) ];
-  -- By definition of inner product, we have that ⟨Gv, Gv⟩ = v* G* G v.
   have h_inner : ∀ (v : Quantum.Vector α),
       ∑ i, (G.val.mulVec v i) * star (G.val.mulVec v i) =
       ∑ i, v i * star (v i) := by
@@ -352,14 +359,14 @@ by
         Finset.sum_congr rfl fun _ _ => by ring )
     generalize_proofs at *; (
     rw [ h_inner, h_unitary ]);
-  -- By combining h_norm_sq and h_inner, we can conclude that the square of
-  -- the norm of Gv is equal to the square of the norm of v.
   intros v
   have := h_norm_sq v
   have := h_inner v
   simp_all +decide [ Complex.normSq, Complex.sq_norm ];
   simp_all +decide [ Complex.ext_iff, Finset.sum_add_distrib, mul_comm ]
 
+/-- Apply a gate to a quantum state, producing a quantum state (unitarity keeps
+the result normalized). -/
 noncomputable def applyGate
   {α : Type*} [Fintype α] [DecidableEq α]
   (G : QuantumGate α) (ψ : QuantumState α) :
@@ -372,49 +379,59 @@ by
   rw [ψ.property] at h
   exact h
 
+/-- The amplitude vector of `applyGate G ψ` is the matrix-vector product `G ψ`. -/
 @[simp] lemma applyGate_val
   {α : Type*} [Fintype α] [DecidableEq α]
   (G : QuantumGate α) (ψ : QuantumState α) :
   (applyGate G ψ).val = Matrix.mulVec (G.val) ψ.val := rfl
 
+/-- Coercion form of `applyGate_val`. -/
 @[simp] lemma applyGate_coe
   {α : Type*} [Fintype α] [DecidableEq α]
   (G : QuantumGate α) (ψ : QuantumState α) :
   (applyGate G ψ : Vector α) = Matrix.mulVec (G.val) ψ := rfl
 
+/-- Gates act on amplitude vectors by matrix-vector multiplication. -/
 noncomputable instance smul_Vector_by_QuantumGate
   {α : Type*} [Fintype α] [DecidableEq α] :
   SMul (QuantumGate α) (Vector α) :=
 { smul := fun U v => Matrix.mulVec (U.val) v }
 
+/-- Gates act on quantum states via `applyGate`. -/
 noncomputable instance smul_QuantumState_by_QuantumGate
   {α : Type*} [Fintype α] [DecidableEq α] :
   SMul (QuantumGate α) (QuantumState α) :=
 { smul := applyGate }
 
+/-- The vector coercion of `G • ψ` is the matrix-vector product `G ψ`. -/
 @[simp] lemma smul_val
   {α} [Fintype α] [DecidableEq α]
   (G : QuantumGate α) (ψ : QuantumState α) :
   (G • ψ : Vector α) = Matrix.mulVec (G.val) ψ := rfl
 
+/-- The `.val` field of `G • ψ` is the matrix-vector product `G ψ`. -/
 @[simp] lemma smul_QState_val
   {α : Type*} [Fintype α] [DecidableEq α]
   (G : QuantumGate α) (ψ : QuantumState α) :
   (G • ψ).val = Matrix.mulVec (G.val) ψ.val := rfl
 
+/-- A matrix is Hermitian when it equals its own conjugate transpose. -/
 def Hermitian {α : Type*} [DecidableEq α] [Fintype α] (M : Matrix α α ℂ) : Prop :=
   Mᴴ = M
 
+/-- Unfold `Hermitian` to the equation `Mᴴ = M`. -/
 @[simp] lemma Hermitian_def {α : Type*} [DecidableEq α] [Fintype α] (M : Matrix α α ℂ) :
   Hermitian M ↔ Mᴴ = M := Iff.rfl
 
+/-- A matrix is involutary when it squares to the identity. -/
 def Involutary {α : Type*} [Fintype α] [DecidableEq α] (M : Matrix α α ℂ) : Prop :=
   M * M = 1
 
+/-- Unfold `Involutary` to the equation `M * M = 1`. -/
 @[simp] lemma Involutary_def {α : Type*} [DecidableEq α] [Fintype α] (M : Matrix α α ℂ) :
   Involutary M ↔ M * M = 1 := Iff.rfl
 
--- Inverse-related lemmas (API stubs, proofs later)
+/-- An involutary matrix is its own inverse. -/
 lemma involutary_inv_eq
   {α : Type*} [Fintype α] [DecidableEq α]
   {M : Matrix α α ℂ} (h : Involutary M) :
@@ -444,14 +461,18 @@ lemma unitary_of_hermitian_involutary
 /-- Identity matrix on the qubit basis. -/
 def Imat : Matrix QubitBasis QubitBasis ℂ := 1
 
+/-- The identity matrix is Hermitian. -/
 lemma Imat_hermitian : Hermitian Imat := by
   rw [Hermitian_def, Imat, conjTranspose_one]
 
+/-- The identity matrix is involutary. -/
 lemma Imat_involutary : Involutary Imat := by
   rw [Involutary_def, Imat, mul_one]
 
+/-- `Imat` squares to the identity. -/
 @[simp] lemma Imat_sq : Imat * Imat = 1 := Imat_involutary
 
+/-- The identity matrix is unitary. -/
 lemma Imat_mem_unitaryGroup :
   Imat ∈ Matrix.unitaryGroup QubitBasis ℂ := by
   have h := unitary_of_hermitian_involutary Imat_hermitian Imat_involutary
@@ -461,26 +482,27 @@ lemma Imat_mem_unitaryGroup :
 noncomputable def I : OneQubitGate :=
   ⟨Imat, Imat_mem_unitaryGroup⟩
 
-/- Pauli X matrix -/
+/-- Pauli X matrix, indexed by the qubit basis `Fin 2`. -/
 def Xmat : Matrix QubitBasis QubitBasis ℂ := !![0, 1; 1, 0]
 
+/-- The Pauli X matrix is Hermitian. -/
 lemma Xmat_hermitian : Hermitian Xmat := by matrix_expand[Xmat]
 
+/-- The Pauli X matrix is involutary. -/
 lemma Xmat_involutary : Involutary Xmat := by matrix_expand[Xmat]
 
+/-- `Xmat` squares to the identity. -/
 @[simp] lemma Xmat_sq : Xmat * Xmat = 1 := Xmat_involutary
 
+/-- The Pauli X matrix is unitary. -/
 lemma Xmat_mem_unitaryGroup :
   Xmat ∈ Matrix.unitaryGroup QubitBasis ℂ :=
 by
-  -- old lemma: gives (UUᴴ = 1 ∧ UᴴU = 1)
   have h := unitary_of_hermitian_involutary Xmat_hermitian Xmat_involutary
-  -- we only need U * Uᴴ = 1
   have hU : Xmat * Xmatᴴ = 1 := h.1
-  -- mathlib's membership lemma:
-  --   A ∈ unitaryGroup ↔ A ⬝ Aᴴ = 1
   exact (Matrix.mem_unitaryGroup_iff.mpr hU)
 
+/-- Pauli X as a one-qubit gate. -/
 noncomputable def X : OneQubitGate :=
 { val      := Xmat
 , property := Xmat_mem_unitaryGroup }
@@ -489,12 +511,16 @@ noncomputable def X : OneQubitGate :=
 def Ymat : Matrix QubitBasis QubitBasis ℂ :=
   !![0, -Complex.I; Complex.I, 0]
 
+/-- The Pauli Y matrix is Hermitian. -/
 lemma Ymat_hermitian : Hermitian Ymat := by matrix_expand[Ymat]
 
+/-- The Pauli Y matrix is involutary. -/
 lemma Ymat_involutary : Involutary Ymat := by matrix_expand[Ymat]
 
+/-- `Ymat` squares to the identity. -/
 @[simp] lemma Ymat_sq : Ymat * Ymat = 1 := Ymat_involutary
 
+/-- The Pauli Y matrix is unitary. -/
 lemma Ymat_mem_unitaryGroup :
   Ymat ∈ Matrix.unitaryGroup QubitBasis ℂ :=
 by
@@ -511,10 +537,13 @@ noncomputable def Y : OneQubitGate :=
 def Zmat : Matrix QubitBasis QubitBasis ℂ :=
   !![1, 0; 0, -1]
 
+/-- The Pauli Z matrix is Hermitian. -/
 lemma Zmat_hermitian : Hermitian Zmat := by matrix_expand[Zmat]
 
+/-- The Pauli Z matrix is involutary. -/
 lemma Zmat_involutary : Involutary Zmat := by matrix_expand[Zmat]
 
+/-- `Zmat` squares to the identity. -/
 @[simp] lemma Zmat_sq : Zmat * Zmat = 1 := Zmat_involutary
 
 /-- Pauli matrix cross products: X * Y = iZ -/
@@ -535,6 +564,7 @@ lemma Zmat_mul_Xmat : Zmat * Xmat = Complex.I • Ymat := by matrix_expand[Xmat,
 /-- Pauli matrix cross products: X * Z = -iY -/
 lemma Xmat_mul_Zmat : Xmat * Zmat = -Complex.I • Ymat := by matrix_expand[Xmat, Ymat, Zmat]
 
+/-- The Pauli Z matrix is unitary. -/
 lemma Zmat_mem_unitaryGroup :
   Zmat ∈ Matrix.unitaryGroup QubitBasis ℂ :=
 by
@@ -546,12 +576,16 @@ by
 noncomputable def Hmat : Matrix QubitBasis QubitBasis ℂ :=
   (1 / Real.sqrt 2) • !![1, 1; 1, -1]
 
+/-- The Hadamard matrix is Hermitian. -/
 lemma Hmat_hermitian : Hermitian Hmat := by matrix_expand[Hmat]
 
+/-- The Hadamard matrix is involutary. -/
 lemma Hmat_involutary : Involutary Hmat := by matrix_expand[Hmat]
 
+/-- `Hmat` squares to the identity. -/
 @[simp] lemma Hmat_sq : Hmat * Hmat = 1 := Hmat_involutary
 
+/-- The Hadamard matrix is unitary. -/
 lemma Hmat_mem_unitaryGroup :
   Hmat ∈ Matrix.unitaryGroup QubitBasis ℂ :=
 by
@@ -570,10 +604,15 @@ noncomputable def Z : OneQubitGate :=
 { val := Zmat
 , property := Zmat_mem_unitaryGroup }
 
+/-- The matrix underlying the gate `I` is `Imat`. -/
 @[simp] lemma coe_I : (I : Matrix QubitBasis QubitBasis ℂ) = Imat := rfl
+/-- The matrix underlying the gate `X` is `Xmat`. -/
 @[simp] lemma coe_X : (X : Matrix QubitBasis QubitBasis ℂ) = Xmat := rfl
+/-- The matrix underlying the gate `Y` is `Ymat`. -/
 @[simp] lemma coe_Y : (Y : Matrix QubitBasis QubitBasis ℂ) = Ymat := rfl
+/-- The matrix underlying the gate `Z` is `Zmat`. -/
 @[simp] lemma coe_Z : (Z : Matrix QubitBasis QubitBasis ℂ) = Zmat := rfl
+/-- The matrix underlying the gate `H` is `Hmat`. -/
 @[simp] lemma coe_H : (H : Matrix QubitBasis QubitBasis ℂ) = Hmat := rfl
 
 /-- Pauli gate cross products: X * Y = iZ -/
@@ -618,22 +657,27 @@ noncomputable def Z : OneQubitGate :=
       UnitComplex.negI_coe]
     exact Xmat_mul_Zmat)
 
+/-- `I` is self-inverse (it is Hermitian and involutary). -/
 @[simp] lemma inv_I : I⁻¹ = I := by
   ext
   rw [gate_inv_val, coe_I, star_eq_conjTranspose, (Hermitian_def Imat).1 Imat_hermitian]
 
+/-- `X` is self-inverse (it is Hermitian and involutary). -/
 @[simp] lemma inv_X : X⁻¹ = X := by
   ext
   rw [gate_inv_val, coe_X, star_eq_conjTranspose, (Hermitian_def Xmat).1 Xmat_hermitian]
 
+/-- `Y` is self-inverse (it is Hermitian and involutary). -/
 @[simp] lemma inv_Y : Y⁻¹ = Y := by
   ext
   rw [gate_inv_val, coe_Y, star_eq_conjTranspose, (Hermitian_def Ymat).1 Ymat_hermitian]
 
+/-- `Z` is self-inverse (it is Hermitian and involutary). -/
 @[simp] lemma inv_Z : Z⁻¹ = Z := by
   ext
   rw [gate_inv_val, coe_Z, star_eq_conjTranspose, (Hermitian_def Zmat).1 Zmat_hermitian]
 
+/-- `H` is self-inverse (it is Hermitian and involutary). -/
 @[simp] lemma inv_H : H⁻¹ = H := by
   ext
   rw [gate_inv_val, coe_H, star_eq_conjTranspose, (Hermitian_def Hmat).1 Hmat_hermitian]
@@ -657,34 +701,39 @@ noncomputable def S : OneQubitGate :=
 /-- The inverse of the phase gate S (S†). -/
 noncomputable def inv_S : OneQubitGate := S⁻¹
 
+/-- The matrix underlying the gate `S` is `Smat`. -/
 @[simp] lemma coe_S : (S : Matrix QubitBasis QubitBasis ℂ) = Smat := rfl
 
+/-- The matrix underlying `inv_S` is the conjugate transpose of `Smat`. -/
 lemma inv_S_val : inv_S.val = star S.val := by
   rw [inv_S, gate_inv_val]
 
+/-- X flips |0⟩ to |1⟩. -/
 @[simp] lemma X_on_ket0 : X • |0⟩ = |1⟩ := by
   vec_expand_simp [Xmat, ket0, ket1]
 
+/-- X flips |1⟩ to |0⟩. -/
 @[simp] lemma X_on_ket1 : X • |1⟩ = |0⟩ := by
   vec_expand_simp [Xmat, ket0, ket1]
 
--- Controlled version of a gate `g` on `k`, acting on `QubitBasis × k`.
+/-- Controlled version of a gate `g` on `k`, acting on `QubitBasis × k`.
+
+The first factor is the control qubit: on the `|0⟩` block the gate acts as the
+identity on `k`, on the `|1⟩` block it acts as `g`, and the off-diagonal blocks
+are zero.
+-/
 noncomputable def controllize
   {k : Type*} [Fintype k] [DecidableEq k]
   (g : QuantumGate k) : QuantumGate (QubitBasis × k) :=
 by
   classical
   exact ⟨
-    -- underlying matrix
     Matrix.of (fun (q₁, t₁) (q₂, t₂) =>
       if (q₁, q₂) = (0, 0) then
-        -- control = 0: act as identity on k
         (if t₁ = t₂ then (1 : ℂ) else 0)
       else if (q₁, q₂) = (1, 1) then
-        -- control = 1: apply g on k
         (g : Matrix k k ℂ) t₁ t₂
       else
-        -- off-diagonal blocks: zero
         0)
     ,
     by
@@ -696,6 +745,7 @@ by
   ⟩
 scoped notation "C[" g "]" => controllize g
 
+/-- The block matrix underlying `controllize g`. -/
 @[simp] lemma controllize_val
   {k : Type*} [Fintype k] [DecidableEq k]
   (g : QuantumGate k) :
@@ -709,11 +759,14 @@ scoped notation "C[" g "]" => controllize g
         0) :=
 rfl
 
-/-- CNOT gate on two qubits: control = first, target = second. -/
+/-- CNOT gate on two qubits: control = first, target = second.
+
+This is `controllize X` with `k = QubitBasis`.
+-/
 noncomputable def CNOT : TwoQubitGate :=
   C[X]
-  -- i.e. controllize X, with k = QubitBasis
 
+/-- Pointwise amplitudes of the two-qubit basis state `ket00`. -/
 @[simp] lemma ket00_apply
   (q : QubitBasis) (t : QubitBasis) :
   (|00⟩ : QuantumState TwoQubitBasis).val (q, t)
@@ -721,15 +774,19 @@ noncomputable def CNOT : TwoQubitGate :=
 by
   simp [ket00]
 
+/-- CNOT maps |00⟩ to |00⟩. -/
 lemma CNOT_on_ket00 : CNOT • |00⟩ = |00⟩ := by
   vec_expand_simp [Matrix.mulVec, CNOT, ket00]
 
+/-- CNOT maps |01⟩ to |01⟩. -/
 lemma CNOT_on_ket01 : CNOT • |01⟩ = |01⟩ := by
   vec_expand_simp[Matrix.mulVec, CNOT, ket01]
 
+/-- CNOT maps |10⟩ to |11⟩. -/
 lemma CNOT_on_ket10 : CNOT • |10⟩ = |11⟩ := by
   vec_expand_simp[Matrix.mulVec, CNOT, ket10, ket11, Xmat]
 
+/-- CNOT maps |11⟩ to |10⟩. -/
 lemma CNOT_on_ket11 : CNOT • |11⟩ = |10⟩ := by
   vec_expand_simp[Matrix.mulVec, CNOT, ket10, ket11, Xmat]
 

--- a/QEC/Foundations/Tensor.lean
+++ b/QEC/Foundations/Tensor.lean
@@ -30,6 +30,8 @@ namespace Quantum
 open Matrix
 open Kronecker
 
+/-- The conjugate transpose of a Kronecker product is the Kronecker product of the
+conjugate transposes. -/
 @[simp]
 theorem star_kron
   {α β : Type*}
@@ -51,6 +53,8 @@ theorem kron_unitary
   classical
   simp [Matrix.mem_unitaryGroup_iff, star_kron, ← Matrix.mul_kronecker_mul]
 
+/-- Tensor product of two gates: the Kronecker product of their matrices, acting
+independently on the two subsystems. -/
 noncomputable def tensorGate
   {α β : Type*}
   [Fintype α] [DecidableEq α]
@@ -64,6 +68,7 @@ by
 
 scoped notation G₁:60 " ⊗ᵍ " G₂:60 => tensorGate G₁ G₂
 
+/-- The matrix underlying `tensorGate G₁ G₂` is the Kronecker product `G₁ ⊗ₖ G₂`. -/
 @[simp]
 lemma tensorGate_val
   {α β : Type*} [Fintype α] [DecidableEq α]
@@ -95,7 +100,8 @@ by
   erw [ Finset.sum_product ]
   simp_all [ ←Finset.mul_sum]
 
-/-- Tensor product of quantum states. -/
+/-- Tensor product of two quantum states: amplitudes multiply component-wise,
+and the result is again normalized. -/
 noncomputable def tensorState
   {α β : Type*} [Fintype α] [DecidableEq α]
   [Fintype β] [DecidableEq β]
@@ -103,23 +109,27 @@ noncomputable def tensorState
   QuantumState (α × β) :=
 by
   refine ⟨tensorVec ψ.val φ.val, ?_⟩
-  -- use the norm lemma with hv := ψ.property, hw := φ.property
   exact norm_tensorVec_of_norm1 ψ.property φ.property
 
 scoped notation ψ:60 " ⊗ₛ " φ:60 => tensorState ψ φ
 
+/-- X on the first of two qubits (X ⊗ I). -/
 noncomputable def X_q1_2 : TwoQubitGate :=
   tensorGate X 1
 
+/-- X on the second of two qubits (I ⊗ X). -/
 noncomputable def X_q2_2 : TwoQubitGate :=
   tensorGate 1 X
 
+/-- Z on the first of two qubits (Z ⊗ I). -/
 noncomputable def Z_q1_2 : TwoQubitGate :=
   tensorGate Z 1
 
+/-- Z on the second of two qubits (I ⊗ Z). -/
 noncomputable def Z_q2_2 : TwoQubitGate :=
   tensorGate 1 Z
 
+/-- X on the first qubit and Z on the second (X ⊗ Z). -/
 noncomputable def X_q1Z_q2_2 : TwoQubitGate :=
   tensorGate X Z
 
@@ -131,171 +141,215 @@ noncomputable def XX_2 : TwoQubitGate :=
 noncomputable def ZZ_2 : TwoQubitGate :=
   tensorGate Z Z
 
+/-- X ⊗ I: |00⟩ ↦ |10⟩. -/
 @[simp] lemma X_q1_2_on_ket00 : X_q1_2 • |00⟩ = |10⟩ := by
   vec_expand_simp [X_q1_2, Matrix.mulVec, ket00, ket10, Xmat]
 
+/-- X ⊗ I: |01⟩ ↦ |11⟩. -/
 @[simp] lemma X_q1_2_on_ket01 : X_q1_2 • |01⟩ = |11⟩ := by
   vec_expand_simp [X_q1_2,  Matrix.mulVec, ket01, ket11, Xmat]
 
+/-- X ⊗ I: |10⟩ ↦ |00⟩. -/
 @[simp] lemma X_q1_2_on_ket10 : X_q1_2 • |10⟩ = |00⟩ := by
   vec_expand_simp [X_q1_2,  Matrix.mulVec, ket10, ket00, Xmat]
 
+/-- X ⊗ I: |11⟩ ↦ |01⟩. -/
 @[simp] lemma X_q1_2_on_ket11 : X_q1_2 • |11⟩ = |01⟩ := by
   vec_expand_simp [X_q1_2,  Matrix.mulVec, ket11, ket01, Xmat]
 
+/-- I ⊗ X: |00⟩ ↦ |01⟩. -/
 @[simp] lemma X_q2_2_on_ket00 : X_q2_2 • |00⟩ = |01⟩ := by
   vec_expand_simp [X_q2_2,  Matrix.mulVec, ket00, ket01, Xmat]
 
+/-- I ⊗ X: |01⟩ ↦ |00⟩. -/
 @[simp] lemma X_q2_2_on_ket01 : X_q2_2 • |01⟩ = |00⟩ := by
   vec_expand_simp [X_q2_2,  Matrix.mulVec, ket01, ket00, Xmat]
 
+/-- I ⊗ X: |10⟩ ↦ |11⟩. -/
 @[simp] lemma X_q2_2_on_ket10 : X_q2_2 • |10⟩ = |11⟩ := by
   vec_expand_simp [X_q2_2,  Matrix.mulVec, ket10, ket11, Xmat]
 
+/-- I ⊗ X: |11⟩ ↦ |10⟩. -/
 @[simp] lemma X_q2_2_on_ket11 : X_q2_2 • |11⟩ = |10⟩ := by
   vec_expand_simp [X_q2_2,  Matrix.mulVec, ket11, ket10, Xmat]
 
--- X on first qubit, I on others: X ⊗ I ⊗ I
+/-- X on the first of three qubits (X ⊗ I ⊗ I). -/
 noncomputable def X_q1_3 : ThreeQubitGate :=
   tensorGate X 1
 
--- X on second qubit, I elsewhere: I ⊗ X ⊗ I
+/-- X on the second of three qubits (I ⊗ X ⊗ I). -/
 noncomputable def X_q2_3 : ThreeQubitGate :=
   tensorGate 1 (tensorGate X 1)
 
--- X on third qubit, I elsewhere: I ⊗ I ⊗ X
+/-- X on the third of three qubits (I ⊗ I ⊗ X). -/
 noncomputable def X_q3_3 : ThreeQubitGate :=
   tensorGate 1 (tensorGate 1 X)
 
--- X on qubits 1 2 3 (X ⊗ X ⊗ X)
+/-- X on all three qubits (X ⊗ X ⊗ X). -/
 noncomputable def X_q1q2q3_3 : ThreeQubitGate :=
   tensorGate X (tensorGate X X)
 
+/-- X ⊗ I ⊗ I: |000⟩ ↦ |100⟩. -/
 @[simp] lemma X_q1_3_on_ket000 : X_q1_3 • ket000 = ket100 := by
   vec_expand_simp [X_q1_3, Matrix.mulVec, Xmat]
 
+/-- X ⊗ I ⊗ I: |001⟩ ↦ |101⟩. -/
 @[simp] lemma X_q1_3_on_ket001 : X_q1_3 • ket001 = ket101 := by
   vec_expand_simp [X_q1_3, Matrix.mulVec, Xmat]
 
+/-- X ⊗ I ⊗ I: |010⟩ ↦ |110⟩. -/
 @[simp] lemma X_q1_3_on_ket010 : X_q1_3 • ket010 = ket110 := by
   vec_expand_simp [X_q1_3, Matrix.mulVec, Xmat]
 
+/-- X ⊗ I ⊗ I: |011⟩ ↦ |111⟩. -/
 @[simp] lemma X_q1_3_on_ket011 : X_q1_3 • ket011 = ket111 := by
   vec_expand_simp [X_q1_3, Matrix.mulVec, Xmat]
 
+/-- X ⊗ I ⊗ I: |100⟩ ↦ |000⟩. -/
 @[simp] lemma X_q1_3_on_ket100 : X_q1_3 • ket100 = ket000 := by
   vec_expand_simp [X_q1_3, Matrix.mulVec, Xmat]
 
+/-- X ⊗ I ⊗ I: |101⟩ ↦ |001⟩. -/
 @[simp] lemma X_q1_3_on_ket101 : X_q1_3 • ket101 = ket001 := by
   vec_expand_simp [X_q1_3, Matrix.mulVec, Xmat]
 
+/-- X ⊗ I ⊗ I: |110⟩ ↦ |010⟩. -/
 @[simp] lemma X_q1_3_on_ket110 : X_q1_3 • ket110 = ket010 := by
   vec_expand_simp [X_q1_3, Matrix.mulVec, Xmat]
 
+/-- X ⊗ I ⊗ I: |111⟩ ↦ |011⟩. -/
 @[simp] lemma X_q1_3_on_ket111 : X_q1_3 • ket111 = ket011 := by
   vec_expand_simp [X_q1_3, Matrix.mulVec, Xmat]
 
+/-- X ⊗ X ⊗ X: |000⟩ ↦ |111⟩. -/
 @[simp] lemma X_q1q2q3_on_ket000 : X_q1q2q3_3 • ket000 = ket111 := by
   vec_expand_simp[X_q1q2q3_3, Matrix.mulVec, Xmat]
 
+/-- X ⊗ X ⊗ X: |111⟩ ↦ |000⟩. -/
 @[simp] lemma X_q1q2q3_on_ket111 : X_q1q2q3_3 • ket111 = ket000 := by
   vec_expand_simp[X_q1q2q3_3, Matrix.mulVec, Xmat]
 
-/-
-  X_q2_3 : I ⊗ X ⊗ I
-  Flips the second bit.
--/
+/-! ### `X_q2_3` (I ⊗ X ⊗ I): flips the second bit -/
 
+
+/-- I ⊗ X ⊗ I: |000⟩ ↦ |010⟩. -/
 @[simp] lemma X_q2_3_on_ket000 : X_q2_3 • ket000 = ket010 := by
   vec_expand_simp [X_q2_3, Matrix.mulVec, Xmat]
 
+/-- I ⊗ X ⊗ I: |001⟩ ↦ |011⟩. -/
 @[simp] lemma X_q2_3_on_ket001 : X_q2_3 • ket001 = ket011 := by
   vec_expand_simp [X_q2_3, Matrix.mulVec, Xmat]
 
+/-- I ⊗ X ⊗ I: |010⟩ ↦ |000⟩. -/
 @[simp] lemma X_q2_3_on_ket010 : X_q2_3 • ket010 = ket000 := by
   vec_expand_simp [X_q2_3, Matrix.mulVec, Xmat]
 
+/-- I ⊗ X ⊗ I: |011⟩ ↦ |001⟩. -/
 @[simp] lemma X_q2_3_on_ket011 : X_q2_3 • ket011 = ket001 := by
   vec_expand_simp [X_q2_3, Matrix.mulVec, Xmat]
 
+/-- I ⊗ X ⊗ I: |100⟩ ↦ |110⟩. -/
 @[simp] lemma X_q2_3_on_ket100 : X_q2_3 • ket100 = ket110 := by
   vec_expand_simp [X_q2_3, Matrix.mulVec, Xmat]
 
+/-- I ⊗ X ⊗ I: |101⟩ ↦ |111⟩. -/
 @[simp] lemma X_q2_3_on_ket101 : X_q2_3 • ket101 = ket111 := by
   vec_expand_simp [X_q2_3, Matrix.mulVec, Xmat]
 
+/-- I ⊗ X ⊗ I: |110⟩ ↦ |100⟩. -/
 @[simp] lemma X_q2_3_on_ket110 : X_q2_3 • ket110 = ket100 := by
   vec_expand_simp [X_q2_3, Matrix.mulVec, Xmat]
 
+/-- I ⊗ X ⊗ I: |111⟩ ↦ |101⟩. -/
 @[simp] lemma X_q2_3_on_ket111 : X_q2_3 • ket111 = ket101 := by
   vec_expand_simp [X_q2_3, Matrix.mulVec, Xmat]
 
 
-/-
-  X_q3_3 : I ⊗ I ⊗ X
-  Flips the third bit.
--/
+/-! ### `X_q3_3` (I ⊗ I ⊗ X): flips the third bit -/
 
+
+/-- I ⊗ I ⊗ X: |000⟩ ↦ |001⟩. -/
 @[simp] lemma X_q3_3_on_ket000 : X_q3_3 • ket000 = ket001 := by
   vec_expand_simp [X_q3_3, Matrix.mulVec, Xmat]
 
+/-- I ⊗ I ⊗ X: |001⟩ ↦ |000⟩. -/
 @[simp] lemma X_q3_3_on_ket001 : X_q3_3 • ket001 = ket000 := by
   vec_expand_simp [X_q3_3, Matrix.mulVec, Xmat]
 
+/-- I ⊗ I ⊗ X: |010⟩ ↦ |011⟩. -/
 @[simp] lemma X_q3_3_on_ket010 : X_q3_3 • ket010 = ket011 := by
   vec_expand_simp [X_q3_3, Matrix.mulVec, Xmat]
 
+/-- I ⊗ I ⊗ X: |011⟩ ↦ |010⟩. -/
 @[simp] lemma X_q3_3_on_ket011 : X_q3_3 • ket011 = ket010 := by
   vec_expand_simp [X_q3_3, Matrix.mulVec, Xmat]
 
+/-- I ⊗ I ⊗ X: |100⟩ ↦ |101⟩. -/
 @[simp] lemma X_q3_3_on_ket100 : X_q3_3 • ket100 = ket101 := by
   vec_expand_simp [X_q3_3, Matrix.mulVec, Xmat]
 
+/-- I ⊗ I ⊗ X: |101⟩ ↦ |100⟩. -/
 @[simp] lemma X_q3_3_on_ket101 : X_q3_3 • ket101 = ket100 := by
   vec_expand_simp [X_q3_3, Matrix.mulVec, Xmat]
 
+/-- I ⊗ I ⊗ X: |110⟩ ↦ |111⟩. -/
 @[simp] lemma X_q3_3_on_ket110 : X_q3_3 • ket110 = ket111 := by
   vec_expand_simp [X_q3_3, Matrix.mulVec, Xmat]
 
+/-- I ⊗ I ⊗ X: |111⟩ ↦ |110⟩. -/
 @[simp] lemma X_q3_3_on_ket111 : X_q3_3 • ket111 = ket110 := by
   vec_expand_simp [X_q3_3, Matrix.mulVec, Xmat]
 
-/-- CNOT on qubits 1 (control) and 2 (target) of a 3-qubit register. -/
+/-- CNOT on qubits 1 (control) and 2 (target) of a 3-qubit register.
+
+The control sits on q1 and the controlled gate on `(q2, q3)` flips q2 only.
+-/
 noncomputable def CNOT_q1_q2_3 : ThreeQubitGate :=
-  -- control on q1, gate on (q2,q3) flips q2 only
   controllize (X_q1_2)
 
-/-- CNOT on qubits 1 (control) and 3 (target) of a 3-qubit register. -/
+/-- CNOT on qubits 1 (control) and 3 (target) of a 3-qubit register.
+
+The control sits on q1 and the controlled gate on `(q2, q3)` flips q3 only.
+-/
 noncomputable def CNOT_q1_q3_3 : ThreeQubitGate :=
-  -- control on q1, gate on (q2,q3) flips q3 only
   controllize (X_q2_2)
 
-/-- CNOT on qubits 2 (control) and 3 (target) of a 3-qubit register. -/
+/-- CNOT on qubits 2 (control) and 3 (target) of a 3-qubit register.
+
+This is the identity on q1 tensored with CNOT on `(q2, q3)`.
+-/
 noncomputable def CNOT_q2_q3_3 : ThreeQubitGate :=
-  -- identity on q1, CNOT on (q2,q3)
   tensorGate (1 : OneQubitGate) CNOT
 
+/-- CNOT with control q2 and target q3: |000⟩ ↦ |000⟩. -/
 @[simp] lemma CNOT_q2_q3_3_on_ket000 : CNOT_q2_q3_3 • ket000 = ket000 := by
   vec_expand_simp [CNOT_q2_q3_3, Matrix.mulVec, CNOT, controllize, Xmat]
 
+/-- CNOT with control q2 and target q3: |001⟩ ↦ |001⟩. -/
 @[simp] lemma CNOT_q2_q3_3_on_ket001 : CNOT_q2_q3_3 • ket001 = ket001 := by
   vec_expand_simp [CNOT_q2_q3_3,  Matrix.mulVec, CNOT, controllize, Xmat]
 
+/-- CNOT with control q2 and target q3: |010⟩ ↦ |011⟩. -/
 @[simp] lemma CNOT_q2_q3_3_on_ket010 : CNOT_q2_q3_3 • ket010 = ket011 := by
   vec_expand_simp [CNOT_q2_q3_3,  Matrix.mulVec, CNOT, controllize, Xmat]
 
+/-- CNOT with control q2 and target q3: |011⟩ ↦ |010⟩. -/
 @[simp] lemma CNOT_q2_q3_3_on_ket011 : CNOT_q2_q3_3 • ket011 = ket010 := by
   vec_expand_simp [CNOT_q2_q3_3,  Matrix.mulVec, CNOT, controllize, Xmat]
 
+/-- CNOT with control q2 and target q3: |100⟩ ↦ |100⟩. -/
 @[simp] lemma CNOT_q2_q3_3_on_ket100 : CNOT_q2_q3_3 • ket100 = ket100 := by
   vec_expand_simp [CNOT_q2_q3_3,  Matrix.mulVec, CNOT, controllize, Xmat]
 
+/-- CNOT with control q2 and target q3: |101⟩ ↦ |101⟩. -/
 @[simp] lemma CNOT_q2_q3_3_on_ket101 : CNOT_q2_q3_3 • ket101 = ket101 := by
   vec_expand_simp [CNOT_q2_q3_3,  Matrix.mulVec, CNOT, controllize, Xmat]
 
+/-- CNOT with control q2 and target q3: |110⟩ ↦ |111⟩. -/
 @[simp] lemma CNOT_q2_q3_3_on_ket110 : CNOT_q2_q3_3 • ket110 = ket111 := by
   vec_expand_simp [CNOT_q2_q3_3,  Matrix.mulVec, CNOT, controllize, Xmat]
 
+/-- CNOT with control q2 and target q3: |111⟩ ↦ |110⟩. -/
 @[simp] lemma CNOT_q2_q3_3_on_ket111 : CNOT_q2_q3_3 • ket111 = ket110 := by
   vec_expand_simp [CNOT_q2_q3_3,  Matrix.mulVec, CNOT, controllize, Xmat]
 


### PR DESCRIPTION
Documentation pass over `QEC/Foundations`: every `def`/`abbrev`/`lemma`/`theorem`/`instance` now carries a `/--` docstring, and the narration comments inside proof bodies are gone.

Based on `claude/qec-quantum-state-notation-1ea822` so the ket-notation statements (`X • |0⟩ = |1⟩`) are preserved — docstrings sit above them unchanged.

## 1. Documentation coverage

A scanner over the directory now reports zero declarations without a docstring.

- **Basic** — `norm`/`norm_def`, `TwoQubitState`, `ThreeQubitVec`/`ThreeQubitState`, `basisVec` and its lemmas, `norm_basisVec`, `ketPlusNorm1`, `ketMinusNorm1`, `ket00`–`ket11`, `ket000`–`ket111` and the eight `_val` simp lemmas. The shared `toNQubitBasis` docstring is split so the n=3 conversion gets its own.
- **Gates** — the gate-inverse API, `UnitComplex` coercions and the `Coe` instance, `applyMatrixVec`, `gate_preserves_norm`, `applyGate`, both `SMul` instances, `Hermitian`/`Involutary`, `involutary_inv_eq`, the full `{I,X,Y,Z,H}mat_{hermitian,involutary,sq,mem_unitaryGroup}` grid, `X`, `coe_*`, `inv_*`, `inv_S_val`, `X_on_ket*`, `controllize_val`, `ket00_apply`, `CNOT_on_ket*`.
- **Tensor** — `star_kron`, `tensorGate`/`tensorGate_val`, the two- and three-qubit Pauli placements, and all of the ket-action lemmas.
- `GateConjugation` and `UniformTransversalGate` were already fully documented.

Three comments Lean never attached as docs — a `/- -/` block on `Xmat`, and `--` lines above `basisVec` and `controllize` — are now real `/-- -/` blocks. Two stale `-- Inverse-related lemmas (API stubs, proofs later)` banners are dropped; those proofs are complete.

## 2. In-proof comments removed

`gate_preserves_norm` (four narration blocks), `Xmat_mem_unitaryGroup` (the "old lemma / we only need / mathlib's membership lemma" chain), `controllize` (branch comments, folded into its docstring), `tensorState`, the `vec_expand` tactic quotation, and the trailing notes on `CNOT` and the three `CNOT_q*_q*_3` defs.

One judgment call: the floating `/- X_q2_3 : I ⊗ X ⊗ I / Flips the second bit -/` blocks in Tensor weren't inside proofs, so removal wasn't required — they became `/-! ### -/` section headers so they render in the module docs instead of being invisible.

## Verification

**This change is comment-only.** Stripping all comments from the five files at this revision and at the branch point yields identical text, so no proof term or statement is touched and the base branch's build result carries over.

An earlier revision of this work (same docstrings, on the pre-Dirac-notation base) was confirmed with `lake build QEC.Foundations.Foundations`. No build was re-run after the rebase onto the ket-notation branch, since the comment-stripped equality makes it redundant. The remaining `linter.flexible` warnings in these files are pre-existing and sit on `simp` calls in proof bodies this PR does not modify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
