### PR TITLE
feat(pauli): σ[…] construction notation + delaborator; migrate literal codes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,6 +269,16 @@ For CSS-specific simp-set idioms (e.g. when to drop
 
 These are local to this codebase — search here before assuming mathlib has them:
 
+- **`σ[…]` Pauli construction notation** (scoped — `open scoped Pauli`; defined in
+  `PauliGroup/Notation.lean`): `σ[XZZXI] : NQubitPauliGroupElement 5`, with phase
+  prefixes `iσ[…]` (phasePower 1), `-σ[…]` (2), `-iσ[…]` (3). Elaborates to
+  **exactly** the literal `⟨phase, (NQubitPauliOperator.identity n).set i₀ op₀ …⟩`
+  normal form (non-identity positions, increasing index order), so
+  `rfl`/`decide`/`simp` behavior is identical to a hand-written `.set`-chain; a
+  delaborator displays literal-shaped elements back as `σ[…]` in goals. Concrete
+  literal codes (`Codes/Small/`, `Repetition/Three.lean`) use it; parametric
+  families with symbolic indices (`Repetition/N.lean`, `Iceberg/N.lean`, toric)
+  cannot.
 - `NQubitPauliGroupElement.toMatrix`, `.mulOp`, `.phasePower`, `.operators`
 - `NQubitPauliGroupElement.Anticommute`, `.anticommutesAt`
 - `NQubitPauliGroupElement.commutes_iff_even_anticommutes` — main parity-based

--- a/QEC/Stabilizer/Codes/Repetition/Three.lean
+++ b/QEC/Stabilizer/Codes/Repetition/Three.lean
@@ -16,6 +16,7 @@ import QEC.Stabilizer.Foundations.PauliGroup.NQubitElement
 
 namespace Quantum
 open scoped BigOperators
+open scoped Pauli
 
 namespace StabilizerGroup
 namespace RepetitionCode3
@@ -28,12 +29,10 @@ logical X = X₁X₂X₃, logical Z = Z₁Z₂Z₃. The subgroup is abelian and 
 -/
 
 /-- Z₁Z₂: Z on qubits 0 and 1, I on qubit 2. -/
-def Z1Z2 : NQubitPauliGroupElement 3 :=
-  ⟨0, ((NQubitPauliOperator.identity 3).set 0 PauliOperator.Z).set 1 PauliOperator.Z⟩
+def Z1Z2 : NQubitPauliGroupElement 3 := σ[ZZI]
 
 /-- Z₂Z₃: I on qubit 0, Z on qubits 1 and 2. -/
-def Z2Z3 : NQubitPauliGroupElement 3 :=
-  ⟨0, ((NQubitPauliOperator.identity 3).set 1 PauliOperator.Z).set 2 PauliOperator.Z⟩
+def Z2Z3 : NQubitPauliGroupElement 3 := σ[IZZ]
 
 /-- The generator set for the 3-qubit repetition-code stabilizer subgroup. -/
 def generators : Set (NQubitPauliGroupElement 3) :=
@@ -236,8 +235,7 @@ The repetition code has distance 1: a single Z on any physical qubit is a nontri
 open NQubitPauliOperator NQubitPauliGroupElement
 
 /-- Z on qubit 2 only (I on qubits 0 and 1). -/
-def Z_on_qubit2 : NQubitPauliGroupElement 3 :=
-  ⟨0, (NQubitPauliOperator.identity 3).set 2 PauliOperator.Z⟩
+def Z_on_qubit2 : NQubitPauliGroupElement 3 := σ[IIZ]
 
 lemma Z_on_qubit2_operators (i : Fin 3) :
     Z_on_qubit2.operators i = if i = 2 then PauliOperator.Z else PauliOperator.I := by

--- a/QEC/Stabilizer/Codes/Small/CSS_4_1_2.lean
+++ b/QEC/Stabilizer/Codes/Small/CSS_4_1_2.lean
@@ -20,6 +20,7 @@ import QEC.Stabilizer.Framework.Symplectic.IndependentEquiv
 
 namespace Quantum
 open scoped BigOperators
+open scoped Pauli
 
 namespace StabilizerGroup
 namespace CSS_4_1_2
@@ -69,20 +70,13 @@ open NQubitPauliGroupElement
 /-! ## §1 — Generators -/
 
 /-- First Z-check stabilizer: `Z Z I I` (Z on qubits 0, 1). -/
-def S_Z1 : NQubitPauliGroupElement 4 :=
-  ⟨0,
-    ((NQubitPauliOperator.identity 4).set 0 PauliOperator.Z).set 1 PauliOperator.Z⟩
+def S_Z1 : NQubitPauliGroupElement 4 := σ[ZZII]
 
 /-- Second Z-check stabilizer: `I I Z Z` (Z on qubits 2, 3). -/
-def S_Z2 : NQubitPauliGroupElement 4 :=
-  ⟨0,
-    ((NQubitPauliOperator.identity 4).set 2 PauliOperator.Z).set 3 PauliOperator.Z⟩
+def S_Z2 : NQubitPauliGroupElement 4 := σ[IIZZ]
 
 /-- The X-check stabilizer: `X X X X` (X on every qubit). -/
-def S_X1 : NQubitPauliGroupElement 4 :=
-  ⟨0,
-    (((NQubitPauliOperator.identity 4).set 0 PauliOperator.X).set 1 PauliOperator.X).set 2
-      PauliOperator.X |>.set 3 PauliOperator.X⟩
+def S_X1 : NQubitPauliGroupElement 4 := σ[XXXX]
 
 /-! ## §2 — Generator sets and subgroup -/
 
@@ -276,12 +270,10 @@ basis kets is constant on each codeword).
 -/
 
 /-- Logical X: `X X I I` (overlaps `S_Z1` at qubits 0, 1; even ⇒ commutes). -/
-def logicalX : NQubitPauliGroupElement 4 :=
-  ⟨0, ((NQubitPauliOperator.identity 4).set 0 PauliOperator.X).set 1 PauliOperator.X⟩
+def logicalX : NQubitPauliGroupElement 4 := σ[XXII]
 
 /-- Logical Z: `Z I Z I` (overlaps `S_X1` at qubits 0, 2; even ⇒ commutes). -/
-def logicalZ : NQubitPauliGroupElement 4 :=
-  ⟨0, ((NQubitPauliOperator.identity 4).set 0 PauliOperator.Z).set 2 PauliOperator.Z⟩
+def logicalZ : NQubitPauliGroupElement 4 := σ[ZIZI]
 
 /-! ### §11 — Logical anticommutation -/
 

--- a/QEC/Stabilizer/Codes/Small/FiveQubit_5_1_3.lean
+++ b/QEC/Stabilizer/Codes/Small/FiveQubit_5_1_3.lean
@@ -19,6 +19,7 @@ import QEC.Stabilizer.Framework.Symplectic.SymplecticSpan
 
 namespace Quantum
 open scoped BigOperators
+open scoped Pauli
 
 namespace StabilizerGroup
 namespace FiveQubit_5_1_3
@@ -106,28 +107,16 @@ noncomputable local instance decidableAnticommute
 /-! ## §1 — Generators (cyclic shifts of `XZZXI`) -/
 
 /-- First generator: `X Z Z X I` (positions 0..4). -/
-def g1 : NQubitPauliGroupElement 5 :=
-  ⟨0,
-    ((((NQubitPauliOperator.identity 5).set 0 PauliOperator.X).set 1 PauliOperator.Z).set 2
-      PauliOperator.Z).set 3 PauliOperator.X⟩
+def g1 : NQubitPauliGroupElement 5 := σ[XZZXI]
 
 /-- Second generator: `I X Z Z X` (cyclic shift of `g1` by 1). -/
-def g2 : NQubitPauliGroupElement 5 :=
-  ⟨0,
-    ((((NQubitPauliOperator.identity 5).set 1 PauliOperator.X).set 2 PauliOperator.Z).set 3
-      PauliOperator.Z).set 4 PauliOperator.X⟩
+def g2 : NQubitPauliGroupElement 5 := σ[IXZZX]
 
 /-- Third generator: `X I X Z Z` (cyclic shift of `g1` by 2). -/
-def g3 : NQubitPauliGroupElement 5 :=
-  ⟨0,
-    ((((NQubitPauliOperator.identity 5).set 0 PauliOperator.X).set 2 PauliOperator.X).set 3
-      PauliOperator.Z).set 4 PauliOperator.Z⟩
+def g3 : NQubitPauliGroupElement 5 := σ[XIXZZ]
 
 /-- Fourth generator: `Z X I X Z` (cyclic shift of `g1` by 3). -/
-def g4 : NQubitPauliGroupElement 5 :=
-  ⟨0,
-    ((((NQubitPauliOperator.identity 5).set 0 PauliOperator.Z).set 1 PauliOperator.X).set 3
-      PauliOperator.X).set 4 PauliOperator.Z⟩
+def g4 : NQubitPauliGroupElement 5 := σ[ZXIXZ]
 
 /-! ## §2 — Generator set and subgroup
 
@@ -557,10 +546,7 @@ private lemma anticommute_of_operators_eq
 I, X` and phase power 2. This is the operator-part of `logicalX * g1` (see
 `logicalX_w3_eq_mul` below for the equivalence). Defined explicitly (not via
 the `*` of noncomputable group operations) so that `decide` can reduce it. -/
-def logicalX_w3 : NQubitPauliGroupElement 5 :=
-  ⟨2,
-    (((NQubitPauliOperator.identity 5).set 1 PauliOperator.Y).set 2
-      PauliOperator.Y).set 4 PauliOperator.X⟩
+def logicalX_w3 : NQubitPauliGroupElement 5 := -σ[IYYIX]
 
 /-- Sanity check: the explicit definition matches `logicalX * g1`. -/
 lemma logicalX_w3_eq_mul : logicalX_w3 = logicalX * g1 := by

--- a/QEC/Stabilizer/Codes/Small/FourQubit_4_2_2.lean
+++ b/QEC/Stabilizer/Codes/Small/FourQubit_4_2_2.lean
@@ -20,6 +20,7 @@ import QEC.Stabilizer.Framework.Symplectic.IndependentEquiv
 
 namespace Quantum
 open scoped BigOperators
+open scoped Pauli
 
 namespace StabilizerGroup
 namespace FourQubit_4_2_2
@@ -55,16 +56,10 @@ open NQubitPauliGroupElement
 /-! ## Generators -/
 
 /-- Z-check stabilizer: `ZZZZ` (Z on every qubit). -/
-def Z1 : NQubitPauliGroupElement 4 :=
-  ⟨0,
-    (((NQubitPauliOperator.identity 4).set 0 PauliOperator.Z).set 1 PauliOperator.Z).set 2
-      PauliOperator.Z |>.set 3 PauliOperator.Z⟩
+def Z1 : NQubitPauliGroupElement 4 := σ[ZZZZ]
 
 /-- X-check stabilizer: `XXXX` (X on every qubit). -/
-def X1 : NQubitPauliGroupElement 4 :=
-  ⟨0,
-    (((NQubitPauliOperator.identity 4).set 0 PauliOperator.X).set 1 PauliOperator.X).set 2
-      PauliOperator.X |>.set 3 PauliOperator.X⟩
+def X1 : NQubitPauliGroupElement 4 := σ[XXXX]
 
 /-- The single Z-check generator. -/
 def ZGenerators : Set (NQubitPauliGroupElement 4) :=
@@ -224,20 +219,16 @@ The four logical operators consistent with the codeword basis above:
 -/
 
 /-- Logical X for logical qubit 1: `IXIX`. -/
-def logicalX_1 : NQubitPauliGroupElement 4 :=
-  ⟨0, ((NQubitPauliOperator.identity 4).set 1 PauliOperator.X).set 3 PauliOperator.X⟩
+def logicalX_1 : NQubitPauliGroupElement 4 := σ[IXIX]
 
 /-- Logical X for logical qubit 2: `IIXX`. -/
-def logicalX_2 : NQubitPauliGroupElement 4 :=
-  ⟨0, ((NQubitPauliOperator.identity 4).set 2 PauliOperator.X).set 3 PauliOperator.X⟩
+def logicalX_2 : NQubitPauliGroupElement 4 := σ[IIXX]
 
 /-- Logical Z for logical qubit 1: `IIZZ`. -/
-def logicalZ_1 : NQubitPauliGroupElement 4 :=
-  ⟨0, ((NQubitPauliOperator.identity 4).set 2 PauliOperator.Z).set 3 PauliOperator.Z⟩
+def logicalZ_1 : NQubitPauliGroupElement 4 := σ[IIZZ]
 
 /-- Logical Z for logical qubit 2: `IZIZ`. -/
-def logicalZ_2 : NQubitPauliGroupElement 4 :=
-  ⟨0, ((NQubitPauliOperator.identity 4).set 1 PauliOperator.Z).set 3 PauliOperator.Z⟩
+def logicalZ_2 : NQubitPauliGroupElement 4 := σ[IZIZ]
 
 /-! ### Diagonal anticommutation: X̄_ℓ anticommutes Z̄_ℓ -/
 

--- a/QEC/Stabilizer/Codes/Small/Shor9.lean
+++ b/QEC/Stabilizer/Codes/Small/Shor9.lean
@@ -9,6 +9,7 @@ import QEC.Stabilizer.Foundations.PauliGroup.CommutationTactics
 
 namespace Quantum
 open scoped BigOperators
+open scoped Pauli
 
 namespace StabilizerGroup
 namespace Shor9
@@ -40,42 +41,28 @@ presentation; overlapping supports).
 -/
 
 /-- Z⊗Z on qubits 0 and 1 (first block, adjacent pair). -/
-def M1 : NQubitPauliGroupElement 9 :=
-  ⟨0, ((NQubitPauliOperator.identity 9).set 0 PauliOperator.Z).set 1 PauliOperator.Z⟩
+def M1 : NQubitPauliGroupElement 9 := σ[ZZIIIIIII]
 
 /-- Z⊗Z on qubits 1 and 2 (first block, adjacent pair). -/
-def M2 : NQubitPauliGroupElement 9 :=
-  ⟨0, ((NQubitPauliOperator.identity 9).set 1 PauliOperator.Z).set 2 PauliOperator.Z⟩
+def M2 : NQubitPauliGroupElement 9 := σ[IZZIIIIII]
 
 /-- Z⊗Z on qubits 3 and 4 (second block). -/
-def M3 : NQubitPauliGroupElement 9 :=
-  ⟨0, ((NQubitPauliOperator.identity 9).set 3 PauliOperator.Z).set 4 PauliOperator.Z⟩
+def M3 : NQubitPauliGroupElement 9 := σ[IIIZZIIII]
 
 /-- Z⊗Z on qubits 4 and 5 (second block). -/
-def M4 : NQubitPauliGroupElement 9 :=
-  ⟨0, ((NQubitPauliOperator.identity 9).set 4 PauliOperator.Z).set 5 PauliOperator.Z⟩
+def M4 : NQubitPauliGroupElement 9 := σ[IIIIZZIII]
 
 /-- Z⊗Z on qubits 6 and 7 (third block). -/
-def M5 : NQubitPauliGroupElement 9 :=
-  ⟨0, ((NQubitPauliOperator.identity 9).set 6 PauliOperator.Z).set 7 PauliOperator.Z⟩
+def M5 : NQubitPauliGroupElement 9 := σ[IIIIIIZZI]
 
 /-- Z⊗Z on qubits 7 and 8 (third block). -/
-def M6 : NQubitPauliGroupElement 9 :=
-  ⟨0, ((NQubitPauliOperator.identity 9).set 7 PauliOperator.Z).set 8 PauliOperator.Z⟩
+def M6 : NQubitPauliGroupElement 9 := σ[IIIIIIIZZ]
 
 /-- X on each of qubits 0–5 (six-qubit X stabilizer, overlapping first two blocks). -/
-def M7 : NQubitPauliGroupElement 9 :=
-  ⟨0,
-    ((((((NQubitPauliOperator.identity 9).set 0 PauliOperator.X).set 1 PauliOperator.X).set 2
-                PauliOperator.X).set 3 PauliOperator.X).set 4 PauliOperator.X).set 5
-      PauliOperator.X⟩
+def M7 : NQubitPauliGroupElement 9 := σ[XXXXXXIII]
 
 /-- X on each of qubits 3–8 (six-qubit X stabilizer, overlapping last two blocks). -/
-def M8 : NQubitPauliGroupElement 9 :=
-  ⟨0,
-    ((((((NQubitPauliOperator.identity 9).set 3 PauliOperator.X).set 4 PauliOperator.X).set 5
-                PauliOperator.X).set 6 PauliOperator.X).set 7 PauliOperator.X).set 8
-      PauliOperator.X⟩
+def M8 : NQubitPauliGroupElement 9 := σ[IIIXXXXXX]
 
 /-- The six Z-type generators `M1`–`M6`. -/
 def ZGenerators : Set (NQubitPauliGroupElement 9) :=

--- a/QEC/Stabilizer/Codes/Small/SixQubit_6_2_2.lean
+++ b/QEC/Stabilizer/Codes/Small/SixQubit_6_2_2.lean
@@ -20,6 +20,7 @@ import QEC.Stabilizer.Framework.Symplectic.IndependentEquiv
 
 namespace Quantum
 open scoped BigOperators
+open scoped Pauli
 
 namespace StabilizerGroup
 namespace SixQubit_6_2_2
@@ -85,28 +86,16 @@ Qubit indexing is 0-based; qubits 0,1 are the "top" pair, 2,3 the
 -/
 
 /-- First Z-check stabilizer: `Z Z Z Z I I` (Z on qubits 0,1,2,3). -/
-def S_Z1 : NQubitPauliGroupElement 6 :=
-  ⟨0,
-    (((NQubitPauliOperator.identity 6).set 0 PauliOperator.Z).set 1 PauliOperator.Z).set 2
-      PauliOperator.Z |>.set 3 PauliOperator.Z⟩
+def S_Z1 : NQubitPauliGroupElement 6 := σ[ZZZZII]
 
 /-- Second Z-check stabilizer: `Z Z I I Z Z` (Z on qubits 0,1,4,5). -/
-def S_Z2 : NQubitPauliGroupElement 6 :=
-  ⟨0,
-    (((NQubitPauliOperator.identity 6).set 0 PauliOperator.Z).set 1 PauliOperator.Z).set 4
-      PauliOperator.Z |>.set 5 PauliOperator.Z⟩
+def S_Z2 : NQubitPauliGroupElement 6 := σ[ZZIIZZ]
 
 /-- First X-check stabilizer: `X X X X I I` (X on qubits 0,1,2,3). -/
-def S_X1 : NQubitPauliGroupElement 6 :=
-  ⟨0,
-    (((NQubitPauliOperator.identity 6).set 0 PauliOperator.X).set 1 PauliOperator.X).set 2
-      PauliOperator.X |>.set 3 PauliOperator.X⟩
+def S_X1 : NQubitPauliGroupElement 6 := σ[XXXXII]
 
 /-- Second X-check stabilizer: `X X I I X X` (X on qubits 0,1,4,5). -/
-def S_X2 : NQubitPauliGroupElement 6 :=
-  ⟨0,
-    (((NQubitPauliOperator.identity 6).set 0 PauliOperator.X).set 1 PauliOperator.X).set 4
-      PauliOperator.X |>.set 5 PauliOperator.X⟩
+def S_X2 : NQubitPauliGroupElement 6 := σ[XXIIXX]
 
 /-! ## §2 — Generator sets and subgroup -/
 
@@ -336,24 +325,16 @@ Indexing: `_1` ≡ Knill's "L" (long support on Z, short on X);
 -/
 
 /-- Logical X for logical qubit 1: `IIXXII` (X on qubits 2, 3). -/
-def logicalX_1 : NQubitPauliGroupElement 6 :=
-  ⟨0, ((NQubitPauliOperator.identity 6).set 2 PauliOperator.X).set 3 PauliOperator.X⟩
+def logicalX_1 : NQubitPauliGroupElement 6 := σ[IIXXII]
 
 /-- Logical X for logical qubit 2: `IXIXXI` (X on qubits 1, 3, 4). -/
-def logicalX_2 : NQubitPauliGroupElement 6 :=
-  ⟨0,
-    (((NQubitPauliOperator.identity 6).set 1 PauliOperator.X).set 3 PauliOperator.X).set 4
-      PauliOperator.X⟩
+def logicalX_2 : NQubitPauliGroupElement 6 := σ[IXIXXI]
 
 /-- Logical Z for logical qubit 1: `ZIIZZI` (Z on qubits 0, 3, 4). -/
-def logicalZ_1 : NQubitPauliGroupElement 6 :=
-  ⟨0,
-    (((NQubitPauliOperator.identity 6).set 0 PauliOperator.Z).set 3 PauliOperator.Z).set 4
-      PauliOperator.Z⟩
+def logicalZ_1 : NQubitPauliGroupElement 6 := σ[ZIIZZI]
 
 /-- Logical Z for logical qubit 2: `IIIIZZ` (Z on qubits 4, 5). -/
-def logicalZ_2 : NQubitPauliGroupElement 6 :=
-  ⟨0, ((NQubitPauliOperator.identity 6).set 4 PauliOperator.Z).set 5 PauliOperator.Z⟩
+def logicalZ_2 : NQubitPauliGroupElement 6 := σ[IIIIZZ]
 
 /-! ### Diagonal anticommutation: X̄_ℓ anticommutes Z̄_ℓ -/
 

--- a/QEC/Stabilizer/Codes/Small/Steane7.lean
+++ b/QEC/Stabilizer/Codes/Small/Steane7.lean
@@ -17,6 +17,7 @@ import QEC.Stabilizer.Foundations.PauliGroup.NQubitOperator
 
 namespace Quantum
 open scoped BigOperators
+open scoped Pauli
 
 namespace StabilizerGroup
 namespace Steane7
@@ -46,40 +47,22 @@ open NQubitPauliGroupElement
 -/
 
 /-- Z-check on row r₁ = {0,1,2,4}: Z on qubits 0,1,2,4 and I elsewhere. -/
-def Z1 : NQubitPauliGroupElement 7 :=
-  ⟨0,
-    (((NQubitPauliOperator.identity 7).set 0 PauliOperator.Z).set 1 PauliOperator.Z).set 2
-      PauliOperator.Z |>.set 4 PauliOperator.Z⟩
+def Z1 : NQubitPauliGroupElement 7 := σ[ZZZIZII]
 
 /-- Z-check on row r₂ = {0,1,3,5}: Z on qubits 0,1,3,5 and I elsewhere. -/
-def Z2 : NQubitPauliGroupElement 7 :=
-  ⟨0,
-    (((NQubitPauliOperator.identity 7).set 0 PauliOperator.Z).set 1 PauliOperator.Z).set 3
-      PauliOperator.Z |>.set 5 PauliOperator.Z⟩
+def Z2 : NQubitPauliGroupElement 7 := σ[ZZIZIZI]
 
 /-- Z-check on row r₃ = {0,2,3,6}: Z on qubits 0,2,3,6 and I elsewhere. -/
-def Z3 : NQubitPauliGroupElement 7 :=
-  ⟨0,
-    (((NQubitPauliOperator.identity 7).set 0 PauliOperator.Z).set 2 PauliOperator.Z).set 3
-      PauliOperator.Z |>.set 6 PauliOperator.Z⟩
+def Z3 : NQubitPauliGroupElement 7 := σ[ZIZZIIZ]
 
 /-- X-check on row r₁ = {0,1,2,4}: X on qubits 0,1,2,4 and I elsewhere. -/
-def X1 : NQubitPauliGroupElement 7 :=
-  ⟨0,
-    (((NQubitPauliOperator.identity 7).set 0 PauliOperator.X).set 1 PauliOperator.X).set 2
-      PauliOperator.X |>.set 4 PauliOperator.X⟩
+def X1 : NQubitPauliGroupElement 7 := σ[XXXIXII]
 
 /-- X-check on row r₂ = {0,1,3,5}: X on qubits 0,1,3,5 and I elsewhere. -/
-def X2 : NQubitPauliGroupElement 7 :=
-  ⟨0,
-    (((NQubitPauliOperator.identity 7).set 0 PauliOperator.X).set 1 PauliOperator.X).set 3
-      PauliOperator.X |>.set 5 PauliOperator.X⟩
+def X2 : NQubitPauliGroupElement 7 := σ[XXIXIXI]
 
 /-- X-check on row r₃ = {0,2,3,6}: X on qubits 0,2,3,6 and I elsewhere. -/
-def X3 : NQubitPauliGroupElement 7 :=
-  ⟨0,
-    (((NQubitPauliOperator.identity 7).set 0 PauliOperator.X).set 2 PauliOperator.X).set 3
-      PauliOperator.X |>.set 6 PauliOperator.X⟩
+def X3 : NQubitPauliGroupElement 7 := σ[XIXXIIX]
 
 /-- The three Z-check generators (Z on each parity-check row). -/
 def ZGenerators : Set (NQubitPauliGroupElement 7) :=

--- a/QEC/Stabilizer/Codes/_TEMPLATE.lean
+++ b/QEC/Stabilizer/Codes/_TEMPLATE.lean
@@ -12,6 +12,7 @@ import QEC.Stabilizer.Foundations.PauliGroup.Commutation
 import QEC.Stabilizer.Foundations.PauliGroup.CommutationTactics
 import QEC.Stabilizer.Foundations.PauliGroup.NQubitOperator
 import QEC.Stabilizer.Foundations.PauliGroup.NQubitElement
+import QEC.Stabilizer.Foundations.PauliGroup.Notation
 import QEC.Stabilizer.Foundations.BinarySymplectic.Core
 import QEC.Stabilizer.Foundations.BinarySymplectic.CheckMatrix
 import QEC.Stabilizer.Foundations.BinarySymplectic.CheckMatrixDecidable
@@ -82,35 +83,46 @@ namespace StabilizerGroup
 namespace _Template
 
 open NQubitPauliGroupElement
+open scoped Pauli
 
 /-!
 ## §1 — Generators
 
 For an `[[n, k, d]]` CSS code, you need `m_Z` Z-type generators and `m_X`
 X-type generators, with `m_Z + m_X = n - k`. Each is an
-`NQubitPauliGroupElement n` with `phasePower = 0`.
+`NQubitPauliGroupElement n` with `phasePower = 0`, written with the scoped
+`σ[…]` construction notation (`open scoped Pauli`, provided by
+`QEC.Stabilizer.Foundations.PauliGroup.Notation` — see this file's header).
 
 Pattern (Steane code, [[7, 1, 3]], `m_Z = m_X = 3`):
 
 ```lean
 /-- Z-check on row r₁ = {0,1,2,4}: Z on qubits 0,1,2,4 and I elsewhere. -/
-def Z1 : NQubitPauliGroupElement 7 :=
-  ⟨0,
-    (((NQubitPauliOperator.identity 7).set 0 PauliOperator.Z).set 1 PauliOperator.Z).set 2
-      PauliOperator.Z |>.set 4 PauliOperator.Z⟩
+def Z1 : NQubitPauliGroupElement 7 := σ[ZZZIZII]
 ```
+
+`σ[ZZZIZII]` elaborates to **exactly** the literal normal form
+
+```lean
+⟨0,
+  (((NQubitPauliOperator.identity 7).set 0 PauliOperator.Z).set 1 PauliOperator.Z).set 2
+    PauliOperator.Z |>.set 4 PauliOperator.Z⟩
+```
+
+(`.set` applied at the non-identity positions in increasing index order), so
+`rfl`/`decide`/`simp` behavior is identical to writing the chain by hand, and
+goals display such literals back as `σ[…]`.
 
 Conventions:
 
-- `phasePower = 0` always for stabilizer generators (the `0 : Fin 4` in the
-  anonymous constructor).
-- 0-based qubit indexing.
-- Chain `.set` calls left-to-right by increasing qubit index for readability.
+- `phasePower = 0` always for stabilizer generators — the plain `σ[…]` form.
+  (Phase-prefix variants exist for other elements: `iσ[…]` = phase `i`,
+  `-σ[…]` = phase `-1`, `-iσ[…]` = phase `-i`.)
+- 0-based qubit indexing: the k-th letter is the operator on qubit k.
 - One `def` per generator. Name them `Z1, Z2, …, X1, X2, …`.
 
-**Non-CSS variant.** Mixed-Pauli generators (e.g., 5-qubit perfect code
-`XZZXI`) use a single chain of `.set` with the appropriate `PauliOperator`
-per qubit; there is no Z/X partition.
+**Non-CSS variant.** Mixed-Pauli generators use the same notation (e.g., the
+5-qubit perfect code's `σ[XZZXI]`); there is no Z/X partition.
 -/
 
 /-!

--- a/QEC/Stabilizer/Foundations/PauliGroup.lean
+++ b/QEC/Stabilizer/Foundations/PauliGroup.lean
@@ -1,6 +1,7 @@
 import QEC.Stabilizer.Foundations.PauliGroupSingle
 import QEC.Stabilizer.Foundations.PauliGroup.NQubitOperator
 import QEC.Stabilizer.Foundations.PauliGroup.NQubitElement
+import QEC.Stabilizer.Foundations.PauliGroup.Notation
 import QEC.Stabilizer.Foundations.PauliGroup.TransversalConjugation
 import QEC.Stabilizer.Foundations.PauliGroup.Commutation
 import QEC.Stabilizer.Foundations.PauliGroup.CommutationTactics
@@ -14,6 +15,8 @@ group development from smaller files:
 
 - `QEC.Stabilizer.Foundations.PauliGroup.NQubitOperator`
 - `QEC.Stabilizer.Foundations.PauliGroup.NQubitElement`
+- `QEC.Stabilizer.Foundations.PauliGroup.Notation`
+  (scoped `σ[XZIX]` construction notation, `open scoped Pauli`)
 - `QEC.Stabilizer.Foundations.PauliGroup.TransversalConjugation`
 - `QEC.Stabilizer.Foundations.PauliGroup.Commutation`
 - `QEC.Stabilizer.Foundations.PauliGroup.CommutationTactics`

--- a/QEC/Stabilizer/Foundations/PauliGroup/Notation.lean
+++ b/QEC/Stabilizer/Foundations/PauliGroup/Notation.lean
@@ -1,0 +1,223 @@
+import Lean.PrettyPrinter.Delaborator.Basic
+import QEC.Stabilizer.Foundations.PauliGroup.NQubitElement
+
+/-!
+# Physics-style construction notation for `NQubitPauliGroupElement`
+
+This file provides scoped notation for writing concrete n-qubit Pauli group elements the
+way the physics literature does:
+
+- `σ[XXIXII]` — phase `+1` (`phasePower = 0`)
+- `iσ[XXIXII]` — phase `i` (`phasePower = 1`)
+- `-σ[XXIXII]` — phase `-1` (`phasePower = 2`)
+- `-iσ[XXIXII]` — phase `-i` (`phasePower = 3`)
+
+The letters between the brackets form a single identifier over the alphabet `X`, `Y`,
+`Z`, `I`, read left to right as qubits `0, 1, …`; the number of letters fixes the number
+of qubits, so `σ[XIZ] : NQubitPauliGroupElement 3` with no ascription needed.
+
+The notation is **scoped**: enable it with `open scoped Pauli`. It must be opt-in
+because any notation whose leading token is `σ[` takes over that token from `GetElem`
+indexing (`σ[i]`) for variables named `σ` (likewise `iσ[…]` for variables named `iσ`).
+The phase prefixes are part of the leading token (`-σ[`, `iσ[`, `-iσ[`): write them with
+no space before `σ[`, and keep spaces around a binary `-` (`a - σ[XX]`) when you mean
+subtraction with the scope open.
+
+## Elaboration guarantee
+
+`σ[…]` elaborates to **exactly** the canonical literal normal form used throughout the
+concrete code files:
+
+```lean
+⟨phase, ((NQubitPauliOperator.identity n).set i₀ op₀).set i₁ op₁ ⋯⟩
+```
+
+with `.set` applied only at the non-identity positions, in increasing index order. The
+notation is a macro (pure syntax expansion into that form), so kernel-reduction behavior
+and every existing `simp`/`decide`/`rfl` proof over such literals are unchanged. In
+particular there is deliberately no `ofList`-style helper on the elaboration path: a list
+lookup is an O(n) walk under kernel reduction (see the axiom-policy notes in
+`CLAUDE.md`), whereas the `.set` chain is the form all existing proofs already consume.
+
+## Delaborator
+
+Terms of exactly that literal shape (literal phase, literal indices, `PauliOperator`
+constructors, literal qubit count) display back as `σ[…]`/`iσ[…]`/`-σ[…]`/`-iσ[…]` in
+goals and diagnostics. Anything else — variable phase or operators, symbolic indices, a
+partially reduced chain — is left to the default printer. The delaborator is registered
+globally, so the display is independent of whether the scope is open;
+`set_option pp.notation false` (or `pp.explicit true`) recovers the raw term.
+-/
+
+namespace Pauli
+
+open Lean
+
+/-- `σ[XZIX]` is the `NQubitPauliGroupElement` with phase `+1` (`phasePower = 0`) whose
+operator at qubit `k` is the `k`-th letter (letters `X`, `Y`, `Z`, `I`; qubit count =
+letter count). Scoped: enable with `open scoped Pauli`. Elaborates to the literal
+`⟨0, (NQubitPauliOperator.identity n).set i₀ op₀ …⟩` normal form. -/
+scoped syntax:max (name := sigma) "σ[" ident "]" : term
+
+/-- `iσ[XZIX]`: as `σ[XZIX]` but with phase `i` (`phasePower = 1`).
+Scoped: enable with `open scoped Pauli`. -/
+scoped syntax:max (name := iSigma) "iσ[" ident "]" : term
+
+/-- `-σ[XZIX]`: as `σ[XZIX]` but with phase `-1` (`phasePower = 2`).
+Scoped: enable with `open scoped Pauli`. -/
+scoped syntax:max (name := negSigma) "-σ[" ident "]" : term
+
+/-- `-iσ[XZIX]`: as `σ[XZIX]` but with phase `-i` (`phasePower = 3`).
+Scoped: enable with `open scoped Pauli`. -/
+scoped syntax:max (name := negISigma) "-iσ[" ident "]" : term
+
+/-- Split the letters identifier of a `σ[…]`-family literal into its characters, checking
+that the identifier is a single atomic name over the alphabet `X`, `Y`, `Z`, `I`. -/
+def pauliLetters (stx : Syntax) : MacroM (List Char) := do
+  let .str .anonymous s := stx.getId.eraseMacroScopes
+    | Macro.throwErrorAt stx "expected a string of Pauli letters (X, Y, Z, I)"
+  let cs := s.toList
+  for c in cs do
+    unless c == 'X' || c == 'Y' || c == 'Z' || c == 'I' do
+      Macro.throwErrorAt stx s!"invalid Pauli letter '{c}': expected X, Y, Z, or I"
+  return cs
+
+/-- Expand a `σ[…]`-family literal with the given `phasePower` into the canonical normal
+form `NQubitPauliGroupElement.mk phase ((NQubitPauliOperator.identity n).set i₀ op₀ …)`,
+setting only the non-identity positions, in increasing index order. -/
+def expandSigma (phase : Nat) (letters : Syntax) : MacroM Term := do
+  let cs ← pauliLetters letters
+  let mut ops : Term ← `(Quantum.NQubitPauliOperator.identity $(quote cs.length))
+  let mut i : Nat := 0
+  for c in cs do
+    if c != 'I' then
+      let opStx : Term ← match c with
+        | 'X' => `(Quantum.PauliOperator.X)
+        | 'Y' => `(Quantum.PauliOperator.Y)
+        | _ => `(Quantum.PauliOperator.Z)
+      ops ← `(Quantum.NQubitPauliOperator.set $ops $(quote i) $opStx)
+    i := i + 1
+  `(Quantum.NQubitPauliGroupElement.mk $(quote phase) $ops)
+
+macro_rules
+  | `(σ[$letters:ident]) => expandSigma 0 letters
+  | `(iσ[$letters:ident]) => expandSigma 1 letters
+  | `(-σ[$letters:ident]) => expandSigma 2 letters
+  | `(-iσ[$letters:ident]) => expandSigma 3 letters
+
+/-!
+## Delaborator
+
+Displays literal-shaped `NQubitPauliGroupElement.mk` applications back as `σ[…]`.
+-/
+
+section Delaborator
+
+open PrettyPrinter Delaborator SubExpr
+
+/-- Match a literal natural number: a raw `Nat` literal or an `OfNat.ofNat` application
+of one (the form numerals elaborate to). -/
+def natLitOf? (e : Expr) : Option Nat :=
+  match e with
+  | .lit (.natVal k) => some k
+  | _ =>
+    if e.isAppOfArity ``OfNat.ofNat 3 then
+      match e.getArg! 1 with
+      | .lit (.natVal k) => some k
+      | _ => none
+    else none
+
+/-- Match a `PauliOperator` constructor constant, as its letter. -/
+def pauliOpChar? (e : Expr) : Option Char :=
+  match e with
+  | .const c _ =>
+    if c == ``Quantum.PauliOperator.X then some 'X'
+    else if c == ``Quantum.PauliOperator.Y then some 'Y'
+    else if c == ``Quantum.PauliOperator.Z then some 'Z'
+    else if c == ``Quantum.PauliOperator.I then some 'I'
+    else none
+  | _ => none
+
+/-- Match a literal `set`-chain `(NQubitPauliOperator.identity n).set i₀ op₀ …` with
+literal indices and constructor operators. Returns the literal `n` together with the
+`(index, letter)` assignments, innermost first. Returns `none` on any other shape. -/
+partial def setChain? (e : Expr) (acc : List (Nat × Char) := []) :
+    Option (Nat × List (Nat × Char)) :=
+  if e.isAppOfArity ``Quantum.NQubitPauliOperator.set 4 then do
+    let i ← natLitOf? (e.getArg! 2)
+    let c ← pauliOpChar? (e.getArg! 3)
+    setChain? (e.getArg! 1) ((i, c) :: acc)
+  else if e.isAppOfArity ``Quantum.NQubitPauliOperator.identity 1 then do
+    let n ← natLitOf? (e.getArg! 0)
+    return (n, acc)
+  else
+    none
+
+/-- Delaborate literal-shaped `NQubitPauliGroupElement.mk` applications back to the
+`σ[…]`/`iσ[…]`/`-σ[…]`/`-iσ[…]` notation. Fires only when the phase is a literal
+`0`–`3`, the operator part is a literal `set`-chain over `identity n` with in-range
+literal indices, and `n > 0`; stays silent otherwise. -/
+@[app_delab Quantum.NQubitPauliGroupElement.mk]
+def delabSigma : Delab :=
+  whenPPOption getPPNotation <| whenNotPPOption getPPExplicit do
+    let e ← getExpr
+    unless e.isAppOfArity ``Quantum.NQubitPauliGroupElement.mk 3 do failure
+    let some phase := natLitOf? (e.getArg! 1) | failure
+    let some (n, sets) := setChain? (e.getArg! 2) | failure
+    unless 0 < n do failure
+    unless sets.all (fun ic => ic.1 < n) do failure
+    -- Later (outer) `.set`s override earlier ones, so fold innermost-first.
+    let letters := String.ofList <| (List.range n).map fun j =>
+      sets.foldl (fun acc ic => if ic.1 == j then ic.2 else acc) 'I'
+    let letters := mkIdent (.mkSimple letters)
+    match phase with
+    | 0 => `(σ[$letters])
+    | 1 => `(iσ[$letters])
+    | 2 => `(-σ[$letters])
+    | 3 => `(-iσ[$letters])
+    | _ => failure
+
+end Delaborator
+
+end Pauli
+
+/-!
+## Round-trip tests
+
+Each phase prefix elaborates to exactly the hand-written literal normal form.
+-/
+
+section RoundTrip
+
+open Quantum
+open scoped Pauli
+
+example :
+    σ[XIZ] =
+      ⟨0, ((NQubitPauliOperator.identity 3).set 0 PauliOperator.X).set 2 PauliOperator.Z⟩ :=
+  rfl
+
+example :
+    σ[XZZXI] =
+      ⟨0, ((((NQubitPauliOperator.identity 5).set 0 PauliOperator.X).set 1
+        PauliOperator.Z).set 2 PauliOperator.Z).set 3 PauliOperator.X⟩ :=
+  rfl
+
+example : σ[IIII] = ⟨0, NQubitPauliOperator.identity 4⟩ := rfl
+
+example : iσ[Z] = ⟨1, (NQubitPauliOperator.identity 1).set 0 PauliOperator.Z⟩ := rfl
+
+example :
+    -σ[YY] =
+      ⟨2, ((NQubitPauliOperator.identity 2).set 0 PauliOperator.Y).set 1 PauliOperator.Y⟩ :=
+  rfl
+
+example : -iσ[XI] = ⟨3, (NQubitPauliOperator.identity 2).set 0 PauliOperator.X⟩ := rfl
+
+example : σ[XIZ].phasePower = 0 := rfl
+
+example : σ[XIZ].operators 2 = PauliOperator.Z := rfl
+
+example : σ[XIZ].operators 1 = PauliOperator.I := rfl
+
+end RoundTrip


### PR DESCRIPTION
## What

Physics-style construction notation for `NQubitPauliGroupElement`, plus a delaborator, and a migration of every literal generator/logical definition to it.

**New module [`QEC/Stabilizer/Foundations/PauliGroup/Notation.lean`](https://github.com/Stavan-Jain/QECLean/blob/claude/dazzling-thompson-ed70fd/QEC/Stabilizer/Foundations/PauliGroup/Notation.lean)** (imported by the `PauliGroup` umbrella):

- Scoped notation, opt-in via `open scoped Pauli`: `σ[XZZXI] : NQubitPauliGroupElement 5`, with phase prefixes `iσ[…]` (phasePower 1), `-σ[…]` (2), `-iσ[…]` (3). Scoped because a leading `σ[` token shadows `GetElem` indexing for variables named `σ`; verified that the tokens do **not** leak outside the scope (`σ[0]` on an `Array`-typed variable named `σ` still parses with the scope closed).
- **Elaboration guarantee:** a macro expands each literal to *exactly* the canonical `⟨phase, (NQubitPauliOperator.identity n).set i₀ op₀ …⟩` normal form (non-identity positions, increasing index order, no `ofList`-style helper on the hot path), so kernel-reduction behavior and every existing `rfl`/`decide`/`simp` proof are unchanged.
- **Delaborator:** literal-shaped `mk` applications display back as `σ[…]`/`iσ[…]`/`-σ[…]`/`-iσ[…]` in goals; any other shape (variable phase/operators, symbolic indices) is left to the default printer. `pp.notation false` recovers the raw term.
- Round-trip `rfl` examples in the file.

## Migration

All 41 literal defs, each pre-verified `rfl`-equal to the verbatim chain it replaces — **zero proof changes**:

- `Small/Steane7.lean` (6), `Small/Shor9.lean` (8), `Small/FiveQubit_5_1_3.lean` (4 generators + the phase-2 witness `logicalX_w3 = -σ[IYYIX]`), `Small/FourQubit_4_2_2.lean` (6), `Small/CSS_4_1_2.lean` (5), `Small/SixQubit_6_2_2.lean` (8), `Repetition/Three.lean` (3)
- `_TEMPLATE.lean` §1 now teaches the notation; CLAUDE.md's project-specific-helpers list gets the new bullet
- Deliberately *not* migrated: parametric families (`Repetition/N`, `Iceberg/N`, `Toric/CodeN` — symbolic indices the literal notation can't express) and the template's all-X/all-Z `NQubitPauliOperator.X n` samples (a different normal form)

## Verification

Full pre-push suite on a clean rebuild: `lake build` (3476 jobs) + `QECLight` + `QECBlueprint` + `Playground.lean` + `scripts/AxiomCheck.lean` — axiom policy OK, 6247 declarations across 166 modules depend on exactly `[propext, Classical.choice, Quot.sound]`. `scripts/check-umbrellas.sh` passes. Only pre-existing warnings (the two `linter.flexible` sites in Steane7 already on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
