### PR TITLE
docs(bb): record the parked cover300 refresh in the README

### DIFF
--- a/QEC/Stabilizer/Codes/BivariateBicycle/README.md
+++ b/QEC/Stabilizer/Codes/BivariateBicycle/README.md
@@ -85,14 +85,19 @@ still carried one has been removed from this tree and lives on branch
 | Parked | Result given up | `native_decide` |
 |---|---|---|
 | `Z3Z6/` (pair72, `[[36,4,4]] → [[72,4,8]]`, d = 8 unconditional) | `pair72_*_distance_eq_8` | 42, five of them `2^18` sweeps that dominated a whole-repo build |
-| `Z5Z15F2A6/` (`[[150,8,8]] → [[300,8,16]]`, two-tier) | `cover300_chain/pauli_distance_eq_16` | 9 (`Defs` coverData ×4, `Witness` ×4, `DeckHomotopy` Bezout ×1) |
+| `Z5Z15F2A6/` (`[[150,8,8]] → [[300,8,16]]`, d = 16 unconditional) | `cover300_chain/pauli_distance_eq_16` | 101 native leaves (the a15/a17 discharge engine — see the branch's `PARKED-NATIVE-DECIDE.md`) |
 | `BaseFloors/` (BB90, BB108, Z6Z14) | three certified `BBSmallCycle` class members | 12 (`epsA/epsB/check_two/check_four` ×3 files) |
 
-`Z3Z6/PARKED.md` on that branch records the Z3Z6 rationale in detail. All three
-are clean leaves — nothing outside each directory imported its declarations
-(`Z5Z15F2A6/Distance.lean` is in-instance and went with it) — so restoring one
-means re-adding the directory, its sibling umbrella, the import line in
-`BivariateBicycle.lean`, and the rows removed from this README.
+`Z3Z6/PARKED.md` on that branch records the Z3Z6 rationale in detail, and the
+branch's root `PARKED-NATIVE-DECIDE.md` covers the rest — including the
+2026-08-27 refresh that brought `Z5Z15F2A6/` to its unconditional a15 state
+(`e6f03ad`: all three floor hypotheses discharged as kernel-checked theorems)
+together with the `Framework/Homological/{BBCoverTranslate,BBDoubling}`
+extensions it depends on. All three are clean leaves in this tree — nothing
+outside each directory imported its declarations — so restoring one means
+re-adding the directory, its sibling umbrella, the import line in
+`BivariateBicycle.lean`, the rows removed from this README, and (for
+`Z5Z15F2A6/`) porting those two framework companions.
 
 The abstract machinery they exercised stays in this tree:
 `Framework/Homological/BBSmallCycle.lean` (the A15/A16 class small-cycle


### PR DESCRIPTION
## What

Docs-only: update the BB README's "Parked instances" section — the `Z5Z15F2A6/` row still described the parked cover300 as the conditional two-tier snapshot (9 native sites), and the restore notes didn't mention its framework companions.

## Why

`claude/z3z6-parked` was cut from `main@7d8bf6d`, which predates the a17/a21/a22/a23 discharge work: the 13-commit chain ending in `e6f03ad` ("d([[300,8,16]]) = 16 UNCONDITIONAL") lived only on `claude/a15-m-kernel-route` and never reached `main`. The designated parking branch therefore preserved a stale conditional snapshot, while the hypothesis-free `cover300_pauli_distance_eq_16` (axioms per `e6f03ad`: the standard three + 101 named `native_decide` obligations, 0 other) was reachable only via `e6f03ad`'s history.

The parking branch has been refreshed (already pushed to origin): merge `a416d91` brings in the a15 tip — `Z5Z15F2A6/` is now byte-identical to `e6f03ad`, together with the `Framework/Homological/{BBCoverTranslate,BBDoubling}` pieces the discharge depends on — and `5e9aae0` updates the branch's `PARKED-NATIVE-DECIDE.md`. `Z3Z6/` and the wave-2 parked paths were verified already at their last pre-removal states.

## Notes

- No Lean changes; nothing `native_decide`-based enters `main` — this PR is README text only.
- The refreshed parked branch is also backed up to the qec-lab remote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
