### PR TITLE
Enhance blueprint documentation and build process

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,46 @@
+{
+  // LaTeX Workshop, configured for the blueprint only.
+  //
+  // The root document is blueprint/src/print.tex, which \inputs content.tex;
+  // content.tex in turn \inputs the node files generated from Lean by
+  //     lake build QECBlueprint && lake build QECBlueprint:blueprint
+  // so re-run those two after editing an annotation in QECBlueprint.lean.
+  // Narrative edits to content.tex need no Lean build.
+
+  // Only ever treat print.tex as a root; without this, LaTeX Workshop also
+  // offers web.tex (a plasTeX source, not xelatex-compilable).
+  "latex-workshop.latex.search.rootFiles.include": ["blueprint/src/print.tex"],
+  "latex-workshop.latex.rootFile.doNotPrompt": true,
+
+  // /blueprint/print/ is already gitignored, so aux files stay out of the tree.
+  "latex-workshop.latex.outDir": "%WORKSPACE_FOLDER%/blueprint/print",
+
+  // Two xelatex passes rather than latexmk: this MacTeX install has no
+  // latexmk (`sudo tlmgr install latexmk` would add it). Pass two is what
+  // resolves \cref references and the table of contents.
+  //
+  // TEXINPUTS is what lets kpsewhich resolve `macros/common` and the
+  // ../../.lake node index -- the same reason the README prefixes its
+  // leanblueprint commands with it.
+  "latex-workshop.latex.tools": [
+    {
+      "name": "xelatex",
+      "command": "xelatex",
+      "args": [
+        "-synctex=1",
+        "-interaction=nonstopmode",
+        "-file-line-error",
+        "-output-directory=%OUTDIR%",
+        "%DOC%"
+      ],
+      "env": { "TEXINPUTS": ".:" }
+    }
+  ],
+  "latex-workshop.latex.recipes": [
+    { "name": "blueprint (xelatex x2)", "tools": ["xelatex", "xelatex"] }
+  ],
+
+  "latex-workshop.latex.autoBuild.run": "onFileChange",
+  "latex-workshop.view.pdf.viewer": "tab",
+  "latex-workshop.synctex.afterBuild.enabled": true
+}

--- a/QECBlueprint.lean
+++ b/QECBlueprint.lean
@@ -43,21 +43,29 @@ the shape of the dependency graph — no dependency is written by hand.
 
 ## Rebuilding
 
+An edit here does not reach either rendering until the emitted LaTeX under
+`.lake/build/blueprint` is regenerated -- `content.tex` reads that directory,
+not this file, so skipping the second step re-renders the previous prose
+without complaining.
+
 ```
 lake build QECBlueprint            -- elaborate the annotations
 lake build QECBlueprint:blueprint  -- emit the LaTeX under .lake/build/blueprint
-leanblueprint web && leanblueprint pdf
+leanblueprint web                  -- render blueprint/web
 ```
+
+For the pdf, `bash scripts/build-blueprint-pdf.sh` does all three (`--tex-only`
+skips the two lake builds) and needs neither `leanblueprint` nor `latexmk`.
 
 See `blueprint/README.md`. Use `#show_blueprint Some.Decl` to inspect a single
 extracted node.
 -/
 
-/-! ## Chapter 1 — The Pauli group -/
+/-! ## Chapter 2 — The Pauli group -/
 
 attribute [blueprint "def:pauli-operator"
   (title := /-- Single-qubit Pauli operator -/)
-  (statement := /-- The four single-qubit Pauli *operators* $I$, $X$, $Y$, $Z$,
+  (statement := /-- The four single-qubit Pauli \emph{operators} $I$, $X$, $Y$, $Z$,
     taken without a phase. This is the operator part of a Pauli group element;
     the phase is tracked separately by \cref{def:pauli-group-element}. -/)]
   Quantum.PauliOperator
@@ -73,7 +81,7 @@ attribute [blueprint "def:pauli-group-element"
 
 attribute [blueprint "def:nqubit-pauli-operator"
   (title := /-- $n$-qubit Pauli operator -/)
-  (statement := /-- An $n$-qubit Pauli *operator* is a function
+  (statement := /-- An $n$-qubit Pauli \emph{operator} is a function
     $\mathrm{Fin}\,n \to \{I,X,Y,Z\}$, i.e. one single-qubit Pauli per qubit.
     Again this is the phase-free part. -/)]
   Quantum.NQubitPauliOperator
@@ -91,9 +99,8 @@ attribute [blueprint "def:nqubit-pauli-group"
 attribute [blueprint "def:pauli-to-matrix"
   (title := /-- Matrix representation -/)
   (statement := /-- The unitary matrix $i^a\, P_1 \otimes \cdots \otimes P_n$ on
-    $(\C^2)^{\otimes n}$ represented by a Pauli group element. This is the
-    semantic anchor of the formalization: it is what makes the syntactic
-    bookkeeping over $\Z_4 \times \{I,X,Y,Z\}^n$ a statement about operators on
+    $(\C^2)^{\otimes n}$ represented by a Pauli group element. It interprets the syntactic
+    bookkeeping over $\Z_4 \times \{I,X,Y,Z\}^n$ as a statement about operators on
     a Hilbert space. -/)]
   Quantum.NQubitPauliGroupElement.toMatrix
 
@@ -126,14 +133,13 @@ attribute [blueprint "def:pauli-weight"
   (title := /-- Weight -/)
   (statement := /-- The weight $\wt(g)$ of a Pauli group element is the
     cardinality of its support (\cref{def:pauli-support}) — the number of qubits
-    it acts on nontrivially. Code distance is a statement about weights. -/)]
+    it acts on nontrivially. -/)]
   Quantum.NQubitPauliGroupElement.weight
 
 attribute [blueprint "def:anticommutes-at"
   (title := /-- Local anticommutation -/)
-  (statement := /-- Two $n$-qubit Pauli operators *anticommute at qubit $i$* if
-    their $i$-th single-qubit operators are distinct and neither is $I$. This is
-    the local test whose global parity governs commutation. -/)]
+  (statement := /-- Two $n$-qubit Pauli operators \emph{anticommute at qubit $i$} if
+    their $i$-th single-qubit operators are distinct and neither is $I$. -/)]
   Quantum.NQubitPauliGroupElement.anticommutesAt
 
 attribute [blueprint "thm:commutes-iff-even"
@@ -150,9 +156,9 @@ attribute [blueprint "thm:commutes-iff-even"
 
 attribute [blueprint "def:anticommute"
   (title := /-- Anticommutation -/)
-  (statement := /-- $p$ and $q$ *anticommute* when $pq = -qp$. Anticommutation
-    with a stabilizer generator is the syndrome signal that detects an
-    error. -/)]
+  (statement := /-- Two elements $p, q \in \mathcal{P}_n$ \emph{anticommute} when
+    $pq = -qp$. Anticommutation with a stabilizer generator is the syndrome
+    signal that detects an error. -/)]
   Quantum.NQubitPauliGroupElement.Anticommute
 
 attribute [blueprint "thm:commute-or-anticommute"
@@ -164,22 +170,20 @@ attribute [blueprint "thm:commute-or-anticommute"
     either $+1$ or $-1$. -/)]
   Quantum.NQubitPauliGroupElement.commute_or_anticommute
 
-/-! ## Chapter 2 — The binary symplectic representation -/
+/-! ## Chapter 3 — The binary symplectic representation -/
 
 attribute [blueprint "def:to-symplectic"
   (title := /-- Symplectic vector of a Pauli operator -/)
-  (statement := /-- The linear-algebra shadow of a Pauli operator: an $n$-qubit
-    Pauli operator is sent to a vector in $\F_2^{2n}$, recording in its first
+  (statement := /-- A linear-algebra semantics of a Pauli operator: an $n$-qubit
+    Pauli operator is interpreted as a vector in $\F_2^{2n}$, recording in its first
     $n$ coordinates which qubits carry an $X$ component and in its last $n$
-    which carry a $Z$ component (so $Y$ contributes to both). Products of Paulis
-    become sums of vectors, which is what turns questions about the group
-    $\mathcal{P}_n$ into linear algebra over $\F_2$. -/)]
+    which carry a $Z$ component (and $Y$ contributes to both). -/)]
   Quantum.NQubitPauliOperator.toSymplectic
 
 attribute [blueprint "thm:to-symplectic-injective"
   (title := /-- The symplectic representation is faithful -/)
   (statement := /-- \Cref{def:to-symplectic} is injective: a Pauli operator is
-    determined by its symplectic vector. Phases are of course not recorded. -/)
+    determined by its symplectic vector. Phases are not recorded. -/)
   (proof := /-- The pair of bits at position $i$ determines the $i$-th
     single-qubit operator, since the four Paulis $I, X, Z, Y$ are sent to the
     four distinct pairs $(0,0)$, $(1,0)$, $(0,1)$, $(1,1)$. -/)]
@@ -195,9 +199,7 @@ attribute [blueprint "def:symplectic-inner"
 attribute [blueprint "thm:commutes-iff-symplectic"
   (title := /-- Commutation is symplectic orthogonality -/)
   (statement := /-- Two elements of $\mathcal{P}_n$ commute if and only if their
-    symplectic vectors are orthogonal under \cref{def:symplectic-inner}. This is
-    the bridge that lets the whole theory be done with linear algebra over
-    $\F_2$: an abelian subgroup becomes a self-orthogonal subspace. -/)
+    symplectic vectors are orthogonal under \cref{def:symplectic-inner}. -/)
   (proof := /-- By \cref{thm:commutes-iff-even} commutation is the parity of the
     number of locally anticommuting qubits. Qubit $i$ contributes $1$ to
     $\langle u, v \rangle$ exactly when the two single-qubit operators there are
@@ -221,7 +223,7 @@ attribute [blueprint "def:rows-linear-independent"
     discharge the independence obligation of \cref{def:stabilizer-code}. -/)]
   Quantum.NQubitPauliGroupElement.rowsLinearIndependent
 
-/-! ## Chapter 3 — Stabilizer groups and the codespace -/
+/-! ## Chapter 4 — Stabilizer groups and the codespace -/
 
 attribute [blueprint "def:is-stabilized-by"
   (title := /-- Stabilized state -/)
@@ -232,7 +234,7 @@ attribute [blueprint "def:is-stabilized-by"
 
 attribute [blueprint "def:stabilizer-group"
   (title := /-- Stabilizer group -/)
-  (statement := /-- A *stabilizer group* is an abelian subgroup
+  (statement := /-- A \emph{stabilizer group} is an abelian subgroup
     $\mathcal{S} \le \mathcal{P}_n$ that does not contain $-I$. The two
     conditions are exactly what is needed for the common $+1$ eigenspace to be
     nonzero: commutativity makes the eigenspace projectors compatible, and
@@ -246,7 +248,7 @@ attribute [blueprint "thm:neg-identity-not-mem"
   (proof := /-- Immediate from the defining field of
     \cref{def:stabilizer-group}. It is recorded separately because it is the
     obligation that concrete codes must discharge by hand, and it is the step
-    that fails for a would-be "stabilizer group" generated by anticommuting
+    that fails for a would-be ``stabilizer group" generated by anticommuting
     operators. -/)]
   Quantum.StabilizerGroup.neg_identity_not_mem
 
@@ -260,9 +262,7 @@ attribute [blueprint "def:codespace"
 attribute [blueprint "def:stabilizer-sum"
   (title := /-- Stabilizer sum -/)
   (statement := /-- The operator $\sum_{g \in \mathcal{S}} g$, which is
-    $|\mathcal{S}|$ times the orthogonal projector onto the codespace. Summing
-    over the group is the standard route to showing the codespace is
-    nonzero. -/)]
+    $|\mathcal{S}|$ times the orthogonal projector onto the codespace. -/)]
   Quantum.StabilizerGroup.stabilizerSum
 
 attribute [blueprint "thm:codespace-nonempty"
@@ -281,8 +281,7 @@ attribute [blueprint "def:centralizer"
   (title := /-- Centralizer -/)
   (statement := /-- The centralizer $\mathcal{C}(\mathcal{S})$ of a stabilizer
     group inside $\mathcal{P}_n$: the Pauli operators commuting with every
-    element of $\mathcal{S}$. These are exactly the operators that preserve the
-    codespace, so they are the candidates for logical operators. -/)]
+    element of $\mathcal{S}$.  -/)]
   Quantum.StabilizerGroup.centralizer
 
 attribute [blueprint "thm:normalizer-eq-centralizer"
@@ -290,30 +289,73 @@ attribute [blueprint "thm:normalizer-eq-centralizer"
   (statement := /-- For a stabilizer group, the Pauli normalizer and the
     centralizer coincide. This is special to the Pauli group and is the reason
     the literature uses the two words interchangeably here. -/)
-  (proof := /-- One inclusion is general. Conversely, if $g$ normalizes
+  (proof := /-- The first inclusion is immediate. Conversely, if $g$ normalizes
     $\mathcal{S}$ then for $s \in \mathcal{S}$ we have
-    $gsg^{-1} \in \mathcal{S}$, and by \cref{thm:commute-or-anticommute} that
-    conjugate is $\pm s$. The value $-s$ is impossible: it would put
+    $gsg^{-1} \in \mathcal{S}$, and by \cref{thm:commute-or-anticommute}
+    that conjugate is $\pm s$. The value $-s$ is impossible: it would put
     $-I = (-s)s^{-1}$ in $\mathcal{S}$, contradicting
-    \cref{thm:neg-identity-not-mem}. So $gsg^{-1} = s$. -/)]
+    \cref{thm:neg-identity-not-mem}. We conclude that
+    $gsg^{-1} = s$ and so $g \in \mathcal{C}(\mathcal{S})$. -/)]
   Quantum.StabilizerGroup.pauliNormalizer_eq_centralizer
 
 attribute [blueprint "thm:stabilizer-le-centralizer"
   (title := /-- The stabilizer sits inside its centralizer -/)
   (statement := /-- $\mathcal{S} \le \mathcal{C}(\mathcal{S})$. -/)
-  (proof := /-- Restatement of commutativity of \cref{def:stabilizer-group}. The
-    quotient $\mathcal{C}(\mathcal{S})/\mathcal{S}$ is what carries the logical
-    operators. -/)]
+  (proof := /-- Restatement of commutativity of \cref{def:stabilizer-group}. -/)]
   Quantum.StabilizerGroup.stabilizer_le_centralizer
 
-/-! ## Chapter 4 — Logical operators, codes, and distance -/
+/-! ## Chapter 5 — Logical operators, codes, and distance -/
+
+attribute [blueprint "def:logical-gate"
+  (title := /-- Logical gate -/)
+  (statement := /-- A unitary $U$ on $n$ qubits is a \emph{logical gate} for
+    $\mathcal{S}$ when it belongs to the logical gate group: for every
+    $g \in \mathcal{S}$ and every codespace state $\psi$, the conjugate
+    $U g U^{\dagger}$ fixes $\psi$. -/)]
+  Quantum.StabilizerGroup.IsLogicalGate
+
+attribute [blueprint "thm:logical-gate-iff"
+  (title := /-- Logical gates preserve the codespace -/)
+  (statement := /-- $U$ is a logical gate for $\mathcal{S}$ if and only if
+    $U\psi$ lies in the codespace whenever $\psi$ does. -/)
+  (proof := /-- The conjugation condition says $U g U^{\dagger}$ fixes every
+    codespace state. Extend it from unit vectors to the whole codespace
+    submodule by linearity, which also shows $U^{\dagger}$ maps the codespace
+    into itself; then for $\psi$ in the codespace and $g \in \mathcal{S}$,
+    $g U \psi = U (U^{\dagger} g U) \psi = U \psi$. Conversely, if $U$ maps the
+    codespace into itself then $U^{\dagger}$ does too, and the conjugation
+    identity follows by applying $g$ to $U^{\dagger}\psi$. -/)]
+  Quantum.StabilizerGroup.isLogicalGate_iff
 
 attribute [blueprint "def:pauli-logical"
   (title := /-- Pauli logical operator -/)
-  (statement := /-- A Pauli operator is *logical* when it lies in the
-    centralizer \cref{def:centralizer}, i.e. it commutes with every stabilizer
-    and therefore maps the codespace to itself. -/)]
+  (statement := /-- A Pauli group element is a \emph{logical operator} when the
+    unitary it represents (\cref{def:pauli-to-matrix}) is a logical gate
+    (\cref{def:logical-gate}). The defining condition is therefore semantic ---
+    it is about the action on the codespace, not about commutation. -/)]
   Quantum.StabilizerGroup.IsPauliLogicalOperator
+
+attribute [blueprint "thm:pauli-logical-iff-centralizer"
+  (title := /-- Logical operators are exactly the centralizer -/)
+  (statement := /-- A Pauli group element preserves the codespace if and only if
+    it lies in the centralizer (\cref{def:centralizer}), i.e. commutes with
+    every stabilizer. -/)
+  (proof := /-- If $g$ commutes with every $s \in \mathcal{S}$ then for $\psi$
+    in the codespace, $s(g\psi) = g(s\psi) = g\psi$, so $g\psi$ is again in the
+    codespace; unitarity of $g$ is what makes this an honest state.
+
+    Conversely, suppose $g \notin \mathcal{C}(\mathcal{S})$. Then some
+    $s \in \mathcal{S}$ fails to commute with $g$, and by
+    \cref{thm:commute-or-anticommute} it anticommutes. For $\psi$ in the
+    codespace, $s(g\psi) = -g(s\psi) = -g\psi$, so $g\psi$ would have to be
+    both fixed and negated by $s$, forcing $g\psi = 0$ --- impossible for a
+    unitary applied to a state, and the codespace is nonempty by
+    \cref{thm:codespace-nonempty}. So $g$ is not a logical operator.
+
+    This equivalence is what licenses the rest of the development to work with
+    commutation alone: every later logicality check is a finite commutation
+    test, and this theorem is why that suffices. -/)]
+  Quantum.StabilizerGroup.isPauliLogicalOperator_iff_mem_centralizer
 
 attribute [blueprint "thm:logical-iff-generators"
   (title := /-- Checking logicality on generators -/)
@@ -327,7 +369,7 @@ attribute [blueprint "thm:logical-iff-generators"
 
 attribute [blueprint "def:nontrivial-logical"
   (title := /-- Nontrivial logical operator -/)
-  (statement := /-- A *nontrivial* logical operator is one that acts on the
+  (statement := /-- A \emph{nontrivial} logical operator is one that acts on the
     encoded information rather than fixing it. The predicate has three
     conditions: $g$ is in the centralizer, $g \notin \mathcal{S}$, and no
     element of $\mathcal{S}$ has the same operator part as $g$.
@@ -387,13 +429,13 @@ attribute [blueprint "def:stabilizer-code"
   (statement := /-- An $[[n,k]]$ stabilizer code: a list of $n-k$ independent,
     pairwise commuting generators avoiding $-I$, together with $k$ pairs of
     logical operators (\cref{def:logical-qubit-ops}). The type carries $n$ and
-    $k$, so instantiating it *is* the theorem that a given family of operators
+    $k$, so instantiating it \emph{is} the theorem that a given family of operators
     encodes $k$ qubits into $n$. -/)]
   Quantum.StabilizerGroup.StabilizerCode
 
 attribute [blueprint "def:has-code-distance"
   (title := /-- Code distance -/)
-  (statement := /-- A code *has distance $d$* when every nontrivial logical
+  (statement := /-- A code \emph{has distance $d$} when every nontrivial logical
     operator (\cref{def:nontrivial-logical}) has weight at least $d$, and some
     nontrivial logical operator has weight exactly $d$. Both halves matter: the
     lower bound is the error-correction guarantee, the witness makes the value
@@ -415,7 +457,7 @@ attribute [blueprint "def:code-with-distance"
     development are inhabitants of this type. -/)]
   Quantum.StabilizerGroup.StabilizerCodeWithDistance
 
-/-! ## Chapter 5 — CSS structure -/
+/-! ## Chapter 6 — CSS structure -/
 
 attribute [blueprint "def:x-type"
   (title := /-- $X$-type element -/)
@@ -444,7 +486,7 @@ attribute [blueprint "thm:css-distance-two"
     \cref{chap:codes}. -/)]
   Quantum.StabilizerGroup.hasCodeDistance_two_of_anticommute_witness
 
-/-! ## Chapter 6 — The homological framework -/
+/-! ## Chapter 7 — The homological framework -/
 
 attribute [blueprint "def:homological-code"
   (title := /-- Homological code -/)
@@ -488,7 +530,7 @@ attribute [blueprint "def:H1"
   (title := /-- First homology -/)
   (statement := /-- $H_1 = Z_1 / B_1$ (\cref{def:cycles},
     \cref{def:boundaries}). The slogan of the whole framework is
-    *logical operators are homology classes*: nontrivial logical operators
+    \emph{logical operators are homology classes}: nontrivial logical operators
     correspond to nonzero classes in $H_1$, and the code distance is the minimum
     weight of a chain representing a nonzero class. -/)]
   Quantum.Stabilizer.Homological.HomologicalCode.H1
@@ -560,7 +602,7 @@ attribute [blueprint "thm:chain-weight-transfer"
     the toric family and the gross code. -/)]
   Quantum.Stabilizer.Homological.HomologicalCode.chainWeight_lower_bound_transfers
 
-/-! ## Chapter 7 — The toric code -/
+/-! ## Chapter 8 — The toric code -/
 
 attribute [blueprint "def:toric-chain-complex"
   (title := /-- The toric chain complex -/)
@@ -640,7 +682,7 @@ attribute [blueprint "def:toric-code"
     The natural generating set has $2L^2$ elements, two more than the
     $n - k = 2L^2 - 2$ that \cref{def:stabilizer-code} demands, because the
     vertex checks multiply to the identity and so do the face checks. The
-    packaging therefore uses a *trimmed* list, and the homological identities
+    packaging therefore uses a \emph{trimmed} list, and the homological identities
     are what prove the trimmed list generates the same subgroup. -/)]
   Quantum.StabilizerGroup.ToricCodeN.toricStabilizerCode
 
@@ -683,7 +725,7 @@ attribute [blueprint "def:toric-code-with-distance"
     \cref{def:code-with-distance}, for every $L \ge 2$. -/)]
   Quantum.StabilizerGroup.ToricCodeN.toricStabilizerCodeWithDistance
 
-/-! ## Chapter 8 — Bivariate-bicycle codes and the gross code -/
+/-! ## Chapter 9 — Bivariate-bicycle codes and the gross code -/
 
 attribute [blueprint "def:x-double-cover"
   (title := /-- Free $\Z_2$ cover of a bivariate-bicycle complex -/)
@@ -738,9 +780,9 @@ attribute [blueprint "thm:gross-logical-weight"
 attribute [blueprint "thm:gross-sector-dichotomy"
   (title := /-- Safe and dangerous sectors -/)
   (statement := /-- Every nontrivial gross logical operator falls into one of
-    two sectors, and in each the weight is at least twelve: the *safe* sector,
+    two sectors, and in each the weight is at least twelve: the \emph{safe} sector,
     where the two sheets of the cover contribute independently, and the
-    *dangerous* sector, where they do not and a finer argument is needed. -/)
+    \emph{dangerous} sector, where they do not and a finer argument is needed. -/)
   (proof := /-- In the safe sector the class survives to each sheet separately,
     so \cref{thm:gross-logical-weight} applies twice and the weights add to at
     least $6 + 6 = 12$. The dangerous sector is where the deck transformation
@@ -773,7 +815,7 @@ attribute [blueprint "def:gross-code-with-distance"
     development. -/)]
   Quantum.Stabilizer.Homological.BB.grossStabilizerCodeWithDistance
 
-/-! ## Chapter 9 — Small and parametric code instances -/
+/-! ## Chapter 10 — Code instances -/
 
 attribute [blueprint "def:steane7"
   (title := /-- The Steane $[[7,1,3]]$ code -/)
@@ -799,7 +841,7 @@ attribute [blueprint "def:five-qubit"
 
 attribute [blueprint "def:four-qubit"
   (title := /-- The $[[4,2,2]]$ code -/)
-  (statement := /-- The smallest error-*detecting* code, encoding two qubits
+  (statement := /-- The smallest error-\emph{detecting} code, encoding two qubits
     with distance two. Its distance is closed by
     \cref{thm:css-distance-two}. -/)]
   Quantum.StabilizerGroup.FourQubit_4_2_2.stabilizerCodeWithDistance
@@ -821,7 +863,6 @@ attribute [blueprint "def:rotated-surface"
 attribute [blueprint "def:repetition-n"
   (title := /-- The $n$-qubit repetition code -/)
   (statement := /-- The bit-flip repetition code as a stabilizer code, with
-    $Z_i Z_{i+1}$ generators. It has distance one as a *quantum* code — phase
-    errors are undetectable — which is why it appears here as a degenerate
-    reference point rather than as a usable code. -/)]
+    $Z_i Z_{i+1}$ generators. It has distance one as a \emph{quantum} code — phase
+    errors are undetectable. -/)]
   Quantum.StabilizerGroup.RepetitionCodeN.stabilizerCode

--- a/blueprint/README.md
+++ b/blueprint/README.md
@@ -59,6 +59,28 @@ bash scripts/check-blueprint-render.sh   # assert the nodes actually rendered
 `kpsewhich` has no default search path of its own. A full TeX Live installation
 sets one up and you can drop the prefix.
 
+For the PDF alone there is a wrapper that does not need `leanblueprint` on
+`PATH` at all:
+
+```bash
+bash scripts/build-blueprint-pdf.sh            # both lake builds, then xelatex
+bash scripts/build-blueprint-pdf.sh --tex-only # only blueprint/src/*.tex changed
+bash scripts/build-blueprint-pdf.sh --open     # ... and open the result
+```
+
+It runs the same engine and flags `latexmkrc` specifies, so it produces the same
+file, but it drives `xelatex` directly rather than through `latexmk` — which
+TeX Live's `basic` scheme does not install. It repeats passes until the `\cref`
+numbers stop moving, keeps `lake`'s (very long) warning output in
+`blueprint/print/lake-build.log` unless a build fails, and reports any label
+still rendering as `??`.
+
+The thing it exists to prevent: **a Lean edit does not reach the PDF until
+`lake build QECBlueprint:blueprint` re-emits the node LaTeX.**
+`content.tex`'s `\inputleannode{}` reads `.lake/build/blueprint/`, not
+`QECBlueprint.lean`, so running only `xelatex` after editing an annotation
+rebuilds the PDF with the previous prose and says nothing.
+
 Then serve it, rather than opening the files directly:
 
 ```bash

--- a/blueprint/src/content.tex
+++ b/blueprint/src/content.tex
@@ -13,80 +13,53 @@
 \label{chap:intro}
 
 This is the blueprint for \href{https://github.com/Stavan-Jain/QECLean}{QECLean},
-a formalization of the stabilizer formalism for quantum error correction in Lean~4
-and Mathlib.
+an ongoing formalization effort for quantum error correction in Lean~4. It consists of an informal mathematical exposition along with a dependency graph that shows how the formalized definitions and theorems in QECLean relate to each other. 
 
-A blueprint is a map of a formalization: informal mathematical exposition, one
-node per definition or theorem, wired into a dependency graph that shows how the
-results rest on one another and how much of the plan is already formal. Here
-every node is \emph{already} formal --- the library is complete and sorry-free ---
-so the graph is best read as a guide to the architecture rather than as a
-to-do list.
+\section{What QECLean contains}
 
-\section{What is proved}
+The final goal of QECLean is to provide a comprehensive formalization of Quantum Error Correction theory. As of August 2026, we've built abstractions to formalize the proofs of the canonical $[[n, k, d]]$ parameters of stabilizer codes. 
 
-Two results anchor the development.
+Our formalization begins with the definition of the n-qubit Pauli group $\mathcal{P}_n$ (\cref{chap:pauli}) and builds theory leading up to the definitions of a StabilizerCode and code distance (\cref{chap:codes-abstract}). We then instantiate our abstract StabilizerCode definition with a variety of well-known quantum error correcting codes (\cref{chap:toric}, \cref{chap:bb}, \cref{chap:codes}). Along the way, we develop frameworks to prove properties of these codes with the goal of making the proofs as general and modular as possible. In \cref{chap:symplectic}, we present the binary symplectic representation to provide efficient procedures to prove commutation and independence properties of stabilizer generators. We also provide extensive support for CSS codes via the homological framework (\cref{chap:homological}). 
 
-\begin{itemize}
-  \item \textbf{The toric family.} For every $L \ge 2$, the $L \times L$ toric
-    code is verified as an $[[2L^2, 2, L]]$ stabilizer code: the distance is
-    exactly $L$, not merely bounded below by it
+Our most notable formalizations are the following:
+
+\begin{enumerate}
+  \item \textbf{The toric family.} For every $L \ge 2$, we verify that the $L \times L$ toric
+    code is a $[[2L^2, 2, L]]$ stabilizer code. Notably, we parametrically prove that the distance is exactly $L$.
     (\cref{thm:toric-distance}).
-  \item \textbf{The gross code.} IBM's $[[144,12,12]]$ bivariate-bicycle code
-    --- the flagship qLDPC code of Bravyi et al. --- is verified with distance
-    exactly $12$, unconditionally (\cref{thm:gross-distance}).
-\end{itemize}
+  \item \textbf{The gross code.} We verify IBM's gross code [Bravyi et al.] as a $[[144,12,12]]$ bivariate-bicycle code. Notably, we prove that the distance is exactly 12 (\cref{thm:gross-distance}).
+\end{enumerate}
 
-Alongside these sit the rotated surface family, the repetition codes, the
+Alongside these sit the rotated surface code family, the repetition codes, the
 iceberg family, and the small named codes: Steane's $[[7,1,3]]$, Shor's
 $[[9,1,3]]$, the perfect $[[5,1,3]]$ code, and the $[[4,2,2]]$ detection code
 (\cref{chap:codes}).
 
-\section{The axiom discipline}
-
-Everything on the main branch depends on exactly Mathlib's three standard
-axioms --- \texttt{propext}, \texttt{Classical.choice}, \texttt{Quot.sound} ---
-and nothing else. In particular there is no \texttt{native\_decide}, which
-would replace a kernel check by a compiler-trust axiom, and no \texttt{sorry}.
-An input that cannot yet be proved is carried as a named hypothesis on the
-theorem, where it is visible in the statement rather than hidden in the axiom
-set. This is enforced in CI, so a violation fails the build rather than landing
-quietly.
-
-The discipline is not free. The gross code distance proof was originally
-carried by 135 \texttt{native\_decide} leaves and had to be converted to
-kernel-checkable form: packed natural-number tables instead of array lookups,
-quantifier bridges so the kernel enumerates concrete lambdas, sparse rewrites
-in place of large finite sums, and Gaussian-style certificates where a sweep
-would otherwise be needed.
+Everything on the main branch depends only on the standard axioms
+\texttt{propext}, \texttt{Classical.choice}, and \texttt{Quot.sound}.
 
 \section{Reading the graph}
 
 An edge $A \to B$ in the dependency graph means that $B$ is the nearest
 blueprint ancestor of $A$: LeanArchitect walks the type and the proof term of
 each annotated declaration and stops as soon as it reaches another annotated
-declaration. The edges are therefore read off the real proof terms rather than
-maintained by hand, and a node that a proof genuinely stopped needing loses its
-edge as soon as the proof changes.
+declaration. The edges are therefore read off the proof terms rather than
+maintained by hand.
 
 \chapter{The Pauli group}
 \label{chap:pauli}
 
-Everything begins with the group $\mathcal{P}_n$ of $n$-qubit Pauli operators
-with phases. The formalization splits an element into a phase exponent in
-$\Z_4$ and a phase-free operator $\mathrm{Fin}\,n \to \{I,X,Y,Z\}$. The split
-is what makes multiplication computable: the operator part multiplies
+In the textbook Quantum Computation and Quantum Information, Nielsen and Chuang write ``The key to the power of the stabilizer formalism lies in the clever use of group theory". The group of interest is the Pauli group $\mathcal{P}_n$ on $n$ qubits. It is defined as the group $n$-qubit Pauli operators with phases $\{\pm 1, \pm i\}$. Our formalization splits an element of this group into a phase exponent in $\Z_4$ and a phase-free operator $\mathrm{Fin}\,n \to \{I,X,Y,Z\}$. The split makes multiplication easy: the operator part multiplies
 qubitwise, and the phases that fall out of products such as $XZ = -iY$
-accumulate separately.
+accumulate separately. 
 
 \inputleannode{def:pauli-operator}
 \inputleannode{def:pauli-group-element}
 \inputleannode{def:nqubit-pauli-operator}
 \inputleannode{def:nqubit-pauli-group}
 
-The syntactic representation is tied to actual operators on a Hilbert space by
-a matrix interpretation; without it the development would be a study of a
-finite group with no quantum content.
+The syntactic representation of $\mathcal{P}_n$ as an inductive type is tied to actual operators on a Hilbert space by
+a matrix interpretation:
 
 \inputleannode{def:pauli-to-matrix}
 \inputleannode{def:pauli-mulop}
@@ -94,32 +67,26 @@ finite group with no quantum content.
 
 \section{Weight}
 
-Code distance is a statement about how many qubits an operator touches, so
-support and weight are the measures everything else is phrased in.
+The following definitions build up to and are motivated by the definition of code distance in \cref{chap:codes-abstract}:
 
 \inputleannode{def:pauli-support}
 \inputleannode{def:pauli-weight}
 
 \section{Commutation}
 
-The single most used fact in the development is that commutation in
-$\mathcal{P}_n$ is a parity condition. Two Paulis pick up a sign $-1$ for each
-qubit where they disagree nontrivially, so the global sign is $(-1)^k$ and
-there is no third possibility between commuting and anticommuting.
+To prove that a group of Paulis form a stabilizer group, we need to show that the group is abelian. A convenient fact that helps us prove that two Paulis commute is that commutation in
+$\mathcal{P}_n$ is a parity condition. In particular, two Paulis pick up a sign $-1$ for each
+qubit where they disagree nontrivially (i.e. the operators on the qubit are both not $I$). If they disagree nontrivially on k qubits, the global sign is $(-1)^k$. Thus, two Paulis commute if they disagree nontrivially on an even number of qubits (k is even) and anticommute if they disagree nontrivially on an odd number of qubits (k is odd).
 
+\inputleannode{def:anticommute}
 \inputleannode{def:anticommutes-at}
 \inputleannode{thm:commutes-iff-even}
-\inputleannode{def:anticommute}
 \inputleannode{thm:commute-or-anticommute}
 
 \chapter{The binary symplectic representation}
 \label{chap:symplectic}
 
-Parity is linear algebra over $\F_2$, and that observation is the engine of the
-whole subject. Forgetting phases sends $\mathcal{P}_n$ onto $\F_2^{2n}$,
-products become sums, and --- by \cref{thm:commutes-iff-symplectic} ---
-commutation becomes orthogonality under a symplectic form. An abelian subgroup
-becomes a self-orthogonal subspace, and independence of generators becomes a
+This chapter introduces the binary symplectic framework that allows us to prove properties about Paulis by doing linear algebra over $\F_2$. In particular, we view Pauli operators as ``symplectic" vectors in $\F_2^{2n}$. Commutation of two Paulis is interpreted as orthogonality of their corresponding symplectic vectors and the independence of a set of paulis is interpreted as linear independence of the matrix of symplectic vectors. Thus, commutation becomes an orthogonality check and independence of generators becomes a
 rank computation.
 
 \inputleannode{def:to-symplectic}
@@ -132,26 +99,22 @@ rank computation.
 \chapter{Stabilizer groups and the codespace}
 \label{chap:stabilizer}
 
+This chapter defines the key abstractions of the stabilizer formalism and sets up the group theoretic properties that are needed to define logical operators in \cref{chap:codes-abstract}. 
+
 \inputleannode{def:is-stabilized-by}
 \inputleannode{def:stabilizer-group}
 \inputleannode{thm:neg-identity-not-mem}
 \inputleannode{def:codespace}
-
-The two conditions in \cref{def:stabilizer-group} --- abelian, and not
-containing $-I$ --- are exactly what is needed for the codespace to be nonzero.
-Commutativity makes the eigenspace projectors compatible; excluding $-I$ rules
-out the contradiction $\psi = -\psi$. The proof that the codespace is genuinely
-nonempty runs through the group sum.
-
 \inputleannode{def:stabilizer-sum}
+
+The two conditions in \cref{def:stabilizer-group} ( abelian, and not
+containing $-I$) are exactly what is needed for the codespace to be nonzero.
+
 \inputleannode{thm:codespace-nonempty}
 
 \section{The centralizer}
 
-Operators that preserve the codespace are those commuting with every
-stabilizer. For the Pauli group --- and this is special to it --- normalizing
-and centralizing coincide, which is why the literature uses the two words
-interchangeably in this setting.
+The analysis of error-correcting properties of a stabilizer code begins with an analysis of how operators behave on the code's codespace. The behavior of an operator on the codespace is directly connected to whether it commutes or anticommutes with the stabilizers. This section defines the subgroup that identifies the operators that commute with the stabilizers. Later, in \cref{thm:pauli-logical-iff-centralizer}, we show that these are exactly the Pauli operators that preserve the codespace.
 
 \inputleannode{def:centralizer}
 \inputleannode{thm:normalizer-eq-centralizer}
@@ -164,7 +127,16 @@ The encoded information is acted on by the quotient
 $\mathcal{C}(\mathcal{S})/\mathcal{S}$: operators that preserve the codespace,
 modulo those that act trivially on it.
 
+What makes an operator logical is semantic --- it must map the codespace into
+itself --- and that is how the definition is set up here, first for an arbitrary
+unitary and then for a Pauli. That this coincides with the syntactic condition of
+commuting with every stabilizer is a theorem, not a definition. It is the reason
+every logicality check later in the development can be a finite commutation test.
+
+\inputleannode{def:logical-gate}
+\inputleannode{thm:logical-gate-iff}
 \inputleannode{def:pauli-logical}
+\inputleannode{thm:pauli-logical-iff-centralizer}
 \inputleannode{thm:logical-iff-generators}
 \inputleannode{def:nontrivial-logical}
 \inputleannode{thm:nontrivial-logical-iff}
@@ -328,9 +300,8 @@ whose floor is again twelve.
 \label{chap:codes}
 
 The remaining codes exercise the same machinery on smaller or differently
-shaped examples. The $[[5,1,3]]$ code is the interesting outlier: its
-generators mix $X$ and $Z$ on the same qubit, so it is not CSS, the homological
-route is unavailable, and its distance is settled instead by a direct search
+shaped examples. The $[[5,1,3]]$ code is the outlier: it is not CSS, and so the homological
+route is unavailable, Its distance is settled instead by a direct search
 over weight-one and weight-two anti-witnesses.
 
 \inputleannode{def:steane7}

--- a/blueprint/src/macros/print.tex
+++ b/blueprint/src/macros/print.tex
@@ -27,3 +27,65 @@
  {\clist_map_inline:nn{#1}{\vphantom{\ref{##1}}}%
   \ignorespaces}
 \ExplSyntaxOff
+
+% ---------------------------------------------------------------------------
+% cleveref names for the shared-counter theorem environments.
+%
+% macros/common.tex declares proposition/lemma/corollary/definition as
+% `\newtheorem{...}[theorem]{...}` so that they all share one numbering
+% sequence. cleveref names a reference after the *counter* the environment
+% steps, not after the environment, so all four rendered as "theorem N" --
+% `\cref{def:pauli-group-element}` on a definition printed "theorem 2".
+%
+% aliascnt fixes this without disturbing the numbering: `\newaliascnt{definition}
+% {theorem}` makes \c@definition and \c@theorem the very same counter, so
+% re-declaring the environment against `definition` keeps the shared sequence
+% while giving cleveref a distinct counter name to look up. The environments
+% already exist at this point, so \let each one back to \relax first --
+% \newtheorem refuses to redefine a live command.
+%
+% Print-only: plasTeX takes the name from the environment's caption rather than
+% from a counter, so the web version already rendered these correctly.
+% ---------------------------------------------------------------------------
+\usepackage{aliascnt}
+
+\newcommand{\bpaliascounter}[2]{%
+  \newaliascnt{#1}{theorem}%
+  \expandafter\let\csname #1\endcsname\relax
+  \expandafter\let\csname end#1\endcsname\relax
+  \newtheorem{#1}[#1]{#2}%
+  \aliascntresetthe{#1}%
+}
+\theoremstyle{plain}
+\bpaliascounter{proposition}{Proposition}
+\bpaliascounter{lemma}{Lemma}
+\bpaliascounter{corollary}{Corollary}
+\theoremstyle{definition}
+\bpaliascounter{definition}{Definition}
+
+% ---------------------------------------------------------------------------
+% Bracket-safe theorem notes.
+%
+% amsthm grabs the optional note of \begin{theorem}[...] with a scan delimited
+% by the first `]`, so a title containing brackets -- every `[[n,k,d]]` title in
+% this blueprint -- ends the note early and drops the remainder into math mode.
+% Six nodes hit this (def:steane7, def:shor9, def:five-qubit, def:four-qubit,
+% def:iceberg, thm:base-distance).
+%
+% Re-grab the note with an xparse `o` argument, which balances nested brackets,
+% and hand it to the original environment wrapped in braces so amsthm's scan
+% never sees a bracket. Only the pdf build needs this: plasTeX parses the
+% optional argument itself and renders these titles correctly as they stand.
+% ---------------------------------------------------------------------------
+\newcommand{\bracketsafethm}[1]{%
+  \expandafter\let\csname bpsafe@#1\expandafter\endcsname\csname #1\endcsname
+  \expandafter\let\csname endbpsafe@#1\expandafter\endcsname\csname end#1\endcsname
+  \RenewDocumentEnvironment{#1}{o}
+    {\IfValueTF{##1}{\csname bpsafe@#1\endcsname[{##1}]}{\csname bpsafe@#1\endcsname}}
+    {\csname endbpsafe@#1\endcsname}%
+}
+\bracketsafethm{theorem}
+\bracketsafethm{proposition}
+\bracketsafethm{lemma}
+\bracketsafethm{corollary}
+\bracketsafethm{definition}

--- a/blueprint/src/print.tex
+++ b/blueprint/src/print.tex
@@ -13,6 +13,11 @@
 
 \usepackage[warnings-off={mathtools-colon,mathtools-overbracket}]{unicode-math}
 
+% Flush-left paragraphs with vertical separation instead of a first-line indent,
+% matching the web rendering (plasTeX's HTML5 theme never indents paragraphs).
+% Loaded last so it can undo the list spacing the packages above set up.
+\usepackage{parskip}
+
 \input{macros/common}
 \input{macros/print}
 

--- a/scripts/build-blueprint-pdf.sh
+++ b/scripts/build-blueprint-pdf.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Render the printable blueprint to blueprint/print/print.pdf.
+#
+# Why a script rather than `leanblueprint pdf`, which blueprint/README.md
+# documents: that command drives the build through `latexmk`, which TeX Live's
+# `basic` scheme does not ship, and it assumes `leanblueprint` itself is on
+# PATH. This script needs neither -- only `lake` and `xelatex` -- and runs the
+# same engine with the same flags latexmkrc specifies.
+#
+# It also handles the three things that are easy to get wrong by hand:
+#
+#   1. A Lean edit does not reach the PDF until `lake build
+#      QECBlueprint:blueprint` re-emits the per-node LaTeX under
+#      .lake/build/blueprint. content.tex's \inputleannode{} reads that
+#      directory, not QECBlueprint.lean, so skipping the step rebuilds the PDF
+#      with the previous prose and no warning.
+#   2. \cref numbers come from print.aux, so one xelatex pass renders stale
+#      cross-references. Passes are repeated here until the labels settle.
+#   3. TEXINPUTS must name the current directory or kpsewhich cannot resolve
+#      \input{macros/common}. See blueprint/README.md.
+#
+# Options:
+#   --tex-only   Skip both lake builds. Use when only blueprint/src/*.tex
+#                changed -- the emitted node files are already current.
+#   --open       Open the finished PDF.
+set -euo pipefail
+
+tex_only=0
+open_pdf=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --tex-only) tex_only=1 ;;
+    --open) open_pdf=1 ;;
+    -h|--help) awk 'NR>1 && !/^#/{exit} NR>1{sub(/^# ?/,""); print}' "$0"; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+src="$root/blueprint/src"
+out="$root/blueprint/print"
+
+# MacTeX installs here and does not always end up on a non-login shell's PATH.
+command -v xelatex >/dev/null || PATH="/Library/TeX/texbin:$PATH"
+command -v xelatex >/dev/null || {
+  echo "xelatex not found. Install MacTeX (or any TeX Live with xelatex)," >&2
+  echo "or add its bin directory to PATH." >&2
+  exit 1
+}
+
+# A whole-repo build prints thousands of linter warnings, which would bury the
+# one line that matters here. Keep the log and show it only if the build fails.
+lake_log="$out/lake-build.log"
+
+run_lake() {
+  echo "==> lake build $1"
+  lake build "$1" >"$lake_log" 2>&1 || {
+    echo >&2
+    echo "lake build $1 failed:" >&2
+    grep -E '^(error|.*: error)' "$lake_log" | head -20 >&2
+    echo >&2
+    echo "Full output: $lake_log" >&2
+    exit 1
+  }
+}
+
+if [ "$tex_only" = 0 ]; then
+  mkdir -p "$out"
+  # Two targets, and the split matters. The first elaborates the attributes and
+  # is the only thing in the repo that fails when an annotated declaration has
+  # been renamed or removed; the second extracts the LaTeX.
+  run_lake QECBlueprint
+  run_lake QECBlueprint:blueprint
+fi
+
+nodes="$root/.lake/build/blueprint/module/QECBlueprint.artifacts"
+[ -d "$nodes" ] || {
+  echo "no extracted blueprint nodes at $nodes." >&2
+  echo "Drop --tex-only so the lake builds run." >&2
+  exit 1
+}
+
+mkdir -p "$out"
+cd "$src"
+
+# `xelatex -synctex=1` is what latexmkrc asks latexmk to run; -halt-on-error
+# turns a TeX error into a nonzero exit instead of a PDF that is quietly
+# missing a chapter.
+run_pass() {
+  TEXINPUTS=".:" xelatex -synctex=1 -interaction=nonstopmode -halt-on-error \
+    -output-directory="$out" print.tex >/dev/null 2>&1 || {
+    echo >&2
+    echo "xelatex failed. From $out/print.log:" >&2
+    grep -n -A5 '^!' "$out/print.log" | head -40 >&2
+    echo >&2
+    echo "Full transcript: $out/print.log" >&2
+    exit 1
+  }
+}
+
+# Four passes is a ceiling, not a target: a blueprint whose labels have not
+# converged by then has a genuine cross-reference problem worth seeing.
+max_passes=4
+for pass in $(seq 1 $max_passes); do
+  echo "==> xelatex (pass $pass)"
+  run_pass
+  grep -q 'Rerun to get\|Label(s) may have changed' "$out/print.log" || break
+  [ "$pass" -lt "$max_passes" ] || {
+    echo "warning: cross-references still unsettled after $max_passes passes." >&2
+    echo "Check $out/print.log for an undefined or duplicated label." >&2
+  }
+done
+
+# TeX wraps the transcript at ~79 columns, and an absolute -output-directory is
+# long enough that "(19 pages)." routinely straddles the break. Join the lines
+# before matching, and treat a miss as cosmetic rather than fatal.
+pages=$(tr '\n' ' ' < "$out/print.log" | tr -s ' ' \
+          | sed -n 's/.*Output written on [^ ]* (\([0-9]*\) pages\{0,1\}).*/\1/p' || true)
+echo
+echo "  $out/print.pdf${pages:+  ($pages pages)}"
+
+# Undefined references survive the build, so say so rather than leaving a "??"
+# in the PDF to be found by a reader.
+if grep -q 'LaTeX Warning: Reference .* undefined' "$out/print.log"; then
+  echo
+  echo "warning: undefined references (these render as '??'):" >&2
+  grep -o "LaTeX Warning: Reference \`[^']*'" "$out/print.log" | sort -u >&2
+fi
+
+# `[ ... ] && open` as the last statement would trip `set -e` whenever the test
+# is false, failing a build that in fact succeeded.
+if [ "$open_pdf" = 1 ]; then
+  open "$out/print.pdf"
+fi


### PR DESCRIPTION
- Updated README.md to include instructions for building the PDF directly using a new script, `build-blueprint-pdf.sh`, which bypasses the need for `leanblueprint` on PATH and handles LaTeX compilation directly with `xelatex`.
- Revised content.tex to improve clarity and structure, including a more detailed description of QECLean's goals and formalizations, and refined the presentation of key results.
- Introduced macros in print.tex to ensure proper handling of theorem notes with brackets, enhancing the document's formatting consistency.
- Added a new settings.json file for VSCode to streamline the LaTeX Workshop configuration specifically for the blueprint project.
- Created a new script, `build-blueprint-pdf.sh`, to automate the PDF generation process, ensuring correct handling of dependencies and cross-references during LaTeX compilation.