### PR TITLE
Filter the dependency graph to one node's dependencies

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -8,10 +8,17 @@ name: Blueprint
 # node whose `\cref` points at nothing. The plasTeX half catches LaTeX errors
 # in the extracted prose.
 #
-# Deployment to GitHub Pages is deliberately manual (see the `deploy` input).
-# This repository's Pages site currently serves the path-preserving redirect
-# built by `pages-redirect.yml`, and whichever workflow deploys last wins, so
-# publishing the blueprint is a decision rather than a side effect of a push.
+# This workflow owns the GitHub Pages site: a push to `main` republishes the
+# blueprint, so what is served always matches `main`. It used to be a manual
+# `workflow_dispatch`, on the grounds that `pages-redirect.yml` also deploys
+# and whichever runs last wins -- but that workflow only triggers on its own
+# file changing or on an explicit dispatch, so it cannot clobber the blueprint
+# by accident, and the real cost of the manual gate was a site that silently
+# fell behind `main` after every merge. The `deploy` input is kept for
+# republishing without a content change.
+#
+# Deploys are restricted to `main`: pull requests and branch pushes build and
+# check the blueprint, and publish nothing.
 
 on:
   push:
@@ -27,7 +34,7 @@ on:
   workflow_dispatch:
     inputs:
       deploy:
-        description: 'Publish to GitHub Pages (overwrites the redirect site)'
+        description: 'Republish to GitHub Pages (pushes to main publish anyway)'
         type: boolean
         default: false
       pdf:
@@ -43,6 +50,12 @@ on:
 concurrency:
   group: blueprint-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || 'auto' }}
   cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
+env:
+  # Publish from `main` only: on any push to it, or on a dispatch that ticked
+  # `deploy`. Steps read this; the deploy job cannot (the `env` context is not
+  # available in a job-level `if:`) and so spells the condition out again.
+  PUBLISH: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.deploy)) }}
 
 permissions:
   contents: read
@@ -164,12 +177,11 @@ jobs:
           path: blueprint/print/print.pdf
           if-no-files-found: error
 
-      # Assemble the Pages site only when a deploy was explicitly asked for.
       # The blueprint lands at the site root; the legacy dashboard redirect
       # that `pages-redirect.yml` publishes is preserved as `404.html`, so old
       # `/QECLean/<path>` links still bounce to the qec-lab dashboard.
       - name: Assemble the Pages site
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy }}
+        if: ${{ env.PUBLISH == 'true' }}
         run: |
           mkdir -p site
           cp -r blueprint/web/. site/
@@ -196,17 +208,22 @@ jobs:
           touch site/.nojekyll
 
       - uses: actions/configure-pages@v5
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy }}
+        if: ${{ env.PUBLISH == 'true' }}
 
       - uses: actions/upload-pages-artifact@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy }}
+        if: ${{ env.PUBLISH == 'true' }}
         with:
           path: site
 
   deploy:
     needs: build
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy }}
+    if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.deploy)) }}
     runs-on: ubuntu-latest
+    # Serialize against the other workflow that can publish to Pages, so two
+    # deploys never race for the site. `pages-redirect.yml` uses this group.
+    concurrency:
+      group: pages
+      cancel-in-progress: false
     permissions:
       contents: read
       pages: write

--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -5,18 +5,18 @@ on:
   pull_request:
   workflow_dispatch:
 
-# Cancel any in-progress run on the same ref when a new push lands.
-# Prevents the pile-up we saw where 6 concurrent runs all churned through
-# docgen for ~2h each.
+# Cancel any in-progress run on the same ref when a new push lands. Originally
+# to stop the pile-up where 6 concurrent runs each churned through docgen for
+# ~2h; docgen has since been removed, but a full Lean build is still worth not
+# running several times over for superseded commits.
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+# This workflow no longer publishes anything (see the note where the docgen
+# step used to be), so it needs no more than read access to the repository.
 permissions:
-  contents: read # Read access to repository contents
-  pages: write # Write access to GitHub Pages
-  id-token: write # Write access to ID tokens
+  contents: read
 
 jobs:
   build:
@@ -50,16 +50,20 @@ jobs:
       # costs seconds rather than a rebuild.
       - name: Axiom policy (standard three axioms only)
         run: lake env lean scripts/AxiomCheck.lean
-      # docgen rebuilds API docs for the project + all of mathlib (~1-2h with
-      # no cache). Skip it on every push/PR; only run on tag pushes or manual
-      # dispatch so day-to-day CI stays fast.
-      - if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
-        uses: leanprover-community/docgen-action@v1
-        with:
-          # Point `homepage` at a directory that does not exist in the repo.
-          # The action's `Check for ${homepage} folder` step then sets
-          # `DOCS_EXISTS=false`, so the Jekyll bundle/build steps are skipped
-          # (they require a `Gemfile` etc., and we don't track a Jekyll site
-          # in the repo — `docs/` is gitignored). API docs still build and
-          # upload to GitHub Pages.
-          homepage: _no_jekyll_site
+      # API documentation used to be built here with
+      # `leanprover-community/docgen-action`, on tag pushes and manual
+      # dispatch. It has been removed because it published to GitHub Pages,
+      # which `blueprint.yml` now owns:
+      #
+      #   * docgen-action uploads its output as *the* Pages site, at the root.
+      #     A repository has one Pages site, so tagging a release replaced the
+      #     published blueprint with the API docs until the next push to main
+      #     put it back.
+      #   * its build, upload and deploy steps are all gated internally on
+      #     `github.event_name == 'push'`, so the manual-dispatch half of that
+      #     `if:` never produced anything anyway.
+      #
+      # To publish API docs again, do it from `blueprint.yml`, which assembles
+      # the whole site: the blueprint at `/`, the docs at `/docs` where the
+      # blueprint's `\lean{}` links already point. See blueprint/README.md
+      # § "The \lean{} links do not resolve yet" for what that costs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -371,6 +371,14 @@ Two files, and the split between them matters:
 - **`blueprint/src/content.tex`** — the narrative: chapters, prose, and one
   `\inputleannode{label}` per node, which fixes the order they appear in.
 
+Presentation lives alongside those in `blueprint/src/` as `extra-css` /
+`extra-js` entries in `plastex.cfg`; `dep_graph_focus.js` is the one with real
+logic in it (it narrows the dependency graph to a chosen node's transitive
+dependencies). It reads the graph source back out of the upstream template's
+inline `renderDot` call, so `scripts/check-blueprint-render.sh` asserts that
+call's shape — if you change how the graph is rendered, read
+[`blueprint/README.md`](blueprint/README.md) § "How it is wired in" first.
+
 **The annotations are deliberately not inline on the declarations.** Inline
 `@[blueprint]` would require `import Architect` in every annotated file, making
 LeanArchitect a hard dependency of `QEC` for every downstream consumer.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Quantum Error Correction in Lean
 
 [![Lean V4](https://img.shields.io/badge/Lean-V4-blueviolet)](https://lean-lang.org/)
+[![Blueprint](https://img.shields.io/badge/blueprint-live-success)](https://stavan-jain.github.io/QECLean/)
 [![Dashboard](https://img.shields.io/badge/pipeline%20dashboard-live-success)](https://stavan-jain.github.io/qec-lab/)
 [![Research: qec-lab](https://img.shields.io/badge/research-qec--lab-informational)](https://github.com/Stavan-Jain/qec-lab)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
@@ -71,6 +72,10 @@ Every step of the homological distance argument is mechanized — no `sorry`s an
 The accompanying expository proof is available as an [interactive write-up](https://stavan-jain.github.io/DistanceBlog/) with diagrams (or the [in-repo version in qec-lab](https://github.com/Stavan-Jain/qec-lab/blob/main/docs/distance_proof.md)).
 
 ## Blueprint
+
+**[Read it here.](https://stavan-jain.github.io/QECLean/)** The
+[dependency graph](https://stavan-jain.github.io/QECLean/dep_graph_document.html)
+is the quickest way in.
 
 A [leanblueprint](https://github.com/PatrickMassot/leanblueprint)-style
 blueprint documents the architecture: ~85 nodes covering the Pauli and binary

--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ the real proof terms instead of being written by hand. There is therefore no
 second copy of the mathematics that can drift out of date — renaming a
 declaration breaks the build rather than silently orphaning a node.
 
+The graph is filterable: picking a node restricts it to that node's transitive
+dependencies — the subgraph the result rests on — and re-runs the layout on just
+that part, so asking what `steane7` needs gives 22 nodes rather than all 85. The
+opposite direction (everything built on a node) and a depth cut-off are there
+too, and a filtered view is a shareable URL:
+`dep_graph_document.html?focus=thm:gross-distance&dir=up`.
+
 ```bash
 lake build QECBlueprint:blueprint && leanblueprint web
 ```

--- a/blueprint/README.md
+++ b/blueprint/README.md
@@ -115,6 +115,74 @@ extraction step is cheap once the build is warm, but note that it loads the
 whole `QEC` environment into a single process, so it wants the same headroom as
 building the bivariate-bicycle leaves.
 
+## Reading one result's dependencies
+
+The dependency graph shows all 85 nodes at once, which answers "what is in this
+library" but not "what does this one theorem actually rest on". The controls
+above the graph narrow it to a single node's transitive dependencies:
+
+- **Focus on** — a node, by full label (`def:steane7`), by the short name shown
+  on the graph (`steane7`), or by any unambiguous fragment of either. The list
+  is a `<datalist>`, so typing filters it.
+- **show** — `what it depends on` (the default) walks *up* to everything the
+  node rests on; `what depends on it` walks down to everything built on top of
+  it; `both directions` is the union.
+- **to depth** — how many edges out to walk. `all the way` is the full
+  transitive closure; a small number is useful on a node near the top of the
+  library, where the closure is most of the graph.
+- **Show everything** restores the full graph.
+
+The subgraph is laid out afresh rather than highlighted in place, so what you
+get is a small readable picture instead of a scattering of nodes across the
+original canvas. The focused node is drawn with a heavy double outline; the
+node colours are left alone, because the legend gives them a meaning.
+
+Clicking a node opens its statement, as before, and that panel now carries a
+**Focus on this** button.
+
+A focused view is a URL, so it can be linked from a discussion or an issue:
+
+```
+dep_graph_document.html?focus=thm:gross-distance&dir=up
+dep_graph_document.html?focus=def:steane7&dir=up&depth=2
+```
+
+`dir` is `up`, `down`, or `both`; `depth` is omitted for the full closure.
+
+**On edge direction**, which is easy to get backwards: plastexdepgraph draws
+`A -> B` to mean *B uses A*, so arrows run from a prerequisite towards the
+result that needs it. The dependencies of a node are therefore its ancestors,
+found by walking the arrows backwards — which is what `what it depends on`
+does.
+
+### How it is wired in
+
+[`src/dep_graph_focus.js`](src/dep_graph_focus.js), listed as `extra-js` in
+`plastex.cfg`. plasTeX copies any `extra-js` file from `blueprint/src/` into
+`web/js/` and the upstream dependency-graph template emits a `<script>` tag for
+it, so no template is forked. It is loaded on every page and does nothing on
+the ones with no graph.
+
+The one thing it needs and is not handed is the graphviz source: the template
+interpolates it directly into a ``.renderDot(`...`)`` call rather than into a
+variable, so the script reads it back out of that call, parses it, and re-emits
+the induced subgraph. If that ever stops working the script leaves the stock
+graph untouched rather than breaking the page — silent, so
+`scripts/check-blueprint-render.sh` asserts the shape it depends on and CI
+fails instead.
+
+Two smaller things worth knowing before editing it:
+
+- Register `end` handlers *before* calling `renderDot`, never chained after it.
+  Once the graphviz wasm is loaded a render completes synchronously and
+  dispatches `end` before `renderDot` returns, so a handler attached afterwards
+  never fires. Upstream can chain because its render is the one that waits for
+  the wasm to load.
+- Re-renders rebind only the node click handlers, not upstream's whole
+  `interactive()`. That function also binds the legend toggle and the modal
+  close buttons with jQuery, whose handlers accumulate — calling it twice makes
+  the legend toggle a no-op.
+
 ## Inspecting a single node
 
 ```lean

--- a/blueprint/README.md
+++ b/blueprint/README.md
@@ -34,6 +34,11 @@ sudo apt-get install graphviz libgraphviz-dev texlive-binaries
 pip install leanblueprint
 ```
 
+On macOS none of that apt line applies: `kpsewhich` comes with MacTeX (already
+on `PATH` as `/Library/TeX/texbin/kpsewhich`), and current `pygraphviz` wheels
+bundle graphviz, so `pip install leanblueprint` into a virtualenv is the whole
+setup — no Homebrew graphviz needed.
+
 `texlive-binaries` is **not optional**, even though nothing here compiles TeX
 for the web build: it provides `kpsewhich`, which plasTeX shells out to in order
 to resolve `\input` paths. See "If the blueprint renders with no nodes" below —
@@ -54,8 +59,30 @@ bash scripts/check-blueprint-render.sh   # assert the nodes actually rendered
 `kpsewhich` has no default search path of its own. A full TeX Live installation
 sets one up and you can drop the prefix.
 
-Open `blueprint/web/index.html`. The dependency graph is linked from the
-navigation bar.
+Then serve it, rather than opening the files directly:
+
+```bash
+bash scripts/preview-blueprint.sh
+```
+
+The dependency graph is linked from the navigation bar. It has to be served
+over HTTP or the graph comes up empty — see the next section for why.
+
+### Working on the graph without building Lean
+
+The dependency-graph page's behaviour lives in `blueprint/src/` as ordinary CSS
+and JavaScript (`extra_styles.css`, `dep_graph_focus.js`), and none of it needs
+the Lean half to be rebuilt. To iterate on it, take the last CI render instead:
+
+```bash
+bash scripts/preview-blueprint.sh --from-ci
+```
+
+That downloads the newest successful Blueprint run's `blueprint-web` artifact
+with `gh`, copies in the current `extra-css` / `extra-js` files the way plasTeX
+would, and serves the result — no Lean build, no `leanblueprint`, no graphviz.
+Re-run it after each edit. Because it is the page CI actually emitted, it
+catches the things a hand-written test page would not.
 
 ### If the dependency graph page is blank
 
@@ -72,10 +99,11 @@ URL file://...`), so the renderer never runs and the container stays empty.
 This is not a build problem — the assets are all present under `blueprint/web/js/`
 and the graph data is embedded in the page as a graphviz `digraph`.
 
-Fix: serve the directory over HTTP.
+Fix: serve the directory over HTTP, which is all
+`scripts/preview-blueprint.sh` does.
 
 ```bash
-cd blueprint/web && python3 -m http.server 8000
+bash scripts/preview-blueprint.sh
 # then open http://localhost:8000/dep_graph_document.html
 ```
 

--- a/blueprint/README.md
+++ b/blueprint/README.md
@@ -84,6 +84,12 @@ would, and serves the result — no Lean build, no `leanblueprint`, no graphviz.
 Re-run it after each edit. Because it is the page CI actually emitted, it
 catches the things a hand-written test page would not.
 
+The repository is passed to `gh` explicitly, derived from the `origin` remote:
+this checkout has two GitHub remotes (`origin` and `lab`), so `gh` cannot infer
+which one a run belongs to and would otherwise demand a `gh repo set-default`.
+Set `BLUEPRINT_GH_REPO=owner/name` to read runs from somewhere else, such as
+upstream while working on a fork.
+
 ### If the dependency graph page is blank
 
 Symptom: the chapters and their theorem/definition boxes all render correctly,

--- a/blueprint/README.md
+++ b/blueprint/README.md
@@ -65,6 +65,9 @@ Then serve it, rather than opening the files directly:
 bash scripts/preview-blueprint.sh
 ```
 
+It serves on port 8000, stepping up to the next free port if something else
+already has it (`--port N` to choose). Localhost only.
+
 The dependency graph is linked from the navigation bar. It has to be served
 over HTTP or the graph comes up empty — see the next section for why.
 

--- a/blueprint/README.md
+++ b/blueprint/README.md
@@ -272,25 +272,41 @@ redirect as `404.html`, so old `/QECLean/<path>` links bounce to the qec-lab
 dashboard; only the site root changes meaning. The two workflows share a `pages`
 concurrency group so their deploys serialize.
 
-### The `\lean{}` links do not resolve yet
+### The `\lean{}` links are hidden, not fixed
 
 `\dochome` in `web.tex` points at `https://stavan-jain.github.io/QECLean/docs`,
 so every node's **Lean** link goes to `…/docs/find/#doc/<decl>`. Nothing
-publishes anything at `/docs`, so those links currently fall through to
-`404.html` and bounce the reader to the qec-lab dashboard.
+publishes anything at `/docs`, so those links fall through to `404.html` and
+bounce the reader to the qec-lab dashboard — worse than no link at all. Until
+the docs exist, `extra_styles.css` hides them:
 
-The obstacle is that a repository has one Pages site and three workflows that
-would each publish at its root: this one, `pages-redirect.yml`, and
-`lean_action_ci.yml`, whose `docgen-action` step deploys API documentation on a
-tag push. Note the last of those: **tagging a release currently replaces the
-blueprint with the API docs**, until the next push to `main` puts it back.
+```css
+a.lean_decl,
+button.modal.lean,
+button.modal.lean + div.modal-container { display: none; }
+```
 
-Making the links work means one workflow assembling the whole site — blueprint
-at `/`, API docs at `/docs` — which in turn means this workflow paying for a
-`doc-gen4` build. That is ~1–2 h cold, though `docgen-action` caches the
-mathlib half against `lake-manifest.json`. Dropping `\dochome` is not a
-workaround: leanblueprint then falls back to mathlib's doc site, where none of
-these declarations exist.
+Three selectors because the two page types render the link differently: a
+chapter page puts it behind the `L∃∀N` button's "Lean declarations" dialog,
+whose entire body is those anchors, so the button and its dialog go too; the
+dependency graph's node modals emit a plain `<a class="lean_link lean_decl">`.
+The neighbouring `uses` dialog is unaffected. Dropping `\dochome` instead is
+not a workaround — leanblueprint then falls back to mathlib's doc site, where
+none of these declarations exist.
+
+To restore the links, publish doc-gen4 output at `/docs` and delete that CSS
+block; nothing else needs to change. The obstacle is that a repository has one
+Pages site, so the workflow that publishes has to assemble all of it —
+blueprint at `/`, docs at `/docs` — which means this workflow paying for a
+doc-gen4 build: ~1–2 h cold, though `docgen-action` caches the mathlib half
+against `lake-manifest.json`.
+
+`lean_action_ci.yml` used to build those docs on tag pushes, but published them
+as the Pages site *root*, so **tagging a release replaced the blueprint with
+the API docs** until the next push to `main` put it back. That step has been
+removed; its manual-dispatch half never produced anything anyway, since
+`docgen-action` gates its build, upload and deploy on `github.event_name ==
+'push'`.
 
 ## Notes
 

--- a/blueprint/README.md
+++ b/blueprint/README.md
@@ -257,17 +257,40 @@ middle of a chain will take over edges that previously ran past it.
 ## Deployment
 
 The `Blueprint` workflow builds on every push and uploads `blueprint/web` as a
-run artifact. Publishing to GitHub Pages is a manual `workflow_dispatch` with
-the `deploy` input set, because this repository's Pages site currently serves
-the path-preserving dashboard redirect from `pages-redirect.yml`, and whichever
-workflow deploys last wins. The deploy path keeps that redirect as `404.html`,
-so old `/QECLean/<path>` links still bounce to the qec-lab dashboard; only the
-site root changes meaning. If you want the blueprint published automatically,
-move the deploy steps onto the `push` trigger and retire `pages-redirect.yml`.
+run artifact. **A push to `main` also republishes
+[the site](https://stavan-jain.github.io/QECLean/)**, so what is served always
+matches `main`; pull requests and branch pushes build and check the blueprint
+but publish nothing. The `deploy` input on `workflow_dispatch` is still there
+for republishing without a content change.
+
+Publishing used to be manual, on the grounds that `pages-redirect.yml` also
+deploys to this Pages site and whichever workflow runs last wins. That workflow
+only triggers on an explicit dispatch or on a push that edits its own file, so
+it cannot clobber the blueprint by accident — while the manual gate reliably
+left the site behind `main` after every merge. The deploy still keeps the
+redirect as `404.html`, so old `/QECLean/<path>` links bounce to the qec-lab
+dashboard; only the site root changes meaning. The two workflows share a `pages`
+concurrency group so their deploys serialize.
+
+### The `\lean{}` links do not resolve yet
 
 `\dochome` in `web.tex` points at `https://stavan-jain.github.io/QECLean/docs`,
-so the `\lean{}` links resolve once API documentation is deployed there
-(`lean_action_ci.yml` builds it on tags and manual dispatch).
+so every node's **Lean** link goes to `…/docs/find/#doc/<decl>`. Nothing
+publishes anything at `/docs`, so those links currently fall through to
+`404.html` and bounce the reader to the qec-lab dashboard.
+
+The obstacle is that a repository has one Pages site and three workflows that
+would each publish at its root: this one, `pages-redirect.yml`, and
+`lean_action_ci.yml`, whose `docgen-action` step deploys API documentation on a
+tag push. Note the last of those: **tagging a release currently replaces the
+blueprint with the API docs**, until the next push to `main` puts it back.
+
+Making the links work means one workflow assembling the whole site — blueprint
+at `/`, API docs at `/docs` — which in turn means this workflow paying for a
+`doc-gen4` build. That is ~1–2 h cold, though `docgen-action` caches the
+mathlib half against `lake-manifest.json`. Dropping `\dochome` is not a
+workaround: leanblueprint then falls back to mathlib's doc site, where none of
+these declarations exist.
 
 ## Notes
 

--- a/blueprint/src/dep_graph_focus.js
+++ b/blueprint/src/dep_graph_focus.js
@@ -1,0 +1,526 @@
+/* Focused-subgraph view for the blueprint dependency graph.
+ *
+ * The dependency graph page renders every node in the blueprint at once, which
+ * is the right default for "what does this library contain" and the wrong one
+ * for "what does this one result rest on". This script adds a picker that
+ * restricts the graph to a single node's transitive dependencies -- the
+ * subgraph leading up to it -- and re-runs the graphviz layout on just that
+ * subgraph, so the answer is a small readable picture rather than a highlighted
+ * region of a large one.
+ *
+ * Edge direction, which is easy to get backwards: plastexdepgraph emits
+ * `A -> B` to mean "B uses A", i.e. arrows run from a prerequisite to the thing
+ * that needs it. So the dependencies of X are its *ancestors*, reached by
+ * walking edges in reverse, and the results that build on X are its
+ * descendants. Both directions are offered; dependencies are the default.
+ *
+ * How it hooks in
+ * ---------------
+ * plasTeX copies every `extra-js` entry from `blueprint/src/` into `web/js/`
+ * and the upstream dep-graph template emits a <script> tag for each, after its
+ * own inline setup script. So this file runs once the graph has been asked to
+ * render, and can reuse the same d3-graphviz instance:
+ * `d3.select('#graph').graphviz()` returns the existing renderer rather than
+ * building a second one (see `selection_graphviz` in d3-graphviz).
+ *
+ * The one thing it needs that upstream does not hand over is the graphviz
+ * source, which the template interpolates straight into a `.renderDot(`...`)`
+ * call instead of a variable. It is recovered by reading that call out of the
+ * inline script. `scripts/check-blueprint-render.sh` asserts that call is still
+ * shaped that way, so an upstream template change fails the build instead of
+ * silently costing us the feature. If recovery fails anyway, the script bails
+ * out without adding its controls, leaving the stock full graph working.
+ *
+ * The file is loaded on every page of the blueprint, not just this one; it
+ * exits immediately when there is no graph to act on.
+ */
+(function () {
+  'use strict';
+
+  const graphDiv = document.getElementById('graph');
+  if (!graphDiv || typeof d3 === 'undefined') return;
+
+  /* ---------------------------------------------------------------- parsing */
+
+  /* Split `text` on `sep`, ignoring separators inside quoted strings or
+   * brackets. The generated dot has no nested brackets, but labels are
+   * arbitrary text and may contain anything. */
+  function splitTop(text, sep) {
+    const out = [];
+    let cur = '', depth = 0, inStr = false;
+    for (let i = 0; i < text.length; i++) {
+      const c = text[i];
+      if (inStr) {
+        cur += c;
+        if (c === '\\' && i + 1 < text.length) cur += text[++i];
+        else if (c === '"') inStr = false;
+        continue;
+      }
+      if (c === '"') { inStr = true; cur += c; continue; }
+      if (c === '[' || c === '{') depth++;
+      else if (c === ']' || c === '}') depth--;
+      else if (c === sep && depth === 0) { out.push(cur); cur = ''; continue; }
+      cur += c;
+    }
+    out.push(cur);
+    return out;
+  }
+
+  /* Split a statement into its head and the raw text of its attribute list,
+   * e.g. `"a" -> "b" [style=dashed]` into `"a" -> "b"` and `style=dashed`. */
+  function splitHeadAttrs(stmt) {
+    let inStr = false;
+    for (let i = 0; i < stmt.length; i++) {
+      const c = stmt[i];
+      if (inStr) {
+        if (c === '\\') i++;
+        else if (c === '"') inStr = false;
+        continue;
+      }
+      if (c === '"') { inStr = true; continue; }
+      if (c === '[') {
+        const end = stmt.lastIndexOf(']');
+        return [stmt.slice(0, i).trim(), stmt.slice(i + 1, end > i ? end : undefined)];
+      }
+    }
+    return [stmt.trim(), null];
+  }
+
+  /* Read the identifiers out of a statement head, dropping the `->` operators.
+   * Handles both quoted (`"def:steane7"`) and bare (`node`) forms. */
+  function parseHeadIds(head) {
+    const ids = [];
+    let i = 0;
+    while (i < head.length) {
+      if (/\s/.test(head[i])) { i++; continue; }
+      if (head[i] === '-' && head[i + 1] === '>') { i += 2; continue; }
+      if (head[i] === '"') {
+        let s = '', j = i + 1;
+        while (j < head.length && head[j] !== '"') {
+          if (head[j] === '\\') { s += head[j + 1]; j += 2; }
+          else s += head[j++];
+        }
+        ids.push(s);
+        i = j + 1;
+      } else {
+        let k = i;
+        while (k < head.length && !/\s/.test(head[k]) && !(head[k] === '-' && head[k + 1] === '>')) k++;
+        ids.push(head.slice(i, k));
+        i = k;
+      }
+    }
+    return ids;
+  }
+
+  /* Parse the subset of dot that pygraphviz emits. Attribute lists are kept as
+   * raw text and passed straight back out: this only needs the graph's shape,
+   * and not reinterpreting styling means it cannot corrupt it. */
+  function parseDot(dot) {
+    const open = dot.indexOf('{');
+    const close = dot.lastIndexOf('}');
+    if (open < 0 || close <= open) return null;
+
+    const model = {
+      header: dot.slice(0, open + 1).trim(),
+      defaults: [],
+      order: [],
+      attrs: new Map(),
+      edges: []
+    };
+
+    for (const raw of splitTop(dot.slice(open + 1, close), ';')) {
+      const stmt = raw.trim();
+      if (!stmt) continue;
+      const [head, attrs] = splitHeadAttrs(stmt);
+      if (/^(graph|node|edge)$/.test(head)) { model.defaults.push(stmt); continue; }
+
+      const ids = parseHeadIds(head);
+      if (!ids.length) continue;
+      for (const id of ids) {
+        if (!model.attrs.has(id)) { model.attrs.set(id, null); model.order.push(id); }
+      }
+      if (ids.length === 1) {
+        /* A bare `"id" [..]` statement carries the node's styling; an id that
+         * only ever appeared inside an edge keeps its null attribute list. */
+        if (attrs !== null) model.attrs.set(ids[0], attrs);
+      } else {
+        for (let k = 0; k + 1 < ids.length; k++) {
+          model.edges.push({ from: ids[k], to: ids[k + 1], attrs: attrs });
+        }
+      }
+    }
+    return model;
+  }
+
+  /* ---------------------------------------------------------------- emitting */
+
+  function quoteId(id) {
+    return '"' + id.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"';
+  }
+
+  /* Rewrite an attribute list, replacing any listed keys. Used only for the
+   * focused node, whose marker must not disturb the colours -- the legend gives
+   * border and fill colours a meaning (formalized, ready, in Mathlib), so the
+   * focus is marked with a heavier double outline instead. */
+  function overrideAttrs(raw, overrides) {
+    const keys = Object.keys(overrides);
+    const kept = (raw ? splitTop(raw, ',') : [])
+      .map(function (s) { return s.trim(); })
+      .filter(function (s) {
+        if (!s) return false;
+        const eq = s.indexOf('=');
+        const key = (eq < 0 ? s : s.slice(0, eq)).trim().replace(/^"|"$/g, '');
+        return keys.indexOf(key) === -1;
+      });
+    for (const k of keys) kept.push(k + '=' + overrides[k]);
+    return kept.join(', ');
+  }
+
+  const FOCUS_MARKER = { penwidth: '4', peripheries: '2' };
+
+  function emitDot(model, keep, focusId) {
+    const lines = [model.header];
+    for (const d of model.defaults) lines.push('\t' + d + ';');
+    for (const id of model.order) {
+      if (keep && !keep.has(id)) continue;
+      let attrs = model.attrs.get(id);
+      if (id === focusId) attrs = overrideAttrs(attrs, FOCUS_MARKER);
+      lines.push('\t' + quoteId(id) + (attrs ? '\t[' + attrs + ']' : '') + ';');
+    }
+    for (const e of model.edges) {
+      if (keep && (!keep.has(e.from) || !keep.has(e.to))) continue;
+      lines.push('\t' + quoteId(e.from) + ' -> ' + quoteId(e.to) +
+                 (e.attrs ? '\t[' + e.attrs + ']' : '') + ';');
+    }
+    lines.push('}');
+    return lines.join('\n');
+  }
+
+  /* ------------------------------------------------------------------- setup */
+
+  /* Recover the graphviz source from the template's inline `.renderDot(`...`)`
+   * call. The text is read raw, so escapes such as the default `label="\N"`
+   * reach graphviz as written rather than being eaten by the JS template
+   * literal -- harmless either way, since every node carries an explicit
+   * label. */
+  function extractDot() {
+    const scripts = document.querySelectorAll('script:not([src])');
+    for (const s of scripts) {
+      const m = /renderDot\(`([\s\S]*?)`\)/.exec(s.textContent);
+      if (m) return m[1];
+    }
+    return null;
+  }
+
+  const source = extractDot();
+  if (source === null) {
+    console.warn('dep_graph_focus: could not read the graph source; ' +
+                 'leaving the full graph as-is.');
+    return;
+  }
+  const model = parseDot(source);
+  if (!model || !model.order.length) {
+    console.warn('dep_graph_focus: graph source did not parse; ' +
+                 'leaving the full graph as-is.');
+    return;
+  }
+
+  /* Adjacency, in both directions. `preds` walks towards dependencies. */
+  const preds = new Map();
+  const succs = new Map();
+  for (const id of model.order) { preds.set(id, []); succs.set(id, []); }
+  for (const e of model.edges) {
+    if (!preds.has(e.to) || !succs.has(e.from)) continue;
+    preds.get(e.to).push(e.from);
+    succs.get(e.from).push(e.to);
+  }
+
+  /* Breadth-first reachability, so `depth` can cut the walk off at a distance
+   * rather than only ever taking the whole transitive closure. */
+  function reach(start, adj, maxDepth) {
+    const seen = new Set([start]);
+    let frontier = [start], depth = 0;
+    while (frontier.length && (!maxDepth || depth < maxDepth)) {
+      const next = [];
+      for (const id of frontier) {
+        for (const nb of adj.get(id) || []) {
+          if (!seen.has(nb)) { seen.add(nb); next.push(nb); }
+        }
+      }
+      frontier = next;
+      depth++;
+    }
+    return seen;
+  }
+
+  /* ---------------------------------------------------------- node metadata */
+
+  /* Human-readable names come from the statement modals the template already
+   * emits, so the picker can say "Definition 12 -- Anticommutation" rather than
+   * only `def:anticommute`. */
+  const titles = new Map();
+  for (const el of document.querySelectorAll('#statements div.thm[id]')) {
+    const head = el.querySelector('.thm_thmheading');
+    if (!head) continue;
+    const part = function (suffix) {
+      const n = head.querySelector('[class$="_thm' + suffix + '"]');
+      return n ? n.textContent.trim() : '';
+    };
+    const words = [part('caption'), part('label')].filter(Boolean).join(' ');
+    const title = part('title');
+    titles.set(el.id, [words, title].filter(Boolean).join(' \u2014 '));
+  }
+
+  function shortName(id) {
+    const i = id.lastIndexOf(':');
+    return i < 0 ? id : id.slice(i + 1);
+  }
+
+  /* Accept a full id (`def:steane7`), the short name shown on the graph node
+   * (`steane7`), or any unambiguous substring of either. */
+  function resolve(text) {
+    const q = text.trim();
+    if (!q) return null;
+    if (model.attrs.has(q)) return q;
+    const lower = q.toLowerCase();
+    const exact = model.order.filter(function (id) {
+      return shortName(id).toLowerCase() === lower;
+    });
+    if (exact.length === 1) return exact[0];
+    const partial = model.order.filter(function (id) {
+      return id.toLowerCase().indexOf(lower) !== -1 ||
+             (titles.get(id) || '').toLowerCase().indexOf(lower) !== -1;
+    });
+    return partial.length === 1 ? partial[0] : null;
+  }
+
+  /* ---------------------------------------------------------------- controls */
+
+  const DIRECTIONS = [
+    ['up', 'what it depends on'],
+    ['down', 'what depends on it'],
+    ['both', 'both directions']
+  ];
+
+  const bar = document.createElement('div');
+  bar.id = 'focus-controls';
+  bar.innerHTML =
+    '<label for="focus-node">Focus on</label>' +
+    '<input id="focus-node" list="focus-node-list" type="search" autocomplete="off" ' +
+           'spellcheck="false" placeholder="a node name, e.g. steane7">' +
+    '<datalist id="focus-node-list"></datalist>' +
+    '<label for="focus-dir">show</label>' +
+    '<select id="focus-dir">' +
+      DIRECTIONS.map(function (d) {
+        return '<option value="' + d[0] + '">' + d[1] + '</option>';
+      }).join('') +
+    '</select>' +
+    '<label for="focus-depth">to depth</label>' +
+    '<select id="focus-depth">' +
+      '<option value="0">all the way</option>' +
+      '<option value="1">1</option><option value="2">2</option>' +
+      '<option value="3">3</option><option value="4">4</option>' +
+    '</select>' +
+    '<button id="focus-clear" type="button">Show everything</button>' +
+    '<span id="focus-status"></span>';
+  graphDiv.parentNode.insertBefore(bar, graphDiv);
+
+  const nodeInput = bar.querySelector('#focus-node');
+  const dirSelect = bar.querySelector('#focus-dir');
+  const depthSelect = bar.querySelector('#focus-depth');
+  const clearButton = bar.querySelector('#focus-clear');
+  const status = bar.querySelector('#focus-status');
+
+  const datalist = bar.querySelector('#focus-node-list');
+  for (const id of model.order.slice().sort()) {
+    const option = document.createElement('option');
+    option.value = id;
+    option.label = titles.get(id) || shortName(id);
+    datalist.appendChild(option);
+  }
+
+  /* A "focus this" control on each statement modal, so a node found by reading
+   * the graph can be focused without retyping its name into the picker. */
+  for (const modal of document.querySelectorAll('#statements .dep-modal-container')) {
+    const thm = modal.querySelector('div.thm[id]');
+    if (!thm || !model.attrs.has(thm.id)) continue;
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'focus-link';
+    button.textContent = 'Focus on this';
+    button.addEventListener('click', function () {
+      modal.style.display = 'none';
+      const statements = document.getElementById('statements');
+      if (statements) statements.style.display = 'none';
+      apply(thm.id, dirSelect.value, Number(depthSelect.value), true);
+    });
+    thm.appendChild(button);
+  }
+
+  /* ------------------------------------------------------------- re-rendering */
+
+  const graphviz = d3.select('#graph').graphviz();
+  let rendering = false;
+  let queued = null;
+  let ready = false;
+
+  /* Upstream binds the node click handlers inside its `interactive()`, which
+   * also binds the legend toggle and the modal close buttons with jQuery.
+   * Those two are on static markup that survives a re-render, and jQuery
+   * handlers accumulate, so calling `interactive()` again would bind the legend
+   * twice and leave it toggling to a no-op. Only the freshly created `.node`
+   * elements need re-binding, so do just that. */
+  function bindNodes() {
+    d3.selectAll('.node')
+      .attr('pointer-events', 'fill')
+      .on('click', function () {
+        const id = d3.select(this).selectAll('title').text().trim();
+        const escaped = typeof latexLabelEscaper === 'function'
+          ? latexLabelEscaper(id)
+          : id.replace(/\./g, '\\.').replace(/:/g, '\\:');
+        $('#statements > div').hide();
+        $('.thm').hide();
+        $('#' + escaped + '_modal').show().children().show().children().show();
+        $('#statements').show();
+      });
+  }
+
+  function onRenderEnd() {
+    rendering = false;
+    bindNodes();
+    try { graphviz.resetZoom(); } catch (e) { /* zoom not initialised yet */ }
+    drain();
+  }
+
+  function drain() {
+    if (queued === null || rendering || !ready) return;
+    const next = queued;
+    queued = null;
+    render(next);
+  }
+
+  function render(dot) {
+    if (!ready || rendering) { queued = dot; return; }
+    rendering = true;
+    /* Attach the handler *before* rendering rather than chaining it onto
+     * `renderDot`. Once the graphviz wasm has loaded a render runs
+     * synchronously and dispatches `end` before `renderDot` returns, so a
+     * handler attached afterwards is already too late and the completion is
+     * never observed. Upstream gets away with chaining only because its render
+     * is the one that waits for the wasm to arrive. */
+    graphviz.on('end', onRenderEnd);
+    graphviz.renderDot(dot);
+  }
+
+  /* Wait for upstream's initial render before taking the `end` event over.
+   * That render is what triggers its `interactive()`, which binds the legend
+   * toggle and the modal close buttons with jQuery handlers that accumulate on
+   * every call -- so it has to run exactly once, and displacing it beforehand
+   * would mean it never ran at all. Waiting also keeps a `?focus=` deep link
+   * from starting a second render while the first is still in flight. */
+  (function awaitInitialRender(attempt) {
+    if (graphDiv.querySelector('svg .node')) { ready = true; drain(); return; }
+    if (attempt > 300) return;          /* ~15s; the graph never came up */
+    window.setTimeout(function () { awaitInitialRender(attempt + 1); }, 50);
+  })(0);
+
+  /* ------------------------------------------------------------------ state */
+
+  let current = null;
+
+  function describe(id, dir, kept) {
+    if (!id) return model.order.length + ' nodes';
+    const word = dir === 'up' ? 'dependencies of' : dir === 'down' ? 'results depending on' : 'neighbourhood of';
+    return kept.size + ' of ' + model.order.length + ' nodes \u2014 ' +
+           word + ' ' + shortName(id);
+  }
+
+  function syncUrl(id, dir, depth) {
+    if (!window.history || !window.history.replaceState) return;
+    const params = new URLSearchParams(window.location.search);
+    if (id) {
+      params.set('focus', id);
+      params.set('dir', dir);
+      if (depth) params.set('depth', String(depth)); else params.delete('depth');
+    } else {
+      params.delete('focus');
+      params.delete('dir');
+      params.delete('depth');
+    }
+    const query = params.toString();
+    window.history.replaceState(null, '',
+      window.location.pathname + (query ? '?' + query : '') + window.location.hash);
+  }
+
+  function apply(id, dir, depth, syncInput) {
+    if (!id) {
+      current = null;
+      if (syncInput) nodeInput.value = '';
+      status.textContent = describe(null, dir, null);
+      syncUrl(null, dir, depth);
+      render(emitDot(model, null, null));
+      return;
+    }
+    let keep;
+    if (dir === 'down') {
+      keep = reach(id, succs, depth);
+    } else if (dir === 'both') {
+      keep = reach(id, preds, depth);
+      for (const n of reach(id, succs, depth)) keep.add(n);
+    } else {
+      keep = reach(id, preds, depth);
+    }
+    current = id;
+    if (syncInput) nodeInput.value = id;
+    status.textContent = describe(id, dir, keep);
+    syncUrl(id, dir, depth);
+    render(emitDot(model, keep, id));
+  }
+
+  function reapply() {
+    apply(current, dirSelect.value, Number(depthSelect.value), false);
+  }
+
+  let debounce = null;
+  function onInput() {
+    window.clearTimeout(debounce);
+    debounce = window.setTimeout(function () {
+      const text = nodeInput.value.trim();
+      if (!text) { apply(null, dirSelect.value, Number(depthSelect.value), false); return; }
+      const id = resolve(text);
+      if (id) {
+        apply(id, dirSelect.value, Number(depthSelect.value), false);
+      } else {
+        status.textContent = 'no single node matches \u201c' + text + '\u201d';
+      }
+    }, 200);
+  }
+
+  nodeInput.addEventListener('input', onInput);
+  nodeInput.addEventListener('change', onInput);
+  dirSelect.addEventListener('change', reapply);
+  depthSelect.addEventListener('change', reapply);
+  clearButton.addEventListener('click', function () {
+    nodeInput.value = '';
+    apply(null, dirSelect.value, Number(depthSelect.value), true);
+  });
+
+  /* A focused view is shareable: `?focus=def:steane7&dir=up` reproduces it. */
+  const params = new URLSearchParams(window.location.search);
+  const wanted = params.get('focus');
+  const wantedDir = params.get('dir');
+  const wantedDepth = Number(params.get('depth')) || 0;
+  if (wantedDir && DIRECTIONS.some(function (d) { return d[0] === wantedDir; })) {
+    dirSelect.value = wantedDir;
+  }
+  if (wantedDepth >= 1 && wantedDepth <= 4) depthSelect.value = String(wantedDepth);
+
+  const initial = wanted ? resolve(wanted) : null;
+  if (initial) {
+    apply(initial, dirSelect.value, Number(depthSelect.value), true);
+  } else {
+    /* The stock render is already running; just describe it and pick up the
+     * node click handlers it binds. */
+    status.textContent = describe(null, dirSelect.value, null);
+  }
+})();

--- a/blueprint/src/extra_styles.css
+++ b/blueprint/src/extra_styles.css
@@ -97,3 +97,34 @@ button.focus-link {
 button.focus-link:hover {
 	background: #eef4f9;
 }
+
+/* --- Suppress the per-node "Lean" links ----------------------------------
+ * leanblueprint points these at `\dochome`/find/#doc/<decl>, i.e. at
+ * https://stavan-jain.github.io/QECLean/docs — and nothing publishes anything
+ * there, so every one of them falls through to 404.html and bounces the reader
+ * to the qec-lab dashboard. A link that silently sends you somewhere unrelated
+ * is worse than no link, so hide them until the docs exist.
+ *
+ * Dropping `\dochome` from web.tex would not help: leanblueprint then falls
+ * back to mathlib's doc site, where none of these declarations exist either.
+ *
+ * `a.lean_decl` is the one class both renderings share -- chapter pages emit
+ * `<a href="..." class="lean_decl">` inside the hover extras, the dependency
+ * graph's modals emit `<a class="lean_link lean_decl">Lean</a>`.
+ *
+ * On a chapter page those anchors are the entire body of the `L∃∀N` button's
+ * "Lean declarations" dialog, so hiding only the anchors would leave a button
+ * that opens an empty box. Hide the button and its dialog as well. The dialog
+ * is matched as the button's next sibling because it carries no class of its
+ * own, and the sibling `uses` dialog must keep working.
+ *
+ * To restore: publish doc-gen4 output at `/docs` (see blueprint/README.md
+ * § "The \lean{} links do not resolve yet") and delete this block. Nothing
+ * else needs to change -- the links are generated, and are correct apart from
+ * pointing at a directory that is not there. */
+
+a.lean_decl,
+button.modal.lean,
+button.modal.lean + div.modal-container {
+	display: none;
+}

--- a/blueprint/src/extra_styles.css
+++ b/blueprint/src/extra_styles.css
@@ -24,3 +24,76 @@ div.proof_content {
 	border-left: .08rem solid grey;
 }
 
+
+/* --- Focused-subgraph controls on the dependency graph page ---------------
+ * Added by `dep_graph_focus.js`, which restricts the graph to one node's
+ * transitive dependencies. Loaded after dep_graph.css, so the #graph height
+ * override below wins and the toolbar does not push the graph off-screen. */
+
+div#focus-controls {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: .4rem .6rem;
+	padding: .4rem 0 .5rem 0;
+	font-size: 95%;
+}
+
+div#focus-controls label {
+	color: #444;
+}
+
+div#focus-controls input#focus-node {
+	min-width: 22rem;
+	flex: 1 1 22rem;
+	padding: .2rem .4rem;
+	border: 1px solid #497da5;
+	border-radius: 4px;
+	font: inherit;
+}
+
+div#focus-controls select {
+	padding: .2rem;
+	border: 1px solid #497da5;
+	border-radius: 4px;
+	font: inherit;
+	background: white;
+}
+
+div#focus-controls button#focus-clear {
+	padding: .2rem .6rem;
+	border: 1px solid #497da5;
+	border-radius: 4px;
+	background: white;
+	font: inherit;
+	cursor: pointer;
+}
+
+div#focus-controls button#focus-clear:hover {
+	background: #eef4f9;
+}
+
+div#focus-controls span#focus-status {
+	margin-left: auto;
+	color: #555;
+	font-style: italic;
+}
+
+div#graph {
+	height: calc(90vh - 3rem);
+}
+
+button.focus-link {
+	margin-left: 1rem;
+	padding: .1rem .5rem;
+	border: 1px solid #497da5;
+	border-radius: 4px;
+	background: white;
+	font-size: 90%;
+	font-style: italic;
+	cursor: pointer;
+}
+
+button.focus-link:hover {
+	background: #eef4f9;
+}

--- a/blueprint/src/plastex.cfg
+++ b/blueprint/src/plastex.cfg
@@ -14,4 +14,5 @@ split-level=0
 [html5]
 localtoc-level=1
 extra-css=extra_styles.css
+extra-js=dep_graph_focus.js
 mathjax-dollars=False

--- a/scripts/check-blueprint-render.sh
+++ b/scripts/check-blueprint-render.sh
@@ -57,4 +57,34 @@ if [ "$gnodes" -lt 1 ]; then
   fail=1
 fi
 
+# --- the focused-subgraph control ------------------------------------------
+#
+# `blueprint/src/dep_graph_focus.js` restricts the graph to one node's
+# transitive dependencies. It has two dependencies on machinery we do not own,
+# and both fail quietly rather than loudly, so assert them here.
+#
+# 1. plasTeX has to copy the file out of blueprint/src and the dep-graph
+#    template has to emit a <script> tag for it. A typo in the `extra-js` line
+#    of plastex.cfg logs one line to stderr and renders a page without it.
+# 2. The script recovers the graphviz source by reading it back out of the
+#    template's inline `.renderDot(`...`)` call, because the template
+#    interpolates the dot straight into that call rather than into a variable.
+#    If plastexdepgraph ever changes that shape the script degrades to leaving
+#    the stock graph alone -- correct, but silent. Catch it at build time.
+
+focus_js="$web/js/dep_graph_focus.js"
+if [ ! -s "$focus_js" ]; then
+  echo "::error::$focus_js missing -- check the extra-js line in blueprint/src/plastex.cfg"
+  fail=1
+elif ! grep -qF 'js/dep_graph_focus.js' "$graph"; then
+  echo "::error::$graph does not load dep_graph_focus.js"
+  fail=1
+elif ! grep -qF 'renderDot(`' "$graph"; then
+  echo "::error::the dependency-graph template no longer renders via renderDot(\`...\`);"
+  echo "::error::dep_graph_focus.js reads the graph source from that call and will now no-op"
+  fail=1
+else
+  echo "focused-subgraph control: script present and graph source readable"
+fi
+
 exit $fail

--- a/scripts/preview-blueprint.sh
+++ b/scripts/preview-blueprint.sh
@@ -38,13 +38,34 @@ src="$root/blueprint/src"
 
 if [ "$from_ci" = 1 ]; then
   command -v gh >/dev/null || { echo "gh is required for --from-ci" >&2; exit 1; }
-  run=$(gh run list --workflow=blueprint.yml --status=success --limit 1 \
-          --json databaseId --jq '.[0].databaseId // empty')
-  [ -n "$run" ] || { echo "no successful Blueprint run to download from" >&2; exit 1; }
-  echo "downloading blueprint-web from run $run"
+
+  # Name the repository explicitly. This checkout has two GitHub remotes --
+  # `origin` (the library) and `lab` (the research repo it was split out of) --
+  # so `gh` cannot infer which one a run belongs to and asks for
+  # `gh repo set-default`. Deriving it from `origin` keeps that out of the
+  # user's global gh config. $BLUEPRINT_GH_REPO overrides, e.g. to read runs
+  # from upstream while working on a fork.
+  repo="${BLUEPRINT_GH_REPO:-}"
+  if [ -z "$repo" ]; then
+    origin=$(git -C "$root" remote get-url origin 2>/dev/null || true)
+    origin="${origin%.git}"
+    case "$origin" in
+      *github.com[:/]*) repo=$(printf '%s' "${origin#*github.com}" | sed 's#^[:/]##') ;;
+    esac
+  fi
+  [ -n "$repo" ] || {
+    echo "could not work out the GitHub repository from the 'origin' remote." >&2
+    echo "Set it explicitly:  BLUEPRINT_GH_REPO=owner/name $0 --from-ci" >&2
+    exit 1
+  }
+
+  run=$(gh run list --repo "$repo" --workflow=blueprint.yml --status=success \
+          --limit 1 --json databaseId --jq '.[0].databaseId // empty')
+  [ -n "$run" ] || { echo "no successful Blueprint run in $repo to download from" >&2; exit 1; }
+  echo "downloading blueprint-web from $repo run $run"
   rm -rf "$web"
   mkdir -p "$web"
-  gh run download "$run" -n blueprint-web -D "$web"
+  gh run download "$run" --repo "$repo" -n blueprint-web -D "$web"
 
   # plasTeX copies each extra-css/extra-js file out of blueprint/src and adds a
   # tag for it to every page it renders. Redo that here, so assets newer than

--- a/scripts/preview-blueprint.sh
+++ b/scripts/preview-blueprint.sh
@@ -103,6 +103,34 @@ fi
   exit 1
 }
 
+# Find a port that is actually free rather than letting http.server bind-fail
+# with a traceback -- 8000 in particular is a popular default and is often
+# already taken by some other local server. Probe exactly the way http.server
+# binds below (localhost, SO_REUSEADDR, which HTTPServer sets) so the answer
+# is not merely advisory.
+requested=$port
+port=$(python3 - "$requested" <<'PORTPROBE'
+import socket, sys
+start = int(sys.argv[1])
+for candidate in range(start, start + 20):
+    probe = socket.socket()
+    probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        probe.bind(('127.0.0.1', candidate))
+    except OSError:
+        continue
+    finally:
+        probe.close()
+    print(candidate)
+    break
+PORTPROBE
+)
+[ -n "$port" ] || {
+  echo "ports $requested-$((requested + 19)) are all in use; pass --port N" >&2
+  exit 1
+}
+[ "$port" = "$requested" ] || echo "port $requested is in use; serving on $port instead"
+
 echo
 echo "  http://localhost:$port/index.html"
 echo "  http://localhost:$port/dep_graph_document.html"
@@ -110,4 +138,6 @@ echo "  http://localhost:$port/dep_graph_document.html?focus=def:steane7&dir=up"
 echo
 echo "Ctrl-C to stop."
 cd "$web"
-exec python3 -m http.server "$port"
+# Bind to localhost: this is a preview of a not-yet-published site, and there
+# is no reason to offer it to the rest of the network.
+exec python3 -m http.server "$port" --bind 127.0.0.1

--- a/scripts/preview-blueprint.sh
+++ b/scripts/preview-blueprint.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Serve the rendered blueprint over HTTP.
+#
+# Why a script rather than `open blueprint/web/index.html`: the dependency
+# graph is not baked into the page as static SVG. It is drawn in the browser by
+# d3-graphviz, which loads `graphvizlib.wasm` at runtime, and Chrome refuses
+# that load from a `file://` origin -- so opening the file directly gives you
+# the full narrative and a blank graph. See blueprint/README.md.
+#
+# Two sources for the site:
+#
+#   (default)   blueprint/web, as produced by `leanblueprint web`.
+#
+#   --from-ci   The newest successful Blueprint run's artifact, downloaded with
+#               `gh`, with blueprint/src's `extra-css` / `extra-js` files copied
+#               in the way plasTeX would. This is the fast path for working on
+#               the front-end assets (dep_graph_focus.js, extra_styles.css):
+#               it needs no Lean build, no leanblueprint and no graphviz, and
+#               it exercises the real emitted page rather than a mock-up.
+#               Re-run it after every edit to those files.
+set -euo pipefail
+
+port=8000
+from_ci=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --from-ci) from_ci=1 ;;
+    --port) port="${2:?--port needs a number}"; shift ;;
+    -h|--help) sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+web="$root/blueprint/web"
+src="$root/blueprint/src"
+
+if [ "$from_ci" = 1 ]; then
+  command -v gh >/dev/null || { echo "gh is required for --from-ci" >&2; exit 1; }
+  run=$(gh run list --workflow=blueprint.yml --status=success --limit 1 \
+          --json databaseId --jq '.[0].databaseId // empty')
+  [ -n "$run" ] || { echo "no successful Blueprint run to download from" >&2; exit 1; }
+  echo "downloading blueprint-web from run $run"
+  rm -rf "$web"
+  mkdir -p "$web"
+  gh run download "$run" -n blueprint-web -D "$web"
+
+  # plasTeX copies each extra-css/extra-js file out of blueprint/src and adds a
+  # tag for it to every page it renders. Redo that here, so assets newer than
+  # the downloaded artifact -- or edited since -- are the ones being served.
+  while IFS= read -r line; do
+    kind="${line%%=*}"; file="${line#*=}"
+    case "$kind" in
+      extra-css) dir=styles; tag="<link rel=\"stylesheet\" href=\"styles/$file\" />" ;;
+      extra-js)  dir=js;     tag="<script type=\"text/javascript\" src=\"js/$file\"></script>" ;;
+      *) continue ;;
+    esac
+    [ -f "$src/$file" ] || { echo "warning: $src/$file does not exist" >&2; continue; }
+    mkdir -p "$web/$dir"
+    cp "$src/$file" "$web/$dir/"
+    for page in "$web"/*.html; do
+      grep -qF "$dir/$file" "$page" && continue
+      # Both tags belong at the end of the document: the stylesheet must win
+      # over the theme, and the script must run after the inline setup script
+      # that kicks off the initial render.
+      python3 - "$page" "$tag" <<'PY'
+import sys, pathlib
+page, tag = pathlib.Path(sys.argv[1]), sys.argv[2]
+s = page.read_text()
+page.write_text(s.replace('</body>', tag + '\n</body>', 1) if '</body>' in s else s + tag)
+PY
+    done
+    echo "  applied $file"
+  done < <(grep -E '^extra-(css|js)=' "$src/plastex.cfg" || true)
+fi
+
+[ -d "$web" ] || {
+  echo "$web does not exist. Build it first:" >&2
+  echo "    lake build QECBlueprint:blueprint && TEXINPUTS=\".:\" leanblueprint web" >&2
+  echo "  or fetch the last CI render:  bash scripts/preview-blueprint.sh --from-ci" >&2
+  exit 1
+}
+
+echo
+echo "  http://localhost:$port/index.html"
+echo "  http://localhost:$port/dep_graph_document.html"
+echo "  http://localhost:$port/dep_graph_document.html?focus=def:steane7&dir=up"
+echo
+echo "Ctrl-C to stop."
+cd "$web"
+exec python3 -m http.server "$port"


### PR DESCRIPTION
## Summary

The blueprint's dependency graph renders all 85 nodes at once, which answers
"what is in this library" but not "what does this one result rest on". This
adds a control that restricts the graph to a chosen node's transitive
dependencies and **re-runs the graphviz layout on just that subgraph**, so the
answer is a small readable picture rather than a highlighted region of a large
one. Focusing `steane7` gives 22 nodes instead of 85.

Arrows in this graph run from a prerequisite towards the result that uses it
(`A -> B` means "B uses A"), so a node's dependencies are its *ancestors*,
reached by walking edges backwards.

Alongside the picker: the opposite direction (what builds on a node), a depth
cut-off — useful on a capstone like `thm:gross-distance`, whose closure is 39
of 85 nodes — a **Focus on this** button on each statement modal, and URL state
so a subgraph is linkable:

```
dep_graph_document.html?focus=thm:gross-distance&dir=up
dep_graph_document.html?focus=def:steane7&dir=up&depth=2
```

## How it hooks in

No template is forked. plasTeX copies `extra-js` files from `blueprint/src/`
into `web/js/` and the upstream dep-graph template already emits a `<script>`
tag for each, so this is one line in `plastex.cfg` plus the script.

The one thing upstream does not hand over is the graphviz source, which it
interpolates straight into its `.renderDot(`...`)` call rather than a variable.
The script reads it back out of that call, parses it, and emits the induced
subgraph. That is a silent dependency, so `check-blueprint-render.sh` now
asserts the shape it relies on — along with the script being copied and loaded
at all. An upstream change fails the build instead of quietly costing the
feature; failing to recover the source at runtime leaves the stock graph
untouched.

Two non-obvious constraints, documented in `blueprint/README.md` and in the
script: `end` handlers must be registered *before* `renderDot`, because once
the graphviz wasm has loaded a render completes synchronously and dispatches
`end` before `renderDot` returns; and re-renders must rebind only the node
click handlers rather than calling upstream's `interactive()`, which also binds
the legend toggle with a jQuery handler that accumulates.

## Also in here

Three things found while testing the above, each its own commit.

- **`scripts/preview-blueprint.sh`** — serving the site over HTTP was already
  required (the graph is drawn from a wasm module the browser will not load
  over `file://`) and already documented; this makes it one command.
  `--from-ci` pulls the newest successful Blueprint artifact and applies the
  current `extra-css`/`extra-js`, so the front-end assets can be iterated on
  with no Lean build, no `leanblueprint` and no graphviz — while still
  exercising the page CI actually emitted. It names the repo explicitly (this
  checkout has two GitHub remotes, so `gh` otherwise demands
  `gh repo set-default`) and picks a free port rather than dying on a
  bind traceback.

- **The Pages deploy now happens on push to `main`.** It was a manual
  dispatch, so the published site fell behind `main` after every merge —
  including the merge of #67, which needed a follow-up dispatch to appear at
  all. The stated reason no longer holds: `pages-redirect.yml` also deploys,
  but only on an explicit dispatch or a push editing its own file, so it
  cannot clobber the blueprint by accident. They now share a `pages`
  concurrency group. Publishing is restricted to `refs/heads/main`; the old
  dispatch-only gate happened to allow a deploy from any branch, and one was
  made from the #67 branch on 2026-08-21.

- **The `\lean{}` links are hidden, and tag pushes no longer replace the
  site.** Both follow from a repository having one Pages site that three
  workflows wanted to publish at its root. `\dochome` points at `/docs`, which
  nothing publishes, so every Lean link fell through to `404.html` and bounced
  the reader to the qec-lab dashboard — worse than no link. Dropping
  `\dochome` would not help; leanblueprint then falls back to mathlib's doc
  site, where none of these declarations exist. Hidden in CSS until the docs
  exist, with the restore path written down. Separately,
  `lean_action_ci.yml`'s `docgen-action` step published API docs as the site
  root on tag pushes, so **tagging a release replaced the blueprint** until the
  next push to `main` put it back; that step is removed (its manual-dispatch
  half never produced anything, since the action gates build, upload and deploy
  on `event_name == 'push'`).

## Verification

The feature was driven in a browser against the real rendered blueprint from
CI. Every node set was cross-checked against an independent BFS over the raw
graphviz source, and all matched exactly:

| focus | direction | nodes | edges |
|---|---|---|---|
| `def:steane7` | dependencies | 22 | 33 |
| `def:steane7` | dependencies, depth 2 | 14 | — |
| `thm:gross-distance` | dependencies | 39 | — |
| `thm:commutes-iff-even` | up / down / both | 7 / 24 / 30 | 40 (both) |

Also confirmed: deep links restore all three controls; the legend toggle still
works (i.e. `interactive()` is not double-bound); the CSS hides all 86 Lean
links on the graph page and all 13 on a chapter page while leaving the `uses`
dialog, the proof links and the LaTeX links intact; and the script no-ops
cleanly on chapter pages, where plasTeX also loads it.

`lake build` passes (3479 jobs). The Lean library is untouched by this PR —
every change is to `blueprint/src/`, `scripts/`, CI and docs.

The CI changes are the part that cannot be verified locally: the YAML, the
publish gating and the resulting set of Pages publishers were all checked, but
the deploy path itself only proves out on a real run. Note that merging this
will republish the site automatically, which is the point, but it happens
without a dispatch now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
