### PR TITLE
QECWidgets: ProofWidgets infoview library (Pauli strips, commutation views, toric lattice, check matrices)

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -50,6 +50,12 @@ jobs:
       # costs seconds rather than a rebuild.
       - name: Axiom policy (standard three axioms only)
         run: lake env lean scripts/AxiomCheck.lean
+      # Infoview widgets live in their own lib so that only it imports
+      # ProofWidgets (see lakefile.toml). It is outside `defaultTargets`, so a
+      # green `lake build` alone would let it rot invisibly — build it
+      # explicitly. Cheap: everything it imports was just built above.
+      - name: Build QECWidgets (infoview widgets)
+        run: lake build QECWidgets
       # API documentation used to be built here with
       # `leanprover-community/docgen-action`, on tag pushes and manual
       # dispatch. It has been removed because it published to GitHub Pages,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,11 @@ build/MCP workflow. Volatile or topic-scoped knowledge lives elsewhere:
   blueprint: what is generated vs. hand-written, how to add a node, how to
   inspect one with `#show_blueprint`. Read before editing `QECBlueprint.lean`
   or `blueprint/`. See also the "Blueprint" section below.
+- **[`QECWidgets/README.md`](QECWidgets/README.md)** — the ProofWidgets-based
+  infoview widgets (`#pauli_strip`, `#toric_chain`, `#check_matrix`, and the
+  expression presenters): what each renders, how meta-level reduction drives
+  them, and the linter rules for adding widget files. Read before editing
+  `QECWidgets/`.
 - **[`QEC/Stabilizer/Codes/BivariateBicycle/README.md`](QEC/Stabilizer/Codes/BivariateBicycle/README.md)**
   — orientation for the BB family (gross d=12 proof spine, instance
   dirs, hypothesis-discharge map, engine-vs-analytic status,
@@ -326,11 +331,12 @@ output prints the residual goal under each failure — read it before guessing
 tactics.
 
 **`lake build` alone is NOT sufficient before pushing.** `defaultTargets` is
-just `QEC`, so four things it does not touch will still fail CI. After any
-change that adds, moves, or removes a module, run all five:
+just `QEC`, so five things it does not touch will still fail CI. After any
+change that adds, moves, or removes a module, run all six:
 
 ```bash
 lake build && lake build QECLight && lake build QECBlueprint \
+  && lake build QECWidgets \
   && lake env lean Playground.lean && lake env lean scripts/AxiomCheck.lean
 ```
 
@@ -346,6 +352,11 @@ lake build && lake build QECLight && lake build QECBlueprint \
   fully-qualified name, so **renaming or removing an annotated declaration
   breaks it** — and nothing else in the build will tell you. Checked by the
   `blueprint` workflow. See "Blueprint" below.
+- **`QECWidgets`** (root `QECWidgets.lean`) carries the ProofWidgets-based
+  infoview widgets. Also outside `defaultTargets`, so that only it imports
+  ProofWidgets and `lake build` stays the plain library build. Checked by
+  the "Build QECWidgets" step in `lean_action_ci`. See
+  [`QECWidgets/README.md`](QECWidgets/README.md).
 - **`scripts/AxiomCheck.lean`** enforces the axiom policy (see below).
   Checked by `lean_action_ci`.
 
@@ -430,6 +441,24 @@ If `lake build` was already invoked and is partway through cloning
 mathlib, killing it leaves `.lake/packages/mathlib/` in a half-cloned
 state (just a `.git/` directory). `rm -rf .lake/packages` cleans it up,
 then symlink as above.
+
+**Cold-build memory cliff (16 GB machines).** The worktree's own
+`.lake/build/` starts empty, so the first `lake build` compiles all of
+`QEC/` — and its tail runs the three BB safe-floor kernel-`decide` leaves
+(`Gross/SafeFloor/MImFloorY{0,1,4}`, ~3.75 GB peak each) concurrently.
+On a 16 GB machine this can OOM-kill the build (and the session driving
+it); CI adds 12 GB of swap for exactly this (see the comment in
+`lean_action_ci.yml`). Locally, build the three leaves sequentially
+first, then the rest:
+
+```bash
+for m in Y0 Y1 Y4; do
+  lake build QEC.Stabilizer.Codes.BivariateBicycle.Gross.SafeFloor.MImFloor$m
+done
+lake build
+```
+
+Quit or idle the Lean LSP first — its file workers hold gigabytes too.
 
 ## Agent tooling: lean-lsp MCP
 

--- a/QEC/Stabilizer/Stabilizer.lean
+++ b/QEC/Stabilizer/Stabilizer.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 Stavan Jain. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Stavan Jain
+-/
 import QEC.Stabilizer.Foundations
 import QEC.Stabilizer.Framework
 import QEC.Stabilizer.Geometry

--- a/QECWidgets.lean
+++ b/QECWidgets.lean
@@ -1,0 +1,21 @@
+import QECWidgets.PauliEval
+import QECWidgets.Style
+import QECWidgets.PauliStrip
+import QECWidgets.PauliGoalPanel
+import QECWidgets.ToricLattice
+import QECWidgets.CheckMatrix
+import QECWidgets.Demo
+
+/-!
+# QECWidgets
+
+ProofWidgets-based infoview widgets for the QEC library: colored per-qubit
+Pauli support strips, commutation parity views, and friends. See
+`QECWidgets/Demo.lean` for living usage examples.
+
+This library is deliberately separate from `QEC` (same policy as
+`QECBlueprint`): only `QECWidgets` imports ProofWidgets, so the mathematical
+library keeps its dependency surface unchanged. Everything here is untrusted
+display-layer meta code — widgets render what reduction finds, and proofs are
+still checked by the kernel as usual.
+-/

--- a/QECWidgets/CheckMatrix.lean
+++ b/QECWidgets/CheckMatrix.lean
@@ -1,0 +1,250 @@
+/-
+Copyright (c) 2026 Stavan Jain. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Stavan Jain
+-/
+import QEC.Stabilizer.Foundations.BinarySymplectic.CheckMatrix
+import QECWidgets.PauliStrip
+
+/-!
+# Check-matrix heatmap
+
+Renders a concrete generator list `L : List (NQubitPauliGroupElement n)` as:
+
+- its binary symplectic check matrix, in the `checkMatrix` column convention
+  (first `n` columns the X-components, last `n` the Z-components, X = coral /
+  Z = blue); and
+- the symplectic Gram matrix: cell `(i, j)` is the symplectic inner product
+  of rows `i` and `j` mod 2 — red exactly when generators `i` and `j`
+  anticommute. Color marks only that signal: a valid stabilizer generator
+  list shows a quiet all-hairline Gram matrix, and the header verdict (plus
+  the card's state bar) says so.
+
+Use `#check_matrix gens`, or the `Check matrix` expression presenter via
+`ProofWidgets.SelectionPanel`.
+-/
+
+namespace QECWidgets
+
+open Lean Server Meta ProofWidgets Quantum
+
+/-- Most rows a check-matrix view will draw. -/
+def maxCheckRows : Nat := 64
+
+/-- Walk a list expression into its element expressions by weak-head
+reduction (`none` if some spine cell is stuck or the list is longer than
+`maxLen`). -/
+def listElems? (e : Expr) (maxLen : Nat := maxCheckRows) : MetaM (Option (Array Expr)) := do
+  let mut cur := e
+  let mut out : Array Expr := #[]
+  for _ in [0:maxLen + 1] do
+    let mut next : Option Expr := none
+    let mut done := false
+    for c in ← whnfCandidates cur do
+      if c.isAppOfArity ``List.cons 3 then
+        out := out.push (c.getArg! 1)
+        next := some (c.getArg! 2)
+        break
+      if c.isAppOfArity ``List.nil 1 then
+        done := true
+        break
+    if done then return some out
+    match next with
+    | some t => cur := t
+    | none => return none
+  return none
+
+/-- Recognize a generator-list expression: type `List (NQubitPauliGroupElement n)`
+with `n` literal. Returns `n`. -/
+def genListShape? (e : Expr) : MetaM (Option Nat) := do
+  let t ← instantiateMVars (← inferType e)
+  if t.isAppOfArity ``List 1 then
+    let elemT ← whnfR (t.getArg! 0)
+    if elemT.isAppOfArity ``NQubitPauliGroupElement 1 then
+      return ← natOfExpr? (elemT.getArg! 0)
+  return none
+
+/-- X-component of a single-qubit factor (`toSymplecticSingle.1`). -/
+def xBit : PauliOperator → Bool
+  | .X => true
+  | .Y => true
+  | _ => false
+
+/-- Z-component of a single-qubit factor (`toSymplecticSingle.2`). -/
+def zBit : PauliOperator → Bool
+  | .Z => true
+  | .Y => true
+  | _ => false
+
+/-- Symplectic inner product of two rows mod 2 (`true` = anticommute), or
+`none` when unresolved cells make the parity unknown. -/
+def gramBit (vp vq : PauliView) : Option Bool := Id.run do
+  if vp.numStuck + vq.numStuck > 0 then return none
+  let mut c := 0
+  for i in [0:vp.numQubits] do
+    match vp.ops.getD i none, vq.ops.getD i none with
+    | some a, some b => if anticommutesBool a b then c := c + 1
+    | _, _ => pure ()
+  return some (c % 2 == 1)
+
+/-- One heatmap cell: a `qecw-bit` with a variant class; sizes other than the
+stylesheet's 13 px default are set inline (for wide matrices). -/
+private def bitHtml (variant : String) (title : String) (size : Nat := 13) : Html :=
+  let attrs := #[("title", Json.str title)] ++
+    (if size == 13 then #[]
+     else #[("style", json% { width: $(s!"{size}px"), height: $(s!"{size}px") })])
+  cls "span" ("qecw-bit " ++ variant) attrs
+
+/-- Leading row-index label for matrix rows. -/
+private def rowIdx (i : Nat) : Html :=
+  cls "span" "qecw-rowlabel" #[] #[.text (toString i)]
+
+/-- One check-matrix row: leading generator index, X block, gap, Z block. -/
+private def matrixRow (size : Nat) (i : Nat) (v : PauliView) : Html := Id.run do
+  let mut cells : Array Html := #[rowIdx i]
+  let block (isX : Bool) : Array Html := Id.run do
+    let mut out : Array Html := #[]
+    for q in [0:v.numQubits] do
+      let part := if isX then "X" else "Z"
+      let cell := match v.ops.getD q none with
+        | none => bitHtml "qecw-bit-stuck" s!"g{i}, {part} part, qubit {q}: unresolved" size
+        | some p =>
+          let bit := if isX then xBit p else zBit p
+          let variant := if !bit then "qecw-bit-0"
+            else if isX then "qecw-bit-x" else "qecw-bit-z"
+          bitHtml variant s!"g{i}, {part} part, qubit {q}: {if bit then 1 else 0}" size
+      out := out.push cell
+    return out
+  cells := cells ++ block true
+  cells := cells.push (styled "span" (json% { display: "inline-block", width: "10px" }) #[])
+  cells := cells ++ block false
+  return styled "div" (json% { display: "flex", alignItems: "center" }) cells
+
+/-- The Gram matrix block: `k × k` commutation parities. Only anticommuting
+pairs are colored; commuting pairs stay hairline-quiet. -/
+private def gramHtml (size : Nat) (views : Array PauliView) : Html := Id.run do
+  let k := views.size
+  let mut rows : Array Html := #[]
+  for i in [0:k] do
+    let mut cells : Array Html := #[rowIdx i]
+    for j in [0:k] do
+      let cell :=
+        if i == j then
+          bitHtml "qecw-bit-diag" s!"⟨g{i}, g{i}⟩ = 0" size
+        else
+          match gramBit (views.getD i default) (views.getD j default) with
+          | none => bitHtml "qecw-bit-stuck" s!"⟨g{i}, g{j}⟩ unresolved" size
+          | some true => bitHtml "qecw-bit-anti" s!"⟨g{i}, g{j}⟩ = 1 — anticommute!" size
+          | some false => bitHtml "qecw-bit-0" s!"⟨g{i}, g{j}⟩ = 0 — commute" size
+      cells := cells.push cell
+    rows := rows.push (styled "div" (json% { display: "flex", alignItems: "center" }) cells)
+  return el "div" #[] rows
+
+/-- Render a generator list as check matrix + Gram matrix, plus a text
+summary, or `none` when the expression is not a concrete generator list. -/
+def checkMatrixRender? (e : Expr) : MetaM (Option (Html × String)) := do
+  let e ← instantiateMVars e
+  let some n ← genListShape? e | return none
+  if n == 0 || n > maxStripQubits then return none
+  let some elems ← listElems? e | return none
+  if elems.isEmpty then return none
+  let mut views : Array PauliView := #[]
+  for g in elems do
+    views := views.push (← elementView g n)
+  let k := views.size
+  -- Gram verdict.
+  let mut badPairs := 0
+  let mut unknownPairs := 0
+  for i in [0:k] do
+    for j in [0:k] do
+      if i < j then
+        match gramBit (views.getD i default) (views.getD j default) with
+        | some true => badPairs := badPairs + 1
+        | none => unknownPairs := unknownPairs + 1
+        | some false => pure ()
+  let plural (k : Nat) : String := if k == 1 then "pair" else "pairs"
+  let (accent, verdictFact) :=
+    if unknownPairs > 0 then
+      (warnColor, headerFact s!"? {unknownPairs} {plural unknownPairs} unresolved"
+        "some entries did not reduce, so those commutation parities are unknown"
+        (some warnColor))
+    else if badPairs == 0 then
+      (okColor, headerFact "✓ all pairs commute" "valid stabilizer generator list"
+        (some okColor))
+    else
+      (badColor, headerFact s!"✗ {badPairs} anticommuting {plural badPairs}"
+        "see the red Gram cells — this list is not mutually commuting" (some badColor))
+  let header := headerHtml (← exprName e) #[verdictFact]
+  let size : Nat := if n ≤ 32 then 13 else if n ≤ 80 then 9 else 5
+  let blockW := n * (size + 2)
+  let blockLabel (letter color title : String) : Html :=
+    cls "span" "qecw-micro"
+      #[("title", Json.str title),
+        ("style", json% {
+          width: $(s!"{blockW}px"), textAlign: "center", fontWeight: "600",
+          color: $(color) })]
+      #[.text letter]
+  let blockLabels := styled "div" (json% { display: "flex", marginLeft: "37px" })
+    #[blockLabel "X" xAccent.hex s!"X components (columns 0–{n - 1} of checkMatrix)",
+      styled "span" (json% { width: "12px" }) #[],
+      blockLabel "Z" zAccent.hex s!"Z components (columns {n}–{2 * n - 1})"]
+  let mut mat : Array Html := #[]
+  for i in [0:k] do
+    mat := mat.push (matrixRow size i (views.getD i default))
+  let matBox := styled "div" (json% { overflowX: "auto", paddingBottom: "2px" }) mat
+  let gramLabel := cls "div" "qecw-micro"
+    #[("title", Json.str "symplectic Gram matrix — red = the pair anticommutes"),
+      ("style", json% { margin: "8px 0 2px 37px" })]
+    #[.text "Gram"]
+  let html := card (accent := some accent)
+    #[header, blockLabels, matBox, gramLabel, gramHtml size views]
+  let mut txt := ""
+  for i in [0:k] do
+    txt := txt ++ s!"g{i}: {(views.getD i default).letters}\n"
+  txt := txt ++
+    (if unknownPairs > 0 then s!"{unknownPairs} {plural unknownPairs} unresolved"
+     else if badPairs == 0 then "all pairs commute — valid stabilizer generator list"
+     else s!"{badPairs} anticommuting {plural badPairs} — NOT mutually commuting")
+  return some (html, txt)
+
+/-- Presenter entry point: render or fail (failure = "not applicable"). -/
+def checkMatrixPresent (e : Expr) : MetaM Html := do
+  match ← checkMatrixRender? e with
+  | some (h, _) => return h
+  | none => throwError "not a concrete Pauli generator list"
+
+/-- Infoview presenter for generator lists: check matrix plus Gram matrix.
+With `ProofWidgets.SelectionPanel` open, shift-click a
+`List (NQubitPauliGroupElement n)` in the goal to render it. -/
+@[expr_presenter]
+def checkMatrixPresenter : ExprPresenter where
+  userName := "Check matrix"
+  layoutKind := .block
+  present := checkMatrixPresent
+
+/-- `#check_matrix gens` displays the binary symplectic check matrix of a
+concrete `List (NQubitPauliGroupElement n)` (X block then Z block, matching
+`checkMatrix`), together with the pairwise commutation (Gram) matrix — red
+cells are anticommuting pairs, so a valid stabilizer generator list shows
+none. -/
+syntax (name := checkMatrixCmd) "#check_matrix " term : command
+
+open Elab Command in
+@[command_elab checkMatrixCmd]
+def elabCheckMatrixCmd : CommandElab
+  | stx@`(#check_matrix $t:term) => do
+    let (ht, txt) ← liftTermElabM do
+      let e ← Term.elabTerm t none
+      Term.synthesizeSyntheticMVarsNoPostponing
+      match ← checkMatrixRender? (← instantiateMVars e) with
+      | some r => pure r
+      | none => throwError
+          "#check_matrix: not a concrete generator list. Expected a \
+          List (NQubitPauliGroupElement n) with a literal qubit count whose spine and \
+          entries reduce (at most {maxCheckRows} generators, n ≤ {maxStripQubits})."
+    logInfoAt stx txt
+    liftCoreM <| Widget.savePanelWidgetInfo (hash HtmlDisplayPanel.javascript)
+      (return json% { html : $(← rpcEncode ht) }) stx
+  | stx => throwError "Unexpected syntax {stx}."
+
+end QECWidgets

--- a/QECWidgets/Demo.lean
+++ b/QECWidgets/Demo.lean
@@ -1,0 +1,151 @@
+/-
+Copyright (c) 2026 Stavan Jain. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Stavan Jain
+-/
+import QEC.Stabilizer.Codes.Small.Steane7
+import QECWidgets.PauliStrip
+import QECWidgets.PauliGoalPanel
+import QECWidgets.ToricLattice
+import QECWidgets.CheckMatrix
+import ProofWidgets.Component.Panel.SelectionPanel
+import ProofWidgets.Component.Panel.GoalTypePanel
+
+/-!
+# Widget demos
+
+Living usage examples for the QEC infoview widgets. Open this file in an
+editor to see every widget render; it is imported by the `QECWidgets`
+umbrella so the demos are compiled (and therefore cannot silently rot).
+
+Each `#pauli_strip` below puts a widget in the infoview when the cursor is
+on the command. The `example`s at the bottom show the in-proof panels.
+-/
+
+namespace QECWidgets.Demo
+
+open Quantum Quantum.StabilizerGroup ProofWidgets
+
+/-! ## Single terms: generators and logicals of the Steane code -/
+
+
+#pauli_strip Steane7.X1
+
+#pauli_strip Steane7.Z2
+
+#pauli_strip Steane7.logicalX
+
+-- A product through the noncomputable `Mul` (reduction, not compilation),
+-- with a nontrivial phase: `logicalY = i · X̄Z̄` is phase −1 on all-Y
+-- (cf. `logicalY_eq_phase2_allY`).
+#pauli_strip Steane7.logicalY
+
+#pauli_strip (Steane7.X1 * Steane7.Z1)
+
+#pauli_strip (⟨3,
+    (((NQubitPauliOperator.identity 7).set 0 PauliOperator.X).set 2 PauliOperator.X).set 3
+      PauliOperator.X |>.set 6 PauliOperator.X⟩ : NQubitPauliGroupElement 7)
+
+/-! ## Propositions: commutation views -/
+
+-- Logical X and logical Z overlap on all 7 qubits: odd, so they anticommute.
+#pauli_strip (NQubitPauliGroupElement.Anticommute Steane7.logicalX Steane7.logicalZ)
+
+-- A commutation goal in equality form: the sides agree qubit-wise and in
+-- phase (4 anticommuting positions — even), so the equality holds.
+#pauli_strip (Steane7.logicalX * Steane7.Z1 = Steane7.Z1 * Steane7.logicalX)
+
+-- Anticommutation seen as a phase gap: the two products carry the same
+-- operator part and differ only in the leading glyph (+i vs −i).
+#pauli_strip (Steane7.logicalX * Steane7.logicalZ = Steane7.logicalZ * Steane7.logicalX)
+
+/-! ## Check matrices -/
+
+-- The full Steane generator list: (H | H) blocks, all-zero Gram matrix.
+#check_matrix Steane7.generatorsList
+
+-- A non-commuting list for contrast: the Gram matrix flags the logical pair.
+#check_matrix [Steane7.logicalX, Steane7.logicalZ, Steane7.Z1]
+
+/-! ## Toric lattice views -/
+
+section Toric
+
+open Quantum.Stabilizer.Lattice
+
+/-- A vertical non-contractible loop on the 4 × 4 torus: the `v`-edges of
+column `x = 1`. Its class generates one factor of `H₁`. -/
+def zLoop : C1 4 := fun e =>
+  match e with
+  | .h _ _ => 0
+  | .v x _ => if x = 1 then 1 else 0
+
+/-- A horizontal *dual* loop: the `v`-edges of row `y = 2` — the support an
+X-type dual cycle crosses. It shares exactly one edge with `zLoop`, namely
+`v (1, 2)`. -/
+def xLoop : C1 4 := fun e =>
+  match e with
+  | .h _ _ => 0
+  | .v _ y => if y = 2 then 1 else 0
+
+-- A bare 1-chain (neutral purple), and the same chain as a Z operator.
+#toric_chain zLoop
+
+#toric_chain (toricZOperatorOfChain 4 zLoop)
+
+-- The same object through the Pauli-strip widget: qubit indices are
+-- `edgeToQubitIdx`, so the lattice and the strip are two views of one thing.
+#pauli_strip (toricZOperatorOfChain 4 zLoop)
+
+-- The two loops cross at exactly one edge (v (1,2)), so the operators
+-- anticommute — homological intersection parity, visible as one ringed cell.
+#pauli_strip (NQubitPauliGroupElement.Anticommute
+  (toricZOperatorOfChain 4 zLoop) (toricXOperatorOfChain 4 xLoop))
+
+end Toric
+
+/-! ## In-proof panels
+
+With `GoalTypePanel`, a goal of one of the recognized proposition shapes is
+rendered directly above the tactic state. With `SelectionPanel`, shift-click
+any Pauli subexpression in the goal to render it. Put the cursor inside the
+proofs below to try both.
+
+The `decide` calls need `Decidable` instances at the group-element level.
+Same pattern as `FiveQubit_5_1_3.lean`: these stay `local instance` because
+adding them to the global pool once disrupted unrelated typeclass synthesis —
+see the note in `PauliGroup/Commutation.lean`.
+-/
+
+/-- `DecidableEq` on `NQubitPauliGroupElement n` via field-wise decision.
+Demo-local; see the section comment above. -/
+local instance instDecidableEqNQubitPauliGroupElement (n : ℕ) :
+    DecidableEq (NQubitPauliGroupElement n) := fun p q =>
+  decidable_of_iff (p.phasePower = q.phasePower ∧ p.operators = q.operators)
+    ⟨fun ⟨h1, h2⟩ => by cases p; cases q; simp_all,
+     fun h => by cases h; exact ⟨rfl, rfl⟩⟩
+
+/-- `Decidable (Anticommute p q)` via the local `DecidableEq`; `noncomputable`
+because `*` on `NQubitPauliGroupElement` is noncomputable, but `decide` still
+reduces through the kernel (`native_decide` does not work — prefer `decide`). -/
+noncomputable local instance decidableAnticommute (p q : NQubitPauliGroupElement 7) :
+    Decidable (NQubitPauliGroupElement.Anticommute p q) :=
+  show Decidable (p * q = NQubitPauliGroupElement.minusOne 7 * (q * p)) from inferInstance
+
+-- `pauli_strip?` renders the goal as a strip view with a parity verdict;
+-- since the verdict says the goal holds, the panel offers a link that
+-- replaces the `pauli_strip?` call with `decide` (the trailing `decide`
+-- keeps this demo compiling meanwhile).
+example : NQubitPauliGroupElement.Anticommute Steane7.logicalX Steane7.logicalZ := by
+  pauli_strip?
+  decide
+
+example : NQubitPauliGroupElement.Anticommute Steane7.logicalX Steane7.logicalZ := by
+  with_panel_widgets [GoalTypePanel]
+    decide
+
+example : Steane7.X1 * Steane7.Z2 = Steane7.Z2 * Steane7.X1 := by
+  with_panel_widgets [SelectionPanel]
+    decide
+
+end QECWidgets.Demo

--- a/QECWidgets/PauliEval.lean
+++ b/QECWidgets/PauliEval.lean
@@ -1,0 +1,183 @@
+/-
+Copyright (c) 2026 Stavan Jain. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Stavan Jain
+-/
+import QEC.Stabilizer.Foundations.PauliGroup
+
+/-!
+# Meta-level evaluation of Pauli expressions
+
+Support layer for the QEC infoview widgets: turns an `Expr` denoting a
+*concrete* Pauli object (a generator of a specific code, a product of such
+generators, a commutation proposition between them, …) into plain meta-level
+data (`PauliView`) that the renderers in `QECWidgets.PauliStrip` can draw.
+
+Everything here is display-only meta code. Nothing is trusted: the widgets
+show what weak-head reduction finds, and any proof the user writes is still
+checked by the kernel as usual.
+
+The reduction strategy matters. `Mul` on `NQubitPauliGroupElement` is
+`noncomputable`, so `#eval`-style compilation is unavailable, but the terms
+still *reduce* — the same fact that lets `decide` close `Anticommute` goals
+through the kernel. We therefore evaluate by weak-head normalization,
+escalating through transparency levels and finishing with the kernel
+evaluator (which ignores `@[irreducible]` markers, i.e. sees exactly what
+`decide` sees).
+-/
+
+namespace QECWidgets
+
+open Lean Meta Quantum
+
+/-- The weak-head normal forms of `e` to try when looking for a constructor
+head: default transparency first (cheap), then `.all`, and finally the kernel
+evaluator. Failures are dropped rather than propagated — callers just match
+against whichever candidates exist. -/
+def whnfCandidates (e : Expr) : MetaM (List Expr) := do
+  let mut out : List Expr := []
+  try out := out.concat (← whnf e) catch _ => pure ()
+  try out := out.concat (← withTransparency .all (whnf e)) catch _ => pure ()
+  try
+    match Kernel.whnf (← getEnv) (← getLCtx) e with
+    | .ok e' => out := out.concat e'
+    | .error _ => pure ()
+  catch _ => pure ()
+  return out
+
+/-- Extract a `Nat` literal from `e`, reducing and unwrapping `OfNat.ofNat`
+as needed. -/
+partial def natOfExpr? (e : Expr) : MetaM (Option Nat) := do
+  if let some k := e.rawNatLit? then return some k
+  for e' in ← whnfCandidates e do
+    if let some k := e'.rawNatLit? then return some k
+    if e'.isAppOfArity ``OfNat.ofNat 3 then
+      if let some k ← natOfExpr? (e'.getArg! 1) then return some k
+  return none
+
+/-- Extract the value of a `Fin`-like literal (this covers `ZMod (k+1)`,
+which reduces to `Fin (k+1)`): reduce to `Fin.mk v _` and read off `v`. -/
+def finValOfExpr? (e : Expr) : MetaM (Option Nat) := do
+  for e' in ← whnfCandidates e do
+    if e'.isAppOfArity ``Fin.mk 3 then
+      return ← natOfExpr? (e'.getArg! 1)
+  return none
+
+/-- Reduce `e` to a `PauliOperator` constructor, if possible. -/
+def pauliOfExpr? (e : Expr) : MetaM (Option PauliOperator) := do
+  for e' in ← whnfCandidates e do
+    if let some n := e'.constName? then
+      if n == ``Quantum.PauliOperator.I then return some .I
+      if n == ``Quantum.PauliOperator.X then return some .X
+      if n == ``Quantum.PauliOperator.Y then return some .Y
+      if n == ``Quantum.PauliOperator.Z then return some .Z
+  return none
+
+/-- Build the literal `(⟨i, _⟩ : Fin n)`; the bound proof is produced by
+`decide`, so this only works for `i < n` (which is all we ever ask for). -/
+def mkFinLit (n i : Nat) : MetaM Expr := do
+  let prf ← mkDecideProof (← mkAppM ``LT.lt #[mkNatLit i, mkNatLit n])
+  mkAppOptM ``Fin.mk #[some (mkNatLit n), some (mkNatLit i), some prf]
+
+/-- The result of evaluating a Pauli expression: an optional phase exponent
+(`i^k`; `none` for bare operators or when the phase is stuck) and the
+per-qubit factors (`none` where reduction got stuck, e.g. at a variable). -/
+structure PauliView where
+  /-- Number of qubits. -/
+  numQubits : Nat
+  /-- Phase exponent `k` in `i^k`, when the expression is a group element
+  whose phase reduced to a literal. -/
+  phasePower : Option Nat := none
+  /-- Per-qubit single-qubit factors; `none` where reduction got stuck. -/
+  ops : Array (Option PauliOperator)
+deriving Inhabited
+
+/-- Number of resolved non-identity cells. -/
+def PauliView.weight (v : PauliView) : Nat :=
+  v.ops.foldl (fun acc o => if o.isSome && o != some .I then acc + 1 else acc) 0
+
+/-- Number of cells where reduction got stuck. -/
+def PauliView.numStuck (v : PauliView) : Nat :=
+  v.ops.foldl (fun acc o => if o.isNone then acc + 1 else acc) 0
+
+/-- Evaluate an `NQubitPauliOperator n` expression pointwise at every qubit. -/
+def operatorView (ops : Expr) (n : Nat) : MetaM PauliView := do
+  let mut cells : Array (Option PauliOperator) := #[]
+  for i in [0:n] do
+    cells := cells.push (← pauliOfExpr? (mkApp ops (← mkFinLit n i)))
+  return { numQubits := n, ops := cells }
+
+/-- Evaluate an `NQubitPauliGroupElement n` expression: phase exponent plus
+pointwise operators. -/
+def elementView (e : Expr) (n : Nat) : MetaM PauliView := do
+  let ph ← finValOfExpr? (← mkAppM ``Quantum.NQubitPauliGroupElement.phasePower #[e])
+  let v ← operatorView (← mkAppM ``Quantum.NQubitPauliGroupElement.operators #[e]) n
+  return { v with phasePower := ph }
+
+/-- The kinds of Pauli-valued terms the widgets understand. -/
+inductive PauliTermKind where
+  /-- `e : NQubitPauliGroupElement n` (phase and operators). -/
+  | element (n : Nat)
+  /-- `e : NQubitPauliOperator n`, or literally `Fin n → PauliOperator`. -/
+  | operator (n : Nat)
+
+/-- The number of qubits of a term kind. -/
+def PauliTermKind.numQubits : PauliTermKind → Nat
+  | .element n => n
+  | .operator n => n
+
+/-- Classify a *term* by its type: group element or bare operator, with a
+literal qubit count. -/
+def pauliTermKind? (e : Expr) : MetaM (Option PauliTermKind) := do
+  let t ← instantiateMVars (← inferType e)
+  if t.isAppOfArity ``Quantum.NQubitPauliGroupElement 1 then
+    if let some n ← natOfExpr? (t.getArg! 0) then
+      return some (.element n)
+  if t.isAppOfArity ``Quantum.NQubitPauliOperator 1 then
+    if let some n ← natOfExpr? (t.getArg! 0) then
+      return some (.operator n)
+  if let .forallE _ dom body _ := t then
+    if !body.hasLooseBVars && body.isConstOf ``Quantum.PauliOperator
+        && dom.isAppOfArity ``Fin 1 then
+      if let some n ← natOfExpr? (dom.getArg! 0) then
+        return some (.operator n)
+  return none
+
+/-- Evaluate a term of the given kind to a `PauliView`. -/
+def viewOfTerm (k : PauliTermKind) (e : Expr) : MetaM PauliView :=
+  match k with
+  | .element n => elementView e n
+  | .operator n => operatorView e n
+
+/-- The shapes of expressions the Pauli strip widgets can present: Pauli
+terms, `Anticommute p q` propositions, and equalities between Pauli terms
+(the form commutation goals take). -/
+inductive PauliShape where
+  /-- A Pauli-valued term. -/
+  | term (k : PauliTermKind) (e : Expr)
+  /-- The proposition `NQubitPauliGroupElement.Anticommute p q`. -/
+  | anticommute (n : Nat) (p q : Expr)
+  /-- The proposition `lhs = rhs` between Pauli terms of kind `k`. -/
+  | eq (k : PauliTermKind) (lhs rhs : Expr)
+
+/-- Classify an expression for presentation. Propositions are matched on the
+expression itself (this is what a goal or a selected goal location gives us);
+anything else is classified by its type. -/
+def pauliShape? (e : Expr) : MetaM (Option PauliShape) := do
+  if e.isAppOfArity ``Quantum.NQubitPauliGroupElement.Anticommute 3 then
+    if let some n ← natOfExpr? (e.getArg! 0) then
+      return some (.anticommute n (e.getArg! 1) (e.getArg! 2))
+  if e.isAppOfArity ``Eq 3 then
+    if let some k ← pauliTermKind? (e.getArg! 1) then
+      return some (.eq k (e.getArg! 1) (e.getArg! 2))
+  if let some k ← pauliTermKind? e then
+    return some (.term k e)
+  return none
+
+/-- Do two single-qubit Paulis anticommute? (Both non-identity and distinct.) -/
+def anticommutesBool : PauliOperator → PauliOperator → Bool
+  | .I, _ => false
+  | _, .I => false
+  | a, b => a != b
+
+end QECWidgets

--- a/QECWidgets/PauliGoalPanel.lean
+++ b/QECWidgets/PauliGoalPanel.lean
@@ -1,0 +1,126 @@
+/-
+Copyright (c) 2026 Stavan Jain. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Stavan Jain
+-/
+import QECWidgets.PauliStrip
+import ProofWidgets.Component.OfRpcMethod
+import ProofWidgets.Component.MakeEditLink
+
+/-!
+# `pauli_strip?` — the goal as a strip view, with a `decide` suggestion
+
+A suggestion tactic in the `rw??` style: writing `pauli_strip?` in a proof
+renders the current goal's Pauli strip view in the infoview, and — when the
+widget's own parity computation says the goal holds — offers a link that
+replaces the `pauli_strip?` call with `decide`.
+
+The panel is a server-rendered component (`mk_rpc_widget%`): the RPC method
+receives the goals plus the range to replace, so the edit is built against
+the live document (`MakeEditLinkProps.ofReplaceRange` needs the current
+`DocumentMeta`, which only exists server-side).
+-/
+
+namespace QECWidgets
+
+open Lean Server Meta ProofWidgets Quantum
+
+/-- Whether a recognized concrete Pauli proposition holds, by the same
+computation the verdicts use (anticommutation parity / pointwise comparison):
+`some true` exactly when `decide` should close it, `none` when the
+proposition is not recognized or did not fully reduce. -/
+def pauliGoalHolds? (e : Expr) : MetaM (Option Bool) := do
+  let count (marks : Array Bool) : Nat :=
+    marks.foldl (fun acc b => if b then acc + 1 else acc) 0
+  match ← pauliShape? e with
+  | some (.anticommute n p q) =>
+    if n > maxStripQubits then return none
+    let vp ← elementView p n
+    let vq ← elementView q n
+    if vp.numStuck + vq.numStuck > 0 then return none
+    return some (count (marksAnticommute vp vq) % 2 == 1)
+  | some (.eq k lhs rhs) =>
+    if k.numQubits > maxStripQubits then return none
+    let vl ← viewOfTerm k lhs
+    let vr ← viewOfTerm k rhs
+    if vl.numStuck + vr.numStuck > 0 then return none
+    if count (marksDiffer vl vr) > 0 then return some false
+    match k with
+    | .operator _ => return some true
+    | .element _ =>
+      match vl.phasePower, vr.phasePower with
+      | some a, some b => return some (a == b)
+      | _, _ => return none
+  | _ => return none
+
+/-- Props for `PauliSuggestionPanel`: the panel props the infoview injects,
+plus the source range the suggestion link replaces (the `pauli_strip?` call
+itself, recorded when the tactic runs). -/
+structure PauliSuggestionProps where
+  /-- Cursor position in the file. -/
+  pos : Lsp.Position
+  /-- Current tactic-mode goals. -/
+  goals : Array Widget.InteractiveGoal
+  /-- The source range the suggestion link replaces. -/
+  replaceRange : Lsp.Range
+  deriving RpcEncodable
+
+/-- Render the main goal as a Pauli card; when it holds, append the
+`decide` suggestion link. -/
+private def suggestionBody (docMeta : DocumentMeta) (range : Lsp.Range)
+    (goals : Array Widget.InteractiveGoal) : RequestM Html := do
+  let some g := goals[0]?
+    | return .text "No goals."
+  g.ctx.val.runMetaM {} do
+    let md ← g.mvarId.getDecl
+    Meta.withLCtx md.lctx md.localInstances do
+      let ty ← instantiateMVars md.type.consumeMData
+      match ← pauliRender? ty with
+      | none => return .text "The goal is not a recognized concrete Pauli proposition."
+      | some (html, _) =>
+        match ← pauliGoalHolds? ty with
+        | some true =>
+          let link := Html.ofComponent MakeEditLink
+            (.ofReplaceRange docMeta range "decide") #[.text "replace with decide"]
+          return el "div" #[] #[html,
+            cls "div" "qecw-verdict" #[("style", json% { color: $(okColor) })] #[link]]
+        | _ => return html
+
+open RequestM in
+/-- RPC backing `PauliSuggestionPanel`. -/
+@[server_rpc_method]
+def PauliSuggestionPanel.rpc (props : PauliSuggestionProps) : RequestM (RequestTask Html) :=
+  RequestM.asTask do
+    let doc ← RequestM.readDoc
+    let inner ← suggestionBody doc.meta props.replaceRange props.goals
+    return el "details" #[("open", Json.bool true)]
+      #[el "summary" #[("className", Json.str "mv2 pointer")] #[.text "Pauli strip"], inner]
+
+/-- The `pauli_strip?` panel: the goal as a strip view plus, when the parity
+verdict says the goal holds, a link that inserts `decide`. -/
+@[widget_module]
+def PauliSuggestionPanel : Component PauliSuggestionProps :=
+  mk_rpc_widget% PauliSuggestionPanel.rpc
+
+/-- `pauli_strip?` renders the current goal's Pauli strip view in the
+infoview (put the cursor on the tactic). When the widget's parity
+computation says the goal holds, the panel offers a link that replaces this
+tactic call with `decide`. The goal is left untouched until then. -/
+syntax (name := pauliStripTac) "pauli_strip?" : tactic
+
+open Elab Tactic in
+@[tactic pauliStripTac]
+def elabPauliStripTac : Tactic := fun stx => do
+  let some range := (← getFileMap).lspRangeOfStx? stx
+    | throwError "pauli_strip?: could not find the source range of the tactic call"
+  Widget.savePanelWidgetInfo (hash PauliSuggestionPanel.javascript)
+    (pure <| json% { replaceRange : $(toJson range) }) stx
+
+-- Like every suggestion widget, `pauli_strip?` intentionally leaves the goal
+-- unchanged, so register it with the unused-tactic linter's dynamic
+-- allowlist. This runs on import, covering every file that can use the
+-- tactic; the `#allow_unused_tactic!` command is avoided because a silent
+-- `#`-command would itself be flagged by `linter.hashCommand`.
+initialize Mathlib.Linter.UnusedTactic.allowedRef.modify (·.insert ``QECWidgets.pauliStripTac)
+
+end QECWidgets

--- a/QECWidgets/PauliStrip.lean
+++ b/QECWidgets/PauliStrip.lean
@@ -1,0 +1,324 @@
+/-
+Copyright (c) 2026 Stavan Jain. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Stavan Jain
+-/
+import QECWidgets.PauliEval
+import QECWidgets.Style
+import ProofWidgets.Component.HtmlDisplay
+import ProofWidgets.Presentation.Expr
+
+/-!
+# Pauli support strips for the infoview
+
+Renders concrete Pauli objects as colored per-qubit strips:
+
+- `#pauli_strip e` — display `e` below the command, where `e` is an
+  `NQubitPauliGroupElement n`, an `NQubitPauliOperator n`, an
+  `Anticommute p q` proposition, or an equality between Pauli terms
+  (commutation goals). For the proposition shapes the widget shows both
+  operands aligned, rings the qubit positions where the single-qubit factors
+  anticommute (resp. differ), and states the parity verdict — the visual form
+  of `commutes_iff_even_anticommutes`.
+- The `Pauli strip` expression presenter: shift-click any such expression in
+  the goal panel with `ProofWidgets.SelectionPanel` open (or put
+  `ProofWidgets.GoalTypePanel` on a goal of one of the proposition shapes)
+  to see the same rendering during a proof.
+
+Card names are interactive (`exprName`): hover for types, click to jump to
+the definition. Look and feel comes from `QECWidgets.Style`.
+-/
+
+namespace QECWidgets
+
+open Lean Server Meta ProofWidgets Quantum
+
+/-- Display letter for a (possibly unresolved) single-qubit factor. -/
+def opLetter : Option PauliOperator → String
+  | some .I => "·"
+  | some .X => "X"
+  | some .Y => "Y"
+  | some .Z => "Z"
+  | none => "?"
+
+/-- Long name used in cell tooltips. -/
+def opName : Option PauliOperator → String
+  | some .I => "I"
+  | some .X => "X"
+  | some .Y => "Y"
+  | some .Z => "Z"
+  | none => "unresolved"
+
+/-- Cell class per factor (colors and hover states live in the stylesheet). -/
+def opClass : Option PauliOperator → String
+  | some .I => "qecw-i"
+  | some .X => "qecw-x"
+  | some .Y => "qecw-y"
+  | some .Z => "qecw-z"
+  | none => "qecw-stuck"
+
+/-- One qubit cell: the factor letter, a hover tooltip naming the qubit, and
+(when `marked`) a purple ring flagging the position. -/
+def cellHtml (idx : Nat) (marked : Bool) (o : Option PauliOperator) : Html :=
+  cls "span" (s!"qecw-cell {opClass o}" ++ if marked then " qecw-mark" else "")
+    #[("title", Json.str s!"qubit {idx}: {opName o}")]
+    #[.text (opLetter o)]
+
+/-- Cells per display row; longer strips wrap into indexed rows. -/
+def stripRowSize : Nat := 32
+
+/-- Muted label showing the first qubit index of a row. Only rendered when a
+strip wraps into several rows — on a single-row strip it would be a lone `0`. -/
+private def rowLabel (start : Nat) : Html :=
+  cls "span" "qecw-rowlabel" #[] #[.text (toString start)]
+
+/-- Leading phase glyph for a strip: `none` for `+1` (not drawn, as in
+handwritten notation), `i` / `−` / `−i` otherwise, `?` when the phase did not
+reduce. -/
+def phaseGlyph : Option Nat → Option String
+  | some 0 => none
+  | some 1 => some "i"
+  | some 2 => some "−"
+  | some 3 => some "−i"
+  | some k => some s!"i^{k}"
+  | none => some "?"
+
+/-- A phase glyph rendered as a fixed-width leading cell (fixed width so two
+strips shown together stay column-aligned even when only one has a glyph). -/
+def phaseGlyphHtml (g : String) : Html :=
+  cls "span" "qecw-glyph" #[("title", Json.str "global phase")] #[.text g]
+
+/-- The strip proper: rows of qubit cells. Row index labels appear only when
+the strip wraps; `marks` (when nonempty) rings the flagged positions;
+`leading` (when present) is drawn before the first row's cells. -/
+def stripHtml (v : PauliView) (marks : Array Bool := #[])
+    (leading : Option Html := none) : Html := Id.run do
+  let numRows := (v.numQubits + stripRowSize - 1) / stripRowSize
+  let mut rows : Array Html := #[]
+  for r in [0:numRows] do
+    let start := r * stripRowSize
+    let stop := min (start + stripRowSize) v.numQubits
+    let mut cells : Array Html := #[]
+    if numRows > 1 then
+      cells := cells.push (rowLabel start)
+    if r == 0 then
+      if let some g := leading then
+        cells := cells.push g
+    for j in [start:stop] do
+      cells := cells.push (cellHtml j (marks.getD j false) (v.ops.getD j none))
+    rows := rows.push (cls "div" "qecw-strip" #[] cells)
+  return el "div" #[] rows
+
+/-- Pretty-print the phase exponent as `+1`, `+i`, `−1`, `−i`. -/
+def phaseStr : Option Nat → String
+  | some 0 => "+1"
+  | some 1 => "+i"
+  | some 2 => "−1"
+  | some 3 => "−i"
+  | some k => s!"i^{k}"
+  | none => "?"
+
+/-- Standard header facts for a view: weight, phase (only when the strip
+wraps and cannot carry the leading glyph), unresolved count. -/
+private def viewFacts (v : PauliView) (showPhase : Bool) : Array Html := Id.run do
+  let mut fs : Array Html := #[headerFact s!"wt {v.weight}" "number of non-identity qubits"]
+  if showPhase && v.numQubits > stripRowSize then
+    fs := fs.push (headerFact (phaseStr v.phasePower) "global phase")
+  if v.numStuck > 0 then
+    fs := fs.push (headerFact s!"? {v.numStuck}" "cells that did not reduce" (some warnColor))
+  return fs
+
+/-- Single-term view: header plus strip. The phase is drawn as a leading
+glyph on single-row strips, and as a header fact on wrapped ones (a glyph
+would misalign the first row there). -/
+def stripCard (name : Html) (v : PauliView) (showPhase : Bool) : Html :=
+  let leading :=
+    if showPhase && v.numQubits ≤ stripRowSize then (phaseGlyph v.phasePower).map phaseGlyphHtml
+    else none
+  card #[headerHtml name (viewFacts v showPhase), stripHtml v #[] leading]
+
+/-- Compact text form of a strip: one letter per qubit (`·` for identity,
+`?` for unresolved), with a space every 8 qubits. -/
+def PauliView.letters (v : PauliView) : String := Id.run do
+  let mut s := ""
+  for i in [0:v.numQubits] do
+    if i > 0 && i % 8 == 0 then s := s.push ' '
+    s := s ++ opLetter (v.ops.getD i none)
+  return s
+
+/-- Plain-text summary of a single term view (logged by `#pauli_strip`). -/
+def termSummary (v : PauliView) (showPhase : Bool) : String :=
+  let ph := if showPhase then s!", phase {phaseStr v.phasePower}" else ""
+  let stuck := if v.numStuck > 0 then s!", {v.numStuck} unresolved" else ""
+  s!"{v.letters}   (n = {v.numQubits}, weight {v.weight}{ph}{stuck})"
+
+/-- Ring marks for the positions where the two sides' factors anticommute. -/
+def marksAnticommute (vp vq : PauliView) : Array Bool :=
+  (Array.range (max vp.numQubits vq.numQubits)).map fun i =>
+    match vp.ops.getD i none, vq.ops.getD i none with
+    | some a, some b => anticommutesBool a b
+    | _, _ => false
+
+/-- Ring marks for the positions where the two sides' factors differ. -/
+def marksDiffer (vp vq : PauliView) : Array Bool :=
+  (Array.range (max vp.numQubits vq.numQubits)).map fun i =>
+    match vp.ops.getD i none, vq.ops.getD i none with
+    | some a, some b => a != b
+    | _, _ => false
+
+/-- Count of `true` marks. -/
+private def countMarks (marks : Array Bool) : Nat :=
+  marks.foldl (fun acc b => if b then acc + 1 else acc) 0
+
+/-- Two aligned strips with shared marks and a verdict line; `accent` colors
+the card's state bar. Phase glyphs are drawn on both strips whenever either
+side has one, so the columns stay aligned; wrapped strips carry the phase in
+their header facts instead. -/
+def dualCard (nameP nameQ : Html) (vp vq : PauliView) (marks : Array Bool)
+    (verdict : Html) (showPhase : Bool) (accent : Option String := none) : Html :=
+  let glyphs : Option Html × Option Html :=
+    if showPhase && vp.numQubits ≤ stripRowSize then
+      match phaseGlyph vp.phasePower, phaseGlyph vq.phasePower with
+      | none, none => (none, none)
+      | gp, gq => (some (phaseGlyphHtml (gp.getD "")), some (phaseGlyphHtml (gq.getD "")))
+    else (none, none)
+  card (accent := accent) #[
+    headerHtml nameP (viewFacts vp showPhase),
+    stripHtml vp marks glyphs.1,
+    styled "div" (json% { height: "6px" }) #[],
+    headerHtml nameQ (viewFacts vq showPhase),
+    stripHtml vq marks glyphs.2,
+    verdict]
+
+/-- `"3 crossings"` / `"1 crossing"` — singular/plural helper for verdicts. -/
+private def countNoun (c : Nat) (single : String) (plural : String) : String :=
+  s!"{c} {if c == 1 then single else plural}"
+
+/-- Verdict for an `Anticommute p q` proposition, as (color, short, long):
+parity of the number of anticommuting positions, as in
+`commutes_iff_even_anticommutes`. The short form goes on the card, the long
+form into its tooltip and the logged text. -/
+def anticommuteVerdictData (vp vq : PauliView) (marks : Array Bool) :
+    String × String × String :=
+  let c := countMarks marks
+  let stuck := vp.numStuck + vq.numStuck
+  if stuck > 0 then
+    (warnColor, s!"? {countNoun stuck "cell" "cells"} unresolved",
+      s!"{countNoun c "anticommuting position" "anticommuting positions"} among resolved \
+        cells, but {countNoun stuck "cell" "cells"} did not reduce — parity undetermined.")
+  else if c % 2 == 1 then
+    (okColor, s!"✓ anticommute — {countNoun c "crossing" "crossings"} (odd)",
+      s!"{countNoun c "anticommuting qubit position" "anticommuting qubit positions"} — odd, \
+        so the operators anticommute: this Anticommute goal holds (decide closes it).")
+  else
+    (badColor, s!"✗ commute — {countNoun c "crossing" "crossings"} (even)",
+      s!"{countNoun c "anticommuting qubit position" "anticommuting qubit positions"} — even, \
+        so the operators commute: this Anticommute goal is false.")
+
+/-- Verdict for an equality between Pauli terms, as (color, short, long):
+pointwise comparison plus (for group elements) the phase difference. -/
+def eqVerdictData (isElement : Bool) (vp vq : PauliView) (marks : Array Bool) :
+    String × String × String :=
+  let c := countMarks marks
+  let stuck := vp.numStuck + vq.numStuck
+  if stuck > 0 then
+    (warnColor, s!"? {countNoun stuck "cell" "cells"} unresolved",
+      s!"{countNoun c "differing position" "differing positions"} among resolved cells, but \
+        {countNoun stuck "cell" "cells"} did not reduce — comparison incomplete.")
+  else if c > 0 then
+    (badColor, s!"✗ differ at {countNoun c "qubit" "qubits"}",
+      s!"the sides differ at {countNoun c "qubit position" "qubit positions"} — not equal.")
+  else if !isElement then
+    (okColor, "✓ equal", "the sides agree at every qubit — the operators are equal.")
+  else
+    match vp.phasePower, vq.phasePower with
+    | some a, some b =>
+      if a == b then
+        (okColor, "✓ equal",
+          "the sides agree at every qubit and carry the same phase — the elements are equal.")
+      else
+        (badColor, s!"✗ phases differ — {phaseStr (some a)} vs {phaseStr (some b)}",
+          s!"operator parts agree, but the phases differ ({phaseStr (some a)} vs \
+            {phaseStr (some b)}) — not equal. (For p * q = q * p goals this phase gap is \
+            exactly anticommutation.)")
+    | _, _ =>
+      (warnColor, "? phase unresolved",
+        "the operator parts agree, but a phase did not reduce — comparison incomplete.")
+
+/-- Strips wider than this are refused (each cell costs a reduction). -/
+def maxStripQubits : Nat := 512
+
+/-- Render any recognized Pauli shape (term, `Anticommute`, or equality) as
+HTML plus a plain-text summary (logged by `#pauli_strip` so terminals see
+something too), or `none` when `e` is not one / is not concrete enough. -/
+def pauliRender? (e : Expr) : MetaM (Option (Html × String)) := do
+  let e ← instantiateMVars e
+  match ← pauliShape? e with
+  | none => return none
+  | some (.term k te) =>
+    if k.numQubits > maxStripQubits then return none
+    let showPhase := match k with | .element _ => true | .operator _ => false
+    let v ← viewOfTerm k te
+    return some (stripCard (← exprName te) v showPhase, termSummary v showPhase)
+  | some (.anticommute n p q) =>
+    if n > maxStripQubits then return none
+    let vp ← elementView p n
+    let vq ← elementView q n
+    let marks := marksAnticommute vp vq
+    let (color, short, long) := anticommuteVerdictData vp vq marks
+    let html := dualCard (← exprName p) (← exprName q) vp vq marks
+      (verdictLine color short long) true (accent := some color)
+    return some (html, s!"p = {vp.letters}\nq = {vq.letters}\n{long}")
+  | some (.eq k lhs rhs) =>
+    if k.numQubits > maxStripQubits then return none
+    let vl ← viewOfTerm k lhs
+    let vr ← viewOfTerm k rhs
+    let marks := marksDiffer vl vr
+    let isElement := match k with | .element _ => true | .operator _ => false
+    let (color, short, long) := eqVerdictData isElement vl vr marks
+    let html := dualCard (← exprName lhs) (← exprName rhs) vl vr marks
+      (verdictLine color short long) isElement (accent := some color)
+    return some (html, s!"lhs = {vl.letters}\nrhs = {vr.letters}\n{long}")
+
+/-- Presenter entry point: render or fail (failure = "not applicable"). -/
+def pauliPresent (e : Expr) : MetaM Html := do
+  match ← pauliRender? e with
+  | some (h, _) => return h
+  | none => throwError "not a concrete Pauli expression"
+
+/-- Infoview presenter for Pauli terms and commutation propositions. With
+`ProofWidgets.SelectionPanel` open, shift-click a Pauli expression in the
+goal to render it; `ProofWidgets.GoalTypePanel` renders goals of the
+proposition shapes directly. -/
+@[expr_presenter]
+def pauliStripPresenter : ExprPresenter where
+  userName := "Pauli strip"
+  layoutKind := .block
+  present := pauliPresent
+
+/-- `#pauli_strip e` displays a colored per-qubit strip for a concrete Pauli
+expression in the infoview. `e` may be an `NQubitPauliGroupElement n`, an
+`NQubitPauliOperator n`, an `Anticommute p q` proposition, or an equality
+between Pauli terms; the proposition forms render both operands with the
+anticommuting (resp. differing) positions ringed and a parity verdict. -/
+syntax (name := pauliStripCmd) "#pauli_strip " term : command
+
+open Elab Command in
+@[command_elab pauliStripCmd]
+def elabPauliStripCmd : CommandElab
+  | stx@`(#pauli_strip $t:term) => do
+    let (ht, txt) ← liftTermElabM do
+      let e ← Term.elabTerm t none
+      Term.synthesizeSyntheticMVarsNoPostponing
+      match ← pauliRender? (← instantiateMVars e) with
+      | some r => pure r
+      | none => throwError
+          "#pauli_strip: not a recognized concrete Pauli expression. Expected an \
+          NQubitPauliGroupElement n or NQubitPauliOperator n with a literal qubit count, an \
+          Anticommute proposition, or an equality between Pauli terms."
+    logInfoAt stx txt
+    liftCoreM <| Widget.savePanelWidgetInfo (hash HtmlDisplayPanel.javascript)
+      (return json% { html : $(← rpcEncode ht) }) stx
+  | stx => throwError "Unexpected syntax {stx}."
+
+end QECWidgets

--- a/QECWidgets/README.md
+++ b/QECWidgets/README.md
@@ -1,0 +1,96 @@
+# QECWidgets — infoview widgets (read me before editing)
+
+ProofWidgets-based visualizations for working with the library in an editor.
+Everything here is **untrusted display-layer meta code**: the widgets show
+what weak-head reduction finds, proofs are still checked by the kernel as
+usual, and nothing in `QEC/` imports this library. `QECWidgets` is a separate
+`lean_lib` (same policy as `QECBlueprint`) so that only it depends on
+ProofWidgets — which is already in the dependency tree via mathlib, so there
+is no new `require` and no manifest change.
+
+## The widgets
+
+| Widget | Command | Recognizes | Shows |
+|---|---|---|---|
+| Pauli strip | `#pauli_strip e` | `NQubitPauliGroupElement n`, `NQubitPauliOperator n` (literal `n`) | colored per-qubit strip, phase, weight |
+| Commutation views | `#pauli_strip e` | `Anticommute p q`, equalities between Pauli terms | both operands aligned, anticommuting/differing qubits ringed, parity verdict (`commutes_iff_even_anticommutes` as a picture) |
+| Goal suggestion | `pauli_strip?` (tactic) | goals of the two proposition shapes | the goal's strip view; a "replace with decide" link when the verdict says it holds |
+| Toric lattice | `#toric_chain e` | `C1 L` terms, `toric{X,Z}OperatorOfChain L c` (literal `L`) | the chain on the `L × L` torus; wrap edges as dashed stubs; X coral / Z blue |
+| Check matrix | `#check_matrix e` | `List (NQubitPauliGroupElement n)` | `(X ∣ Z)` symplectic heatmap in the `checkMatrix` column convention, plus the Gram matrix (red = anticommuting pair) |
+
+Four surfaces:
+
+1. **Commands** (above) — put the cursor on the line, the widget renders in
+   the infoview. Each command also logs a plain-text summary, so terminal
+   users (and `lake build` logs) see something too.
+2. **The `pauli_strip?` suggestion tactic** — inside a proof of a recognized
+   proposition, renders the goal's strip view; when the parity verdict says
+   the goal holds, the panel offers a link that replaces the tactic call
+   with `decide` (the `rw??` pattern: a `mk_rpc_widget%` panel plus
+   `MakeEditLink`).
+3. **Expression presenters** — during a proof, add
+   `with_panel_widgets [ProofWidgets.SelectionPanel] <tactics>` and
+   shift-click any recognized expression in the goal; or use
+   `ProofWidgets.GoalTypePanel` on a goal that *is* a recognized proposition.
+4. **Text** — the logged summaries make the widgets usable (and testable)
+   without an editor: `lean_diagnostic_messages` / build logs carry them.
+
+Card headers are live terms (`exprName`, ProofWidgets' `InteractiveCode`):
+hover for types and docs, click to jump to the definition.
+
+The cards are deliberately minimal: a state bar (verdict green/red/amber, or
+the operator's identity color), a dim header (expression + weight), the
+diagram, and a compact verdict. Explanations live in hover tooltips and in
+the logged text summaries — when adding to a widget, put detail there, not on
+the card. Phases render as a leading glyph on the strip (`−`, `i`, `−i`;
+nothing for `+1`), and row index labels appear only on strips that wrap.
+
+All look and feel lives in `Style.lean`: the palette (`Accent` values) and
+the `qecw-*` class stylesheet that every card embeds. Styling is class-based
+on purpose — classes give hover states and transitions (inline styles
+cannot), per-theme tuning (`vscode-dark` / `vscode-light` /
+`vscode-high-contrast` body classes), and small RPC payloads (one class name
+per cell instead of a repeated style object). When adding a widget, use the
+existing classes and tokens; do not hand-roll inline colors. In SVG, never
+put `var(...)` in a presentation attribute (it silently fails to parse) —
+use a `qecw-svg-*` class or an inline `style` attribute instead.
+
+`QECWidgets/Demo.lean` is the living gallery; it is imported by the umbrella,
+so the demos compile in CI and cannot silently rot.
+
+## How evaluation works
+
+`Mul` on `NQubitPauliGroupElement` is `noncomputable`, so `#eval`-style
+compilation is unavailable — but the terms still *reduce*, which is the same
+fact that lets `decide` close `Anticommute` goals through the kernel.
+`PauliEval.whnfCandidates` therefore normalizes in an escalating ladder:
+`whnf` at default transparency, then `.all`, then `Kernel.whnf` (which
+ignores `@[irreducible]`, i.e. sees exactly what `decide` sees). Concrete
+generators, products of them, and `toricZOperatorOfChain`-style wrappers all
+reduce; variables and hypotheses render as `?` cells with an "unresolved"
+chip instead of failing.
+
+Size caps (each cell costs a reduction): strips ≤ 512 qubits
+(`maxStripQubits`), lattices `L ≤ 16` (`maxToricL`), check matrices ≤ 64
+generators (`maxCheckRows`).
+
+## Adding a widget — repo-specific rules learned the hard way
+
+- **Copyright headers are required here.** Files *directly imported by a
+  root-level module* (`QECWidgets.lean`) are exactly the ones
+  mathlib's `linter.style.header` checks, so every content file needs the
+  standard mathlib copyright block. (Files under `QEC/` dodge this only
+  because the root imports them through umbrella files.)
+- **Every `#`-command must log a message.** `linter.hashCommand` flags
+  `#`-commands that emit nothing; the text summaries exist partly for this.
+  Do not suppress the linter — emit useful text instead.
+- **`decide`-style instances stay `local instance` in Demo.lean.** The
+  group-element-level `DecidableEq` / `Decidable Anticommute` instances are
+  deliberately not global — see the note in `PauliGroup/Commutation.lean`
+  and CLAUDE.md § "Global vs. local instance discipline".
+- Reuse `PauliEval` (reduction, `Fin`/`Nat`/ctor extraction) and the
+  `PauliStrip` rendering helpers (`el`, `styled`, `chip`, `card`, colors)
+  rather than duplicating them.
+- New modules must be imported by `QECWidgets.lean` (the umbrella) — it is
+  the build target CI runs (`lake build QECWidgets` in
+  `lean_action_ci.yml`), and the lib stays outside `defaultTargets`.

--- a/QECWidgets/Style.lean
+++ b/QECWidgets/Style.lean
@@ -1,0 +1,185 @@
+/-
+Copyright (c) 2026 Stavan Jain. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Stavan Jain
+-/
+import ProofWidgets.Component.HtmlDisplay
+
+/-!
+# Design tokens and stylesheet for the QEC widgets
+
+The single source of truth for how the widgets look: the palette, the
+`qecw-*` class stylesheet, and the shared card/header building blocks.
+
+Styling is class-based rather than inline. That is what enables hover states
+and transitions (inline styles cannot express `:hover`), per-theme tuning
+(VS Code stamps `vscode-dark` / `vscode-light` / `vscode-high-contrast` on
+the webview body), and small RPC payloads (a 144-qubit strip carries one
+class name per cell instead of a repeated style object).
+
+Every card embeds the stylesheet via `styleTag`; duplicate `<style>` tags in
+one webview are idempotent, so cards stay self-contained.
+-/
+
+namespace QECWidgets
+
+open Lean ProofWidgets
+
+/-- Shorthand for `Html.element`. -/
+def el (tag : String) (attrs : Array (String × Json)) (children : Array Html) : Html :=
+  .element tag attrs children
+
+/-- An element carrying only a `style` attribute. -/
+def styled (tag : String) (style : Json) (children : Array Html) : Html :=
+  el tag #[("style", style)] children
+
+/-- An element carrying (at least) a class. React wants `className`. -/
+def cls (tag : String) (className : String) (attrs : Array (String × Json) := #[])
+    (children : Array Html := #[]) : Html :=
+  el tag (#[("className", Json.str className)] ++ attrs) children
+
+/-- An accent color: hex for strokes/text, `"r, g, b"` for alpha tints. -/
+structure Accent where
+  /-- `#rrggbb` form. -/
+  hex : String
+  /-- `"r, g, b"` form, for `rgba(...)` tints. -/
+  rgb : String
+
+/-- X operators: coral. -/
+def xAccent : Accent := ⟨"#d85a30", "216, 90, 48"⟩
+
+/-- Y operators: teal. -/
+def yAccent : Accent := ⟨"#1d9e75", "29, 158, 117"⟩
+
+/-- Z operators: blue. -/
+def zAccent : Accent := ⟨"#378add", "55, 138, 221"⟩
+
+/-- Ring color for flagged qubit positions: purple. -/
+def markHex : String := "#7f77dd"
+
+/-- Anticommuting Gram cells: red. -/
+def antiHex : String := "#e24b4a"
+
+/-- Verdict / state colors (theme variables with sane fallbacks). -/
+def okColor : String := "var(--vscode-charts-green, #2ea060)"
+
+/-- See `okColor`. -/
+def badColor : String := "var(--vscode-errorForeground, #d16969)"
+
+/-- See `okColor`. -/
+def warnColor : String := "var(--vscode-editorWarning-foreground, #c98a1b)"
+
+/-- The `qecw-*` stylesheet. Type scale is 13 px for data, 11 px for meta,
+10 px for micro-labels; data is always in the editor (mono) font, labels in
+the UI font; numerals are tabular so indices align. -/
+def qecwCss : String :=
+  let css := "
+.qecw-card{display:flex;gap:10px;padding:10px 12px;margin:4px 0;
+ border:1px solid var(--vscode-widget-border,rgba(128,128,128,0.3));
+ border-radius:8px;font-family:var(--vscode-font-family,sans-serif)}
+.qecw-bar{width:3px;border-radius:2px;flex:none;
+ background:var(--vscode-widget-border,rgba(128,128,128,0.2))}
+.qecw-body{flex:1;min-width:0}
+.qecw-head{display:flex;align-items:baseline;gap:8px;margin-bottom:4px}
+.qecw-name{font-family:var(--vscode-editor-font-family,monospace);font-size:11px;
+ opacity:.65;word-break:break-all;flex:1;min-width:0}
+.qecw-fact{font-size:11px;white-space:nowrap;font-variant-numeric:tabular-nums;
+ color:var(--vscode-descriptionForeground,#888)}
+.qecw-strip{display:flex;align-items:center;margin-bottom:2px}
+.qecw-cell{display:inline-flex;align-items:center;justify-content:center;
+ width:18px;height:22px;margin:1px;border-radius:4px;font-size:13px;font-weight:500;
+ font-family:var(--vscode-editor-font-family,monospace);
+ transition:background-color .12s ease,opacity .12s ease}
+.qecw-x{color:@XH;background:rgba(@XR,.13)}
+.qecw-x:hover{background:rgba(@XR,.3)}
+.qecw-y{color:@YH;background:rgba(@YR,.13)}
+.qecw-y:hover{background:rgba(@YR,.3)}
+.qecw-z{color:@ZH;background:rgba(@ZR,.13)}
+.qecw-z:hover{background:rgba(@ZR,.3)}
+.qecw-i{color:var(--vscode-descriptionForeground,#888);opacity:.6}
+.qecw-i:hover{opacity:1;background:rgba(128,128,128,.14)}
+.qecw-stuck{color:var(--vscode-errorForeground,#d16969)}
+.qecw-mark{box-shadow:0 0 0 1.5px @MH}
+.qecw-glyph{display:inline-flex;align-items:center;justify-content:center;
+ width:20px;height:22px;margin:1px;font-size:13px;font-weight:500;opacity:.85;
+ font-family:var(--vscode-editor-font-family,monospace)}
+.qecw-rowlabel{display:inline-block;width:30px;text-align:right;margin-right:7px;
+ font-size:10px;opacity:.55;font-variant-numeric:tabular-nums;
+ font-family:var(--vscode-editor-font-family,monospace)}
+.qecw-verdict{display:flex;align-items:center;gap:6px;font-size:11px;font-weight:500;
+ margin-top:6px}
+.qecw-verdict a{color:inherit;text-decoration:none;
+ border-bottom:1px dotted currentColor;cursor:pointer}
+.qecw-micro{font-size:10px;color:var(--vscode-descriptionForeground,#888);
+ font-variant-numeric:tabular-nums}
+.qecw-bit{display:inline-block;width:13px;height:13px;border-radius:3px;margin:1px;
+ transition:transform .1s ease}
+.qecw-bit:hover{transform:scale(1.3)}
+.qecw-bit-x{background:rgba(@XR,.85)}
+.qecw-bit-z{background:rgba(@ZR,.85)}
+.qecw-bit-0{box-shadow:inset 0 0 0 1px rgba(128,128,128,.25)}
+.qecw-bit-diag{background:rgba(128,128,128,.18)}
+.qecw-bit-anti{background:@AH}
+.qecw-bit-stuck{background:rgba(201,138,27,.5)}
+.qecw-svg-grid{stroke:var(--vscode-descriptionForeground,#888);stroke-opacity:.32;
+ stroke-width:1;shape-rendering:crispEdges}
+.qecw-svg-halo{stroke:var(--vscode-editor-background,#fff);stroke-width:5.5;
+ stroke-linecap:round;fill:none}
+.qecw-svg-dot{fill:var(--vscode-descriptionForeground,#888);fill-opacity:.65}
+.qecw-svg-label{font-size:10px;fill:var(--vscode-descriptionForeground,#888);
+ fill-opacity:.85;font-variant-numeric:tabular-nums}
+.vscode-dark .qecw-x{color:#e57a50;background:rgba(@XR,.17)}
+.vscode-dark .qecw-y{color:#2fb98e;background:rgba(@YR,.17)}
+.vscode-dark .qecw-z{color:#61a9e8;background:rgba(@ZR,.17)}
+.vscode-high-contrast .qecw-cell{background:transparent !important;
+ box-shadow:inset 0 0 0 1px currentColor}
+.vscode-high-contrast .qecw-cell.qecw-mark{box-shadow:inset 0 0 0 1px currentColor,
+ 0 0 0 2px @MH}
+.vscode-high-contrast .qecw-bit-0{box-shadow:inset 0 0 0 1px currentColor}
+"
+  css
+    |>.replace "@XH" xAccent.hex |>.replace "@XR" xAccent.rgb
+    |>.replace "@YH" yAccent.hex |>.replace "@YR" yAccent.rgb
+    |>.replace "@ZH" zAccent.hex |>.replace "@ZR" zAccent.rgb
+    |>.replace "@MH" markHex |>.replace "@AH" antiHex
+
+/-- The stylesheet as an embeddable `<style>` element. -/
+def styleTag : Html :=
+  el "style" #[] #[.text qecwCss]
+
+/-- Card container shared by all widgets: stylesheet, state bar, body. The
+`accent` colors the bar (verdict green/red/amber, or an identity color);
+`none` leaves it neutral. -/
+def card (children : Array Html) (accent : Option String := none) : Html :=
+  let bar := match accent with
+    | some c => cls "div" "qecw-bar" #[("style", json% { background: $(c) })]
+    | none => cls "div" "qecw-bar"
+  cls "div" "qecw-card" #[] #[styleTag, bar, cls "div" "qecw-body" #[] children]
+
+/-- A dim compact header fact ("wt 4", "? 2"); the explanation lives in the
+hover tooltip, an optional color marks warnings/verdicts. -/
+def headerFact (label : String) (title : String := "")
+    (color : Option String := none) : Html :=
+  let attrs := #[("title", Json.str title)] ++
+    (match color with
+     | some c => #[("style", json% { color: $(c) })]
+     | none => #[])
+  cls "span" "qecw-fact" attrs #[.text label]
+
+/-- Header line: dim name on the left, compact facts on the right. The name
+is `Html` so callers can pass an interactive expression (`exprName`). -/
+def headerHtml (name : Html) (facts : Array Html) : Html :=
+  cls "div" "qecw-head" #[] (#[cls "span" "qecw-name" #[] #[name]] ++ facts)
+
+/-- Interactive expression for card headers: rendered like terms in the goal
+view — hover for types and docs, click to go to the definition. -/
+def exprName (e : Expr) : MetaM Html := do
+  return Html.ofComponent InteractiveCode { fmt := ← Widget.ppExprTagged e } #[]
+
+/-- A compact one-line verdict; the full explanation lives in the tooltip. -/
+def verdictLine (color : String) (text : String) (title : String := "") : Html :=
+  cls "div" "qecw-verdict"
+    #[("title", Json.str title), ("style", json% { color: $(color) })]
+    #[.text text]
+
+end QECWidgets

--- a/QECWidgets/ToricLattice.lean
+++ b/QECWidgets/ToricLattice.lean
@@ -1,0 +1,281 @@
+/-
+Copyright (c) 2026 Stavan Jain. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Stavan Jain
+-/
+import QEC.Stabilizer.Codes.Toric.ChainOps
+import QECWidgets.PauliStrip
+
+/-!
+# Toric lattice view
+
+Draws a concrete toric 1-chain on the `L × L` torus: qubits are edges,
+edges carried by the chain are highlighted, and edges that wrap around the
+torus are drawn as dotted stubs on both sides. Recognized shapes:
+
+- a term of type `C1 L` (or literally `EdgeIdx L → ZMod 2`) — neutral purple;
+- `toricXOperatorOfChain L c` — the chain `c` in X coral;
+- `toricZOperatorOfChain L c` — the chain `c` in Z blue.
+
+Use the `#toric_chain e` command, or the `Toric lattice` expression presenter
+(via `ProofWidgets.SelectionPanel`) during a proof. Drawing convention
+matches `toricBoundary1`: edge `h x y` joins vertex `(x, y)` to
+`(next x, y)` (rightward), `v x y` joins `(x, y)` to `(x, next y)`
+(downward, matching row-major index order).
+
+Chain strokes are drawn over a background-colored halo (map-style casing) so
+loops read cleanly where they cross the grid.
+-/
+
+namespace QECWidgets
+
+open Lean Server Meta ProofWidgets Quantum Quantum.Stabilizer.Lattice
+
+/-- An evaluated toric 1-chain: one presence bit per horizontal / vertical
+edge (`none` where reduction got stuck). Both arrays are row-major:
+edge `(x, y)` sits at index `y * L + x`. -/
+structure ChainView where
+  /-- Lattice side length. -/
+  L : Nat
+  /-- Horizontal edges `h x y`. -/
+  hEdges : Array (Option Bool)
+  /-- Vertical edges `v x y`. -/
+  vEdges : Array (Option Bool)
+
+/-- Number of edges carried by the chain (resolved cells only). -/
+def ChainView.size (v : ChainView) : Nat :=
+  (v.hEdges ++ v.vEdges).foldl (fun acc o => if o == some true then acc + 1 else acc) 0
+
+/-- Number of edges where reduction got stuck. -/
+def ChainView.numStuck (v : ChainView) : Nat :=
+  (v.hEdges ++ v.vEdges).foldl (fun acc o => if o.isNone then acc + 1 else acc) 0
+
+/-- Reduce a `ZMod 2` value to a `Bool` (is it `1`?). -/
+def zmod2OfExpr? (e : Expr) : MetaM (Option Bool) := do
+  match ← finValOfExpr? e with
+  | some k => return some (k % 2 == 1)
+  | none => return none
+
+/-- Evaluate a `C1 L` expression at every edge of the lattice. -/
+def chainView (c : Expr) (L : Nat) : MetaM ChainView := do
+  let LE := mkNatLit L
+  let mut hs : Array (Option Bool) := #[]
+  let mut vs : Array (Option Bool) := #[]
+  for y in [0:L] do
+    for x in [0:L] do
+      let xE ← mkFinLit L x
+      let yE ← mkFinLit L y
+      hs := hs.push (← zmod2OfExpr? (mkApp c (mkApp3 (mkConst ``EdgeIdx.h) LE xE yE)))
+      vs := vs.push (← zmod2OfExpr? (mkApp c (mkApp3 (mkConst ``EdgeIdx.v) LE xE yE)))
+  return { L := L, hEdges := hs, vEdges := vs }
+
+/-- Which flavor of object the chain came from (fixes the highlight color). -/
+inductive ChainFlavor where
+  /-- A bare 1-chain. -/
+  | plain
+  /-- The chain under `toricXOperatorOfChain`. -/
+  | xOp
+  /-- The chain under `toricZOperatorOfChain`. -/
+  | zOp
+
+/-- Highlight color per flavor. -/
+def ChainFlavor.color : ChainFlavor → String
+  | .plain => markHex
+  | .xOp => xAccent.hex
+  | .zOp => zAccent.hex
+
+/-- Short label per flavor. -/
+def ChainFlavor.label : ChainFlavor → Option String
+  | .plain => none
+  | .xOp => some "X operator support"
+  | .zOp => some "Z operator support"
+
+/-- One-letter header label per flavor (`none` for a bare chain). -/
+def ChainFlavor.letter : ChainFlavor → Option String
+  | .plain => none
+  | .xOp => some "X"
+  | .zOp => some "Z"
+
+/-- Lattices larger than this are refused (each edge costs a reduction, and
+the drawing stops being readable). -/
+def maxToricL : Nat := 16
+
+/-- Recognize a toric-chain-shaped expression: an
+`toricXOperatorOfChain L c` / `toricZOperatorOfChain L c` application, or a
+term whose type is `C1 L` (or unfolded `EdgeIdx L → ZMod 2`), with `L`
+literal. Returns the flavor, `L`, and the chain expression. -/
+def toricShape? (e : Expr) : MetaM (Option (ChainFlavor × Nat × Expr)) := do
+  if e.isAppOfArity ``toricXOperatorOfChain 2 then
+    if let some L ← natOfExpr? (e.getArg! 0) then
+      return some (.xOp, L, e.getArg! 1)
+  if e.isAppOfArity ``toricZOperatorOfChain 2 then
+    if let some L ← natOfExpr? (e.getArg! 0) then
+      return some (.zOp, L, e.getArg! 1)
+  let t ← instantiateMVars (← inferType e)
+  if t.isAppOfArity ``C1 1 then
+    if let some L ← natOfExpr? (t.getArg! 0) then
+      return some (.plain, L, e)
+  if let .forallE _ dom body _ := t then
+    if !body.hasLooseBVars && dom.isAppOfArity ``EdgeIdx 1
+        && body.isAppOfArity ``ZMod 1 then
+      if (← natOfExpr? (body.getArg! 0)) == some 2 then
+        if let some L ← natOfExpr? (dom.getArg! 0) then
+          return some (.plain, L, e)
+  return none
+
+/-- Coordinate attributes for an SVG `line`. -/
+private def lineCoords (x1 y1 x2 y2 : Nat) : Array (String × Json) :=
+  #[("x1", toJson x1), ("y1", toJson y1), ("x2", toJson x2), ("y2", toJson y2)]
+
+/-- A base-grid line (hairline, crisp, muted via the stylesheet). -/
+private def gridLine (x1 y1 x2 y2 : Nat) (dashed : Bool := false) : Html :=
+  cls "line" "qecw-svg-grid"
+    (lineCoords x1 y1 x2 y2 ++
+      if dashed then #[("strokeDasharray", Json.str "2 4")] else #[])
+
+/-- A chain edge: a background-colored halo under a colored stroke, so loops
+stay legible where they cross the grid. Wrap stubs are dotted. -/
+private def chainSeg (x1 y1 x2 y2 : Nat) (color : String) (dashed : Bool := false) :
+    Array Html :=
+  let dash : Array (String × Json) :=
+    if dashed then #[("strokeDasharray", Json.str "0.1 6")] else #[]
+  #[cls "line" "qecw-svg-halo" (lineCoords x1 y1 x2 y2 ++ dash),
+    el "line"
+      (lineCoords x1 y1 x2 y2 ++ dash ++
+        #[("strokeWidth", toJson (2.75 : Float)), ("strokeLinecap", Json.str "round"),
+          ("fill", Json.str "none"), ("style", json% { stroke: $(color) })])
+      #[]]
+
+/-- Draw the lattice: base grid (with dashed wrap stubs), the chain's edges in
+the flavor color over halos, stuck edges in the warning color, vertex dots,
+and coordinate labels on small lattices. -/
+def latticeSvg (v : ChainView) (flavor : ChainFlavor) : Html := Id.run do
+  let L := v.L
+  let s : Nat := if L ≤ 6 then 44 else if L ≤ 10 then 30 else 22
+  let m : Nat := 30
+  let stub := (s * 2) / 5
+  let side := m + (L - 1) * s + m
+  let px (i : Nat) : Nat := m + i * s
+  let mut kids : Array Html := #[]
+  -- Base grid: one solid line per row/column, plus dashed wrap stubs.
+  for i in [0:L] do
+    kids := kids.push (gridLine m (px i) (px (L - 1)) (px i))
+    kids := kids.push (gridLine (px i) m (px i) (px (L - 1)))
+    kids := kids.push (gridLine (m - stub) (px i) m (px i) true)
+    kids := kids.push (gridLine (px (L - 1)) (px i) (px (L - 1) + stub) (px i) true)
+    kids := kids.push (gridLine (px i) (m - stub) (px i) m true)
+    kids := kids.push (gridLine (px i) (px (L - 1)) (px i) (px (L - 1) + stub) true)
+  -- Chain edges (drawn after the grid so they sit on top).
+  for y in [0:L] do
+    for x in [0:L] do
+      let hVal := v.hEdges.getD (y * L + x) none
+      if hVal != some false then
+        let color := if hVal == none then warnColor else flavor.color
+        if x + 1 < L then
+          kids := kids ++ chainSeg (px x) (px y) (px (x + 1)) (px y) color
+        else
+          kids := kids ++ chainSeg (px x) (px y) (px x + stub) (px y) color true
+          kids := kids ++ chainSeg (m - stub) (px y) m (px y) color true
+      let vVal := v.vEdges.getD (y * L + x) none
+      if vVal != some false then
+        let color := if vVal == none then warnColor else flavor.color
+        if y + 1 < L then
+          kids := kids ++ chainSeg (px x) (px y) (px x) (px (y + 1)) color
+        else
+          kids := kids ++ chainSeg (px x) (px y) (px x) (px y + stub) color true
+          kids := kids ++ chainSeg (px x) (m - stub) (px x) m color true
+  -- Vertices and coordinate labels.
+  for y in [0:L] do
+    for x in [0:L] do
+      kids := kids.push <| cls "circle" "qecw-svg-dot"
+        #[("cx", toJson (px x)), ("cy", toJson (px y)), ("r", toJson (1.75 : Float))]
+  if L ≤ 12 then
+    for i in [0:L] do
+      let lbl (tx ty : Nat) : Html := cls "text" "qecw-svg-label"
+        #[("x", toJson tx), ("y", toJson ty), ("textAnchor", Json.str "middle")]
+        #[.text (toString i)]
+      kids := kids.push (lbl (px i) (m - stub - 4))
+      kids := kids.push (lbl (m - stub - 6) (px i + 3))
+  let tooltip := el "title" #[]
+    #[.text "dotted edges wrap around the torus; grid labels are (x, y) lattice coordinates"]
+  return el "svg"
+    #[("xmlns", Json.str "http://www.w3.org/2000/svg"),
+      ("width", toJson side), ("height", toJson side),
+      ("viewBox", Json.str s!"0 0 {side} {side}")]
+    (#[tooltip] ++ kids)
+
+/-- List the chain's edges as text, e.g. `v(1,0) v(1,1) …` (for `logInfo`). -/
+def ChainView.edgeList (v : ChainView) (maxEdges : Nat := 24) : String := Id.run do
+  let mut parts : Array String := #[]
+  for y in [0:v.L] do
+    for x in [0:v.L] do
+      if v.hEdges.getD (y * v.L + x) none == some true then
+        parts := parts.push s!"h({x},{y})"
+  for y in [0:v.L] do
+    for x in [0:v.L] do
+      if v.vEdges.getD (y * v.L + x) none == some true then
+        parts := parts.push s!"v({x},{y})"
+  let shown := " ".intercalate (parts.toList.take maxEdges)
+  return if parts.size > maxEdges then shown ++ " …" else shown
+
+/-- Render a recognized toric shape as HTML plus a text summary, or `none`. -/
+def toricRender? (e : Expr) : MetaM (Option (Html × String)) := do
+  let e ← instantiateMVars e
+  let some (flavor, L, c) ← toricShape? e | return none
+  if L == 0 || L > maxToricL then return none
+  let v ← chainView c L
+  let mut facts : Array Html := #[]
+  if let some letter := flavor.letter then
+    facts := facts.push (headerFact letter ((flavor.label).getD "") (some flavor.color))
+  facts := facts.push (headerFact s!"{v.size} edges" "edges carried by the chain")
+  if v.numStuck > 0 then
+    facts := facts.push
+      (headerFact s!"? {v.numStuck}" "edges that did not reduce" (some warnColor))
+  let accent := match flavor with
+    | .plain => none
+    | _ => some flavor.color
+  let html := card (accent := accent)
+    #[headerHtml (← exprName e) facts, latticeSvg v flavor]
+  let txt := s!"{v.edgeList}   ({v.size} edges on the {L} × {L} torus)"
+  return some (html, txt)
+
+/-- Presenter entry point: render or fail (failure = "not applicable"). -/
+def toricPresent (e : Expr) : MetaM Html := do
+  match ← toricRender? e with
+  | some (h, _) => return h
+  | none => throwError "not a concrete toric chain expression"
+
+/-- Infoview presenter for toric 1-chains and toric chain operators. With
+`ProofWidgets.SelectionPanel` open, shift-click a chain (or a
+`toric{X,Z}OperatorOfChain` application) in the goal to draw it on the torus. -/
+@[expr_presenter]
+def toricLatticePresenter : ExprPresenter where
+  userName := "Toric lattice"
+  layoutKind := .block
+  present := toricPresent
+
+/-- `#toric_chain e` draws a concrete toric 1-chain on the `L × L` torus in
+the infoview. `e` may be a term of type `C1 L`, or an application
+`toricXOperatorOfChain L c` / `toricZOperatorOfChain L c` (colored X coral /
+Z blue). Wrap-around edges are drawn as dotted stubs on both sides. -/
+syntax (name := toricChainCmd) "#toric_chain " term : command
+
+open Elab Command in
+@[command_elab toricChainCmd]
+def elabToricChainCmd : CommandElab
+  | stx@`(#toric_chain $t:term) => do
+    let (ht, txt) ← liftTermElabM do
+      let e ← Term.elabTerm t none
+      Term.synthesizeSyntheticMVarsNoPostponing
+      match ← toricRender? (← instantiateMVars e) with
+      | some r => pure r
+      | none => throwError
+          "#toric_chain: not a recognized concrete toric chain. Expected a term of type \
+          C1 L (with L a literal, L ≤ {maxToricL}), or toricXOperatorOfChain / \
+          toricZOperatorOfChain applied to one."
+    logInfoAt stx txt
+    liftCoreM <| Widget.savePanelWidgetInfo (hash HtmlDisplayPanel.javascript)
+      (return json% { html : $(← rpcEncode ht) }) stx
+  | stx => throwError "Unexpected syntax {stx}."
+
+end QECWidgets

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -47,3 +47,12 @@ name = "QECBlueprint"
 name = "Foundations"
 srcDir = "QEC"
 
+# Infoview widgets (root module `QECWidgets.lean`): Pauli support strips,
+# commutation parity views, and friends, built on ProofWidgets (already a
+# transitive dependency via mathlib — no new `require`). Deliberately NOT in
+# `defaultTargets` (same policy as QECBlueprint): only this target imports
+# ProofWidgets, and `lake build` stays the plain library build. Build with
+# `lake build QECWidgets`; it is part of the pre-push checklist in CLAUDE.md.
+[[lean_lib]]
+name = "QECWidgets"
+


### PR DESCRIPTION
## What this adds

A new root-level `lean_lib` **QECWidgets** with editor visualizations for the stabilizer library. Only this lib imports ProofWidgets (same policy as `QECBlueprint`), and ProofWidgets is already a transitive dependency via mathlib — no new `require`, no manifest change. `lake build` stays the plain library build; CI gets an explicit **Build QECWidgets** step.

| Widget | Surface | Shows |
|---|---|---|
| Pauli strip | `#pauli_strip e` | colored per-qubit strip with weight and a leading phase glyph (`−`, `i`, `−i`) |
| Commutation views | `#pauli_strip (Anticommute p q)` / equalities | both operands aligned, anticommuting/differing qubits ringed, parity verdict — `commutes_iff_even_anticommutes` as a picture |
| Goal suggestion | `pauli_strip?` (tactic) | the goal's strip view; a **replace with `decide`** link when the verdict says it holds (`rw??`-style: `mk_rpc_widget%` panel + `MakeEditLink`) |
| Toric lattice | `#toric_chain e` | `C1 L` chains / `toric{X,Z}OperatorOfChain` on the `L × L` torus, halo-cased strokes, dotted wrap stubs |
| Check matrix | `#check_matrix gens` | (X\|Z) symplectic heatmap + Gram matrix (red = anticommuting pair) |

All widgets also register `@[expr_presenter]`s (SelectionPanel / GoalTypePanel), and every command logs a plain-text summary so terminals and build logs see the result too. `QECWidgets/Demo.lean` is a compiled gallery; `QECWidgets/README.md` is the orientation doc (design tokens, evaluation strategy, linter rules for widget files).

## How it works

Display-only meta code, nothing trusted: evaluation is a whnf ladder (default → `.all` → `Kernel.whnf`) that reduces through the noncomputable `Mul` exactly like `decide` does — e.g. `Steane7.logicalY` renders as phase `−1` all-Y, matching `logicalY_eq_phase2_allY`. Styling is class-based (`Style.lean` tokens + embedded `qecw-*` stylesheet): hover states, dark/light/high-contrast tuning via VS Code body classes, and small RPC payloads. Card headers are live `InteractiveCode` terms (hover for types, click to jump).

## Drive-by fix

`QEC/Stabilizer/Stabilizer.lean` (root-imported umbrella with a module docstring) has been emitting a pre-existing `linter.style.header` "Copyright too short!" warning on every fresh elaboration; it now carries the standard copyright header (separate commit).

## Verification

Full pre-push suite green on this branch: `lake build`, `QECLight`, `QECBlueprint`, `QECWidgets`, `Playground.lean`, `scripts/AxiomCheck.lean` (all 6218 declarations on exactly `[propext, Classical.choice, Quot.sound]`), plus `scripts/check-umbrellas.sh`. Demo outputs are machine-checked against known facts (Steane generator supports, the toric loops sharing exactly qubit 25 = `v(1,2)`, the `±i` phase gap of `X̄Z̄` vs `Z̄X̄`).

Two things to watch:
- the `pauli_strip?` **click** action registers correctly (verified widget props carry the exact replace-range) but the click itself only lives in the infoview — worth a ten-second try in VS Code;
- this PR's CI run is the first execution of the new "Build QECWidgets" step on a GitHub runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)