### PR TITLE
feat(pauli): global DecidableEq + Anticommute instances; one-line commutation checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,16 +284,25 @@ These are local to this codebase — search here before assuming mathlib has the
 - `NQubitPauliGroupElement.commutes_iff_even_anticommutes` — main parity-based
   commutation lemma for general Paulis (the "count of anticommuting qubits is
   even" characterization)
-- **`Decidable (NQubitPauliGroupElement.Anticommute p q)`** (in
-  `PauliGroup/Commutation.lean`) — closes `Anticommute p q` goals via
-  `by decide`. The instance is `noncomputable` because `Mul` on
-  `NQubitPauliGroupElement` is itself noncomputable, but `decide` still
-  reduces through the kernel. `native_decide` does **not** work for
-  the same reason — prefer `decide`. Builds on the computable
-  `DecidableEq (NQubitPauliOperator n)` from `Representation.lean`
-  (the `Classical.decEq` override has been removed). Used heavily by
-  the [[5,1,3]] distance proof for the 105-case weight-{1,2}
-  anti-witness tables.
+- **`DecidableEq (NQubitPauliGroupElement n)`** and
+  **`Decidable (NQubitPauliGroupElement.Anticommute p q)`** (global instances in
+  `PauliGroup/Commutation.lean`) — close element-equality, commutation
+  (`p * q = q * p`), and `Anticommute p q` goals on literal elements via
+  `by decide`. Every pairwise commutation/anticommutation lemma in the concrete
+  codes is a one-liner through these; do **not** batch all pairs of a generator
+  list into a single `decide` (the nested evaluation blows
+  `maxRecDepth`/heartbeats — keep one named lemma per pair). The `Anticommute`
+  instance is `noncomputable` because `Mul` on `NQubitPauliGroupElement` is
+  itself noncomputable, but `decide` still reduces through the kernel;
+  `native_decide` does **not** work for the same reason — prefer `decide`.
+  Builds on the computable `DecidableEq (NQubitPauliOperator n)` from
+  `Representation.lean` (the `Classical.decEq` override has been removed). Used
+  heavily by the [[5,1,3]] distance proof for the 105-case weight-{1,2}
+  anti-witness tables. (These were file-local to `FiveQubit_5_1_3.lean` while
+  `RotatedSurfaceCode3.lean`'s `native_decide` proof needed the Pi-decidability
+  synthesis path; that proof is parked, so they are global again. For symbolic
+  /parametric elements `decide` does not apply — use the
+  `pauli_comm_even_anticommutes` tactic + explicit anticommute-`Finset` pattern.)
 - `StabilizerGroup`, `.toSubgroup`, `.is_abelian`, `.one_mem`,
   `.neg_identity_not_mem`, `.codespaceSubmodule`
 - `IsNontrivialLogicalOperator` has **three** conditions (see

--- a/QEC/Stabilizer/Codes/Repetition/Three.lean
+++ b/QEC/Stabilizer/Codes/Repetition/Three.lean
@@ -144,31 +144,9 @@ def logicalZ : NQubitPauliGroupElement 3 :=
 theorem logicalX_anticommutes_logicalZ : NQubitPauliGroupElement.Anticommute logicalX logicalZ :=
   NQubitPauliOperator.allX_allZ_anticommute 3 (by decide)
 
-private lemma logicalX_commutes_Z1Z2 : logicalX * Z1Z2 = Z1Z2 * logicalX := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 3) logicalX.operators Z1Z2.operators)) =
-        ({0, 1} : Finset (Fin 3)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalX, Z1Z2,
-        NQubitPauliOperator.X, NQubitPauliOperator.set, NQubitPauliOperator.identity,
-        PauliOperator.mulOp]
-  simp [hfilter]
+private lemma logicalX_commutes_Z1Z2 : logicalX * Z1Z2 = Z1Z2 * logicalX := by decide
 
-private lemma logicalX_commutes_Z2Z3 : logicalX * Z2Z3 = Z2Z3 * logicalX := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 3) logicalX.operators Z2Z3.operators)) =
-        ({1, 2} : Finset (Fin 3)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalX, Z2Z3,
-        NQubitPauliOperator.X, NQubitPauliOperator.set, NQubitPauliOperator.identity,
-        PauliOperator.mulOp]
-  simp [hfilter]
+private lemma logicalX_commutes_Z2Z3 : logicalX * Z2Z3 = Z2Z3 * logicalX := by decide
 
 /-- Logical X commutes with every element of the stabilizer. -/
 theorem logicalX_mem_centralizer : logicalX ∈ centralizer stabilizerGroup := by
@@ -268,19 +246,7 @@ lemma Z_on_qubit2_mem_centralizer : Z_on_qubit2 ∈ centralizer stabilizerGroup 
 
 /-- Z_on_qubit2 anticommutes with logical X (overlap only on qubit 2, where X and Z anticommute). -/
 lemma Z_on_qubit2_anticommutes_logicalX :
-    NQubitPauliGroupElement.Anticommute Z_on_qubit2 logicalX := by
-  classical
-  rw [NQubitPauliGroupElement.anticommutes_iff_odd_anticommutes]
-  have hfilter :
-      (Finset.univ.filter
-          (NQubitPauliGroupElement.anticommutesAt (n := 3) Z_on_qubit2.operators
-            logicalX.operators)) = ({2} : Finset (Fin 3)) := by
-    ext i
-    fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, Z_on_qubit2_operators,
-        logicalX, NQubitPauliOperator.X, PauliOperator.mulOp]
-  rw [hfilter]
-  decide
+    NQubitPauliGroupElement.Anticommute Z_on_qubit2 logicalX := by decide
 
 /-- Z_on_qubit2 is not in the stabilizer: it anticommutes with logical X (in the centralizer). -/
 lemma Z_on_qubit2_not_mem_subgroup : Z_on_qubit2 ∉ subgroup := by

--- a/QEC/Stabilizer/Codes/Small/CSS_4_1_2.lean
+++ b/QEC/Stabilizer/Codes/Small/CSS_4_1_2.lean
@@ -130,29 +130,9 @@ lemma XGenerators_are_XType :
 and 1: count 2 (even) ⇒ they commute. `S_Z2 = IIZZ` overlaps `S_X1` at
 qubits 2 and 3: count 2 (even) ⇒ they commute. -/
 
-private lemma S_Z1_comm_S_X1 : S_Z1 * S_X1 = S_X1 * S_Z1 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 4) S_Z1.operators S_X1.operators)) =
-        ({0, 1} : Finset (Fin 4)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, S_Z1, S_X1,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma S_Z1_comm_S_X1 : S_Z1 * S_X1 = S_X1 * S_Z1 := by decide
 
-private lemma S_Z2_comm_S_X1 : S_Z2 * S_X1 = S_X1 * S_Z2 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 4) S_Z2.operators S_X1.operators)) =
-        ({2, 3} : Finset (Fin 4)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, S_Z2, S_X1,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma S_Z2_comm_S_X1 : S_Z2 * S_X1 = S_X1 * S_Z2 := by decide
 
 /-- Every Z-generator commutes with every X-generator. -/
 lemma ZGenerators_commute_XGenerators :
@@ -279,33 +259,11 @@ def logicalZ : NQubitPauliGroupElement 4 := σ[ZIZI]
 
 /-- `X̄ = XXII` and `Z̄ = ZIZI` anticommute (overlap at qubit 0 only — odd parity). -/
 theorem logicalX_anticommutes_logicalZ :
-    NQubitPauliGroupElement.Anticommute logicalX logicalZ := by
-  classical
-  pauli_anticomm_odd_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 4)
-              logicalX.operators logicalZ.operators)) =
-        ({0} : Finset (Fin 4)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalX, logicalZ,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+    NQubitPauliGroupElement.Anticommute logicalX logicalZ := by decide
 
 /-! ### §12 — Logicals in centralizer (per-generator commutation lemmas) -/
 
-private lemma logicalX_commutes_S_Z1 : logicalX * S_Z1 = S_Z1 * logicalX := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 4)
-              logicalX.operators S_Z1.operators)) =
-        ({0, 1} : Finset (Fin 4)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalX, S_Z1,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma logicalX_commutes_S_Z1 : logicalX * S_Z1 = S_Z1 * logicalX := by decide
 
 private lemma logicalX_commutes_S_Z2 : logicalX * S_Z2 = S_Z2 * logicalX := by
   pauli_comm_componentwise [logicalX, S_Z2]
@@ -319,18 +277,7 @@ private lemma logicalZ_commutes_S_Z1 : logicalZ * S_Z1 = S_Z1 * logicalZ := by
 private lemma logicalZ_commutes_S_Z2 : logicalZ * S_Z2 = S_Z2 * logicalZ := by
   pauli_comm_componentwise [logicalZ, S_Z2]
 
-private lemma logicalZ_commutes_S_X1 : logicalZ * S_X1 = S_X1 * logicalZ := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 4)
-              logicalZ.operators S_X1.operators)) =
-        ({0, 2} : Finset (Fin 4)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalZ, S_X1,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma logicalZ_commutes_S_X1 : logicalZ * S_X1 = S_X1 * logicalZ := by decide
 
 /-- `X̄ = XXII` commutes with every element of the stabilizer. -/
 theorem logicalX_mem_centralizer :

--- a/QEC/Stabilizer/Codes/Small/FiveQubit_5_1_3.lean
+++ b/QEC/Stabilizer/Codes/Small/FiveQubit_5_1_3.lean
@@ -76,35 +76,12 @@ lints inherited from upstream files. See
 
 open NQubitPauliGroupElement
 
-/-! ## Local Decidable instances
+/-! ## §1 — Generators (cyclic shifts of `XZZXI`)
 
-These are scoped to this file (via `local instance`) because adding them
-to the global instance pool — as `PauliGroup/Commutation.lean` originally
-did during Stage 4 — disrupted the typeclass synthesis of the
-`weight_2_pairs_span_coeffs` `native_decide` proof in `RotatedSurfaceCode3.lean`.
-The standard Pi-decidability chain in that proof must remain primary, so
-we localise the group-element-level instances here, where the [[5,1,3]]
-distance proof needs them. -/
-
-/-- `DecidableEq` on `NQubitPauliGroupElement n` via field-wise decision.
-File-local to keep RotatedSurfaceCode3.lean's synthesis path intact. -/
-local instance instDecidableEqNQubitPauliGroupElement (n : ℕ) :
-    DecidableEq (NQubitPauliGroupElement n) := fun p q =>
-  decidable_of_iff (p.phasePower = q.phasePower ∧ p.operators = q.operators)
-    ⟨fun ⟨h1, h2⟩ => by cases p; cases q; simp_all,
-     fun h => by cases h; exact ⟨rfl, rfl⟩⟩
-
-/-- `Decidable (Anticommute p q)`: unfolds to equality of two Pauli group
-elements and decides via the local `DecidableEq` above. Marked
-`noncomputable` because `*` on `NQubitPauliGroupElement` is noncomputable,
-but `decide` still reduces through the kernel. (`native_decide` does not
-work — prefer `decide`.) -/
-noncomputable local instance decidableAnticommute
-(p q : NQubitPauliGroupElement 5) :
-    Decidable (NQubitPauliGroupElement.Anticommute p q) :=
-  show Decidable (p * q = NQubitPauliGroupElement.minusOne 5 * (q * p)) from inferInstance
-
-/-! ## §1 — Generators (cyclic shifts of `XZZXI`) -/
+(The `DecidableEq (NQubitPauliGroupElement n)` and `Decidable (Anticommute p q)`
+instances this file's tables lean on were once file-local here; they are global in
+`PauliGroup/Commutation.lean` now that `RotatedSurfaceCode3.lean`'s `native_decide`
+proof — the reason for the localisation — is parked off `main`.) -/
 
 /-- First generator: `X Z Z X I` (positions 0..4). -/
 def g1 : NQubitPauliGroupElement 5 := σ[XZZXI]
@@ -142,81 +119,21 @@ both fail.
 
 Each pair has an even number of anticommuting qubit positions (count = 2
 in every case — see `informal_spec.md` for the explicit Finsets).
-Closed by `pauli_comm_even_anticommutes` + explicit Finset computation,
-mirroring `Steane7.lean`'s `Zᵢ_comm_Xⱼ` pattern.
+Closed by `decide` through the global `DecidableEq (NQubitPauliGroupElement n)`
+instance, mirroring `Steane7.lean`'s `Zᵢ_comm_Xⱼ` pattern.
 -/
 
-private lemma g1_comm_g2 : g1 * g2 = g2 * g1 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 5) g1.operators g2.operators)) =
-        ({1, 3} : Finset (Fin 5)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, g1, g2,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma g1_comm_g2 : g1 * g2 = g2 * g1 := by decide
 
-private lemma g1_comm_g3 : g1 * g3 = g3 * g1 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 5) g1.operators g3.operators)) =
-        ({2, 3} : Finset (Fin 5)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, g1, g3,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma g1_comm_g3 : g1 * g3 = g3 * g1 := by decide
 
-private lemma g1_comm_g4 : g1 * g4 = g4 * g1 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 5) g1.operators g4.operators)) =
-        ({0, 1} : Finset (Fin 5)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, g1, g4,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma g1_comm_g4 : g1 * g4 = g4 * g1 := by decide
 
-private lemma g2_comm_g3 : g2 * g3 = g3 * g2 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 5) g2.operators g3.operators)) =
-        ({2, 4} : Finset (Fin 5)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, g2, g3,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma g2_comm_g3 : g2 * g3 = g3 * g2 := by decide
 
-private lemma g2_comm_g4 : g2 * g4 = g4 * g2 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 5) g2.operators g4.operators)) =
-        ({3, 4} : Finset (Fin 5)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, g2, g4,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma g2_comm_g4 : g2 * g4 = g4 * g2 := by decide
 
-private lemma g3_comm_g4 : g3 * g4 = g4 * g3 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 5) g3.operators g4.operators)) =
-        ({0, 3} : Finset (Fin 5)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, g3, g4,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma g3_comm_g4 : g3 * g4 = g4 * g3 := by decide
 
 /-! ## §5 — All-pair commutation (full stabilizer abelianness) -/
 
@@ -349,109 +266,21 @@ Eight per-generator commutation lemmas (4 for `logicalX`, 4 for
 Finset. Then bundled via `Subgroup.forall_comm_closure_iff`.
 -/
 
-private lemma logicalX_commutes_g1 : logicalX * g1 = g1 * logicalX := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 5) logicalX.operators g1.operators)) =
-        ({1, 2} : Finset (Fin 5)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalX, g1,
-        NQubitPauliOperator.X, NQubitPauliOperator.set, NQubitPauliOperator.identity,
-        PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma logicalX_commutes_g1 : logicalX * g1 = g1 * logicalX := by decide
 
-private lemma logicalX_commutes_g2 : logicalX * g2 = g2 * logicalX := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 5) logicalX.operators g2.operators)) =
-        ({2, 3} : Finset (Fin 5)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalX, g2,
-        NQubitPauliOperator.X, NQubitPauliOperator.set, NQubitPauliOperator.identity,
-        PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma logicalX_commutes_g2 : logicalX * g2 = g2 * logicalX := by decide
 
-private lemma logicalX_commutes_g3 : logicalX * g3 = g3 * logicalX := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 5) logicalX.operators g3.operators)) =
-        ({3, 4} : Finset (Fin 5)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalX, g3,
-        NQubitPauliOperator.X, NQubitPauliOperator.set, NQubitPauliOperator.identity,
-        PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma logicalX_commutes_g3 : logicalX * g3 = g3 * logicalX := by decide
 
-private lemma logicalX_commutes_g4 : logicalX * g4 = g4 * logicalX := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 5) logicalX.operators g4.operators)) =
-        ({0, 4} : Finset (Fin 5)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalX, g4,
-        NQubitPauliOperator.X, NQubitPauliOperator.set, NQubitPauliOperator.identity,
-        PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma logicalX_commutes_g4 : logicalX * g4 = g4 * logicalX := by decide
 
-private lemma logicalZ_commutes_g1 : logicalZ * g1 = g1 * logicalZ := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 5) logicalZ.operators g1.operators)) =
-        ({0, 3} : Finset (Fin 5)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalZ, g1,
-        NQubitPauliOperator.Z, NQubitPauliOperator.set, NQubitPauliOperator.identity,
-        PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma logicalZ_commutes_g1 : logicalZ * g1 = g1 * logicalZ := by decide
 
-private lemma logicalZ_commutes_g2 : logicalZ * g2 = g2 * logicalZ := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 5) logicalZ.operators g2.operators)) =
-        ({1, 4} : Finset (Fin 5)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalZ, g2,
-        NQubitPauliOperator.Z, NQubitPauliOperator.set, NQubitPauliOperator.identity,
-        PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma logicalZ_commutes_g2 : logicalZ * g2 = g2 * logicalZ := by decide
 
-private lemma logicalZ_commutes_g3 : logicalZ * g3 = g3 * logicalZ := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 5) logicalZ.operators g3.operators)) =
-        ({0, 2} : Finset (Fin 5)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalZ, g3,
-        NQubitPauliOperator.Z, NQubitPauliOperator.set, NQubitPauliOperator.identity,
-        PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma logicalZ_commutes_g3 : logicalZ * g3 = g3 * logicalZ := by decide
 
-private lemma logicalZ_commutes_g4 : logicalZ * g4 = g4 * logicalZ := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 5) logicalZ.operators g4.operators)) =
-        ({1, 3} : Finset (Fin 5)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalZ, g4,
-        NQubitPauliOperator.Z, NQubitPauliOperator.set, NQubitPauliOperator.identity,
-        PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma logicalZ_commutes_g4 : logicalZ * g4 = g4 * logicalZ := by decide
 
 /-- `X̄` commutes with every element of the stabilizer. -/
 theorem logicalX_mem_centralizer :
@@ -562,11 +391,7 @@ lemma logicalX_w3_eq_mul : logicalX_w3 = logicalX * g1 := by
 /-- `logicalX_w3` anticommutes with `logicalZ`. By the parity criterion, the
 overlap pattern `IYYIX` vs `ZZZZZ` anticommutes at qubits 1, 2, 4 (odd count). -/
 private lemma logicalX_w3_anticomm_logicalZ :
-    NQubitPauliGroupElement.Anticommute logicalX_w3 logicalZ := by
-  change logicalX_w3 * logicalZ = NQubitPauliGroupElement.minusOne 5 * (logicalZ * logicalX_w3)
-  apply NQubitPauliGroupElement.ext
-  · decide
-  · funext i; fin_cases i <;> decide
+    NQubitPauliGroupElement.Anticommute logicalX_w3 logicalZ := by decide
 
 /-- `logicalX_w3 ∈ centralizer (stabilizerCode.toStabilizerGroup)`. Use the
 equivalence `logicalX_w3 = logicalX * g1`: `logicalX` is in the centralizer

--- a/QEC/Stabilizer/Codes/Small/FourQubit_4_2_2.lean
+++ b/QEC/Stabilizer/Codes/Small/FourQubit_4_2_2.lean
@@ -106,15 +106,7 @@ lemma XGenerators_are_XType :
 `ZZZZ` and `XXXX` overlap at all 4 qubits, so they anticommute pairwise at all 4
 positions — count is 4 (even) ⇒ commute. -/
 
-private lemma Z1_comm_X1 : Z1 * X1 = X1 * Z1 := by
-  classical
-  pauli_comm_even_anticommutes
-  let p := NQubitPauliGroupElement.anticommutesAt (n := 4) Z1.operators X1.operators
-  have hfilter : (Finset.univ.filter p) = ({0, 1, 2, 3} : Finset (Fin 4)) := by
-    ext i; fin_cases i <;>
-      simp [p, NQubitPauliGroupElement.anticommutesAt, Z1, X1, NQubitPauliOperator.set,
-        PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma Z1_comm_X1 : Z1 * X1 = X1 * Z1 := by decide
 
 /-- The unique Z-generator commutes with the unique X-generator (the only cross
 case for this CSS code). -/
@@ -234,33 +226,11 @@ def logicalZ_2 : NQubitPauliGroupElement 4 := σ[IZIZ]
 
 /-- `X̄₁` and `Z̄₁` anticommute (overlap at qubit 3 only — odd parity). -/
 theorem logicalX_1_anticommutes_logicalZ_1 :
-    NQubitPauliGroupElement.Anticommute logicalX_1 logicalZ_1 := by
-  classical
-  pauli_anticomm_odd_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 4)
-              logicalX_1.operators logicalZ_1.operators)) =
-        ({3} : Finset (Fin 4)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalX_1, logicalZ_1,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+    NQubitPauliGroupElement.Anticommute logicalX_1 logicalZ_1 := by decide
 
 /-- `X̄₂` and `Z̄₂` anticommute (overlap at qubit 3 only — odd parity). -/
 theorem logicalX_2_anticommutes_logicalZ_2 :
-    NQubitPauliGroupElement.Anticommute logicalX_2 logicalZ_2 := by
-  classical
-  pauli_anticomm_odd_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 4)
-              logicalX_2.operators logicalZ_2.operators)) =
-        ({3} : Finset (Fin 4)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalX_2, logicalZ_2,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+    NQubitPauliGroupElement.Anticommute logicalX_2 logicalZ_2 := by decide
 
 /-! ### Off-diagonal logical commutation (the k = 2 novelty) -/
 
@@ -271,33 +241,11 @@ theorem logicalX_1_commutes_logicalX_2 :
 
 /-- `X̄₁` and `Z̄₂` commute (anticommute at qubits 1 and 3, count 2 = even). -/
 theorem logicalX_1_commutes_logicalZ_2 :
-    logicalX_1 * logicalZ_2 = logicalZ_2 * logicalX_1 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 4)
-              logicalX_1.operators logicalZ_2.operators)) =
-        ({1, 3} : Finset (Fin 4)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalX_1, logicalZ_2,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+    logicalX_1 * logicalZ_2 = logicalZ_2 * logicalX_1 := by decide
 
 /-- `X̄₂` and `Z̄₁` commute (anticommute at qubits 2 and 3, count 2 = even). -/
 theorem logicalX_2_commutes_logicalZ_1 :
-    logicalX_2 * logicalZ_1 = logicalZ_1 * logicalX_2 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 4)
-              logicalX_2.operators logicalZ_1.operators)) =
-        ({2, 3} : Finset (Fin 4)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalX_2, logicalZ_1,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+    logicalX_2 * logicalZ_1 = logicalZ_1 * logicalX_2 := by decide
 
 /-- `Z̄₁` and `Z̄₂` commute (both Z-type — trivial). -/
 theorem logicalZ_1_commutes_logicalZ_2 :
@@ -306,34 +254,12 @@ theorem logicalZ_1_commutes_logicalZ_2 :
 
 /-! ### Logical operators are in the centralizer -/
 
-private lemma logicalX_1_commutes_Z1 : logicalX_1 * Z1 = Z1 * logicalX_1 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 4)
-              logicalX_1.operators Z1.operators)) =
-        ({1, 3} : Finset (Fin 4)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalX_1, Z1,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma logicalX_1_commutes_Z1 : logicalX_1 * Z1 = Z1 * logicalX_1 := by decide
 
 private lemma logicalX_1_commutes_X1 : logicalX_1 * X1 = X1 * logicalX_1 := by
   pauli_comm_componentwise [logicalX_1, X1]
 
-private lemma logicalX_2_commutes_Z1 : logicalX_2 * Z1 = Z1 * logicalX_2 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 4)
-              logicalX_2.operators Z1.operators)) =
-        ({2, 3} : Finset (Fin 4)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalX_2, Z1,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma logicalX_2_commutes_Z1 : logicalX_2 * Z1 = Z1 * logicalX_2 := by decide
 
 private lemma logicalX_2_commutes_X1 : logicalX_2 * X1 = X1 * logicalX_2 := by
   pauli_comm_componentwise [logicalX_2, X1]
@@ -341,34 +267,12 @@ private lemma logicalX_2_commutes_X1 : logicalX_2 * X1 = X1 * logicalX_2 := by
 private lemma logicalZ_1_commutes_Z1 : logicalZ_1 * Z1 = Z1 * logicalZ_1 := by
   pauli_comm_componentwise [logicalZ_1, Z1]
 
-private lemma logicalZ_1_commutes_X1 : logicalZ_1 * X1 = X1 * logicalZ_1 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 4)
-              logicalZ_1.operators X1.operators)) =
-        ({2, 3} : Finset (Fin 4)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalZ_1, X1,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma logicalZ_1_commutes_X1 : logicalZ_1 * X1 = X1 * logicalZ_1 := by decide
 
 private lemma logicalZ_2_commutes_Z1 : logicalZ_2 * Z1 = Z1 * logicalZ_2 := by
   pauli_comm_componentwise [logicalZ_2, Z1]
 
-private lemma logicalZ_2_commutes_X1 : logicalZ_2 * X1 = X1 * logicalZ_2 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 4)
-              logicalZ_2.operators X1.operators)) =
-        ({1, 3} : Finset (Fin 4)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalZ_2, X1,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma logicalZ_2_commutes_X1 : logicalZ_2 * X1 = X1 * logicalZ_2 := by decide
 
 /-- `X̄₁ = IXIX` commutes with every element of the stabilizer (vs. `ZZZZ` even
 overlap at qubits 1, 3; vs. `XXXX` all X — both commute). -/

--- a/QEC/Stabilizer/Codes/Small/Shor9.lean
+++ b/QEC/Stabilizer/Codes/Small/Shor9.lean
@@ -108,153 +108,34 @@ lemma XGenerators_are_XType :
 /-!
 ## Commutation: Z generators commute with X generators
 
-We use the parity characterization from `PauliGroup/Commutation.lean` and discharge the
-finite parity goals by explicitly identifying the anticommute positions (n = 9).
+Each pair is closed by `decide` through the global
+`DecidableEq (NQubitPauliGroupElement n)` instance from `PauliGroup/Commutation.lean`
+(the even-overlap reasoning is `commutes_iff_even_anticommutes`).
 -/
 
-private lemma M1_comm_M7 : M1 * M7 = M7 * M1 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 9) M1.operators M7.operators)) =
-        ({0, 1} : Finset (Fin 9)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, M1, M7,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  simp [hfilter]
+private lemma M1_comm_M7 : M1 * M7 = M7 * M1 := by decide
 
-private lemma M1_comm_M8 : M1 * M8 = M8 * M1 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 9) M1.operators M8.operators)) =
-        (∅ : Finset (Fin 9)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, M1, M8,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  simp [hfilter]
+private lemma M1_comm_M8 : M1 * M8 = M8 * M1 := by decide
 
-private lemma M2_comm_M7 : M2 * M7 = M7 * M2 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 9) M2.operators M7.operators)) =
-        ({1, 2} : Finset (Fin 9)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, M2, M7,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  simp [hfilter]
+private lemma M2_comm_M7 : M2 * M7 = M7 * M2 := by decide
 
-private lemma M2_comm_M8 : M2 * M8 = M8 * M2 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 9) M2.operators M8.operators)) =
-        (∅ : Finset (Fin 9)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, M2, M8,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  simp [hfilter]
+private lemma M2_comm_M8 : M2 * M8 = M8 * M2 := by decide
 
-private lemma M3_comm_M7 : M3 * M7 = M7 * M3 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 9) M3.operators M7.operators)) =
-        ({3, 4} : Finset (Fin 9)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, M3, M7,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  simp [hfilter]
+private lemma M3_comm_M7 : M3 * M7 = M7 * M3 := by decide
 
-private lemma M3_comm_M8 : M3 * M8 = M8 * M3 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 9) M3.operators M8.operators)) =
-        ({3, 4} : Finset (Fin 9)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, M3, M8,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  simp [hfilter]
+private lemma M3_comm_M8 : M3 * M8 = M8 * M3 := by decide
 
-private lemma M4_comm_M7 : M4 * M7 = M7 * M4 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 9) M4.operators M7.operators)) =
-        ({4, 5} : Finset (Fin 9)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, M4, M7,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  simp [hfilter]
+private lemma M4_comm_M7 : M4 * M7 = M7 * M4 := by decide
 
-private lemma M4_comm_M8 : M4 * M8 = M8 * M4 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 9) M4.operators M8.operators)) =
-        ({4, 5} : Finset (Fin 9)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, M4, M8,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  simp [hfilter]
+private lemma M4_comm_M8 : M4 * M8 = M8 * M4 := by decide
 
-private lemma M5_comm_M7 : M5 * M7 = M7 * M5 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 9) M5.operators M7.operators)) =
-        (∅ : Finset (Fin 9)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, M5, M7,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  simp [hfilter]
+private lemma M5_comm_M7 : M5 * M7 = M7 * M5 := by decide
 
-private lemma M5_comm_M8 : M5 * M8 = M8 * M5 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 9) M5.operators M8.operators)) =
-        ({6, 7} : Finset (Fin 9)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, M5, M8,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  simp [hfilter]
+private lemma M5_comm_M8 : M5 * M8 = M8 * M5 := by decide
 
-private lemma M6_comm_M7 : M6 * M7 = M7 * M6 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 9) M6.operators M7.operators)) =
-        (∅ : Finset (Fin 9)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, M6, M7,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  simp [hfilter]
+private lemma M6_comm_M7 : M6 * M7 = M7 * M6 := by decide
 
-private lemma M6_comm_M8 : M6 * M8 = M8 * M6 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 9) M6.operators M8.operators)) =
-        ({7, 8} : Finset (Fin 9)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, M6, M8,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  simp [hfilter]
+private lemma M6_comm_M8 : M6 * M8 = M8 * M6 := by decide
 
 lemma ZGenerators_commute_XGenerators :
     ∀ z ∈ ZGenerators, ∀ x ∈ XGenerators, z * x = x * z := by

--- a/QEC/Stabilizer/Codes/Small/SixQubit_6_2_2.lean
+++ b/QEC/Stabilizer/Codes/Small/SixQubit_6_2_2.lean
@@ -156,53 +156,13 @@ Pairwise overlap counts (all even ⇒ all commute):
 - `S_Z2` vs `S_X2`: anti at {0,1,4,5}, count 4.
 -/
 
-private lemma S_Z1_comm_S_X1 : S_Z1 * S_X1 = S_X1 * S_Z1 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 6) S_Z1.operators S_X1.operators)) =
-        ({0, 1, 2, 3} : Finset (Fin 6)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, S_Z1, S_X1,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma S_Z1_comm_S_X1 : S_Z1 * S_X1 = S_X1 * S_Z1 := by decide
 
-private lemma S_Z1_comm_S_X2 : S_Z1 * S_X2 = S_X2 * S_Z1 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 6) S_Z1.operators S_X2.operators)) =
-        ({0, 1} : Finset (Fin 6)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, S_Z1, S_X2,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma S_Z1_comm_S_X2 : S_Z1 * S_X2 = S_X2 * S_Z1 := by decide
 
-private lemma S_Z2_comm_S_X1 : S_Z2 * S_X1 = S_X1 * S_Z2 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 6) S_Z2.operators S_X1.operators)) =
-        ({0, 1} : Finset (Fin 6)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, S_Z2, S_X1,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma S_Z2_comm_S_X1 : S_Z2 * S_X1 = S_X1 * S_Z2 := by decide
 
-private lemma S_Z2_comm_S_X2 : S_Z2 * S_X2 = S_X2 * S_Z2 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 6) S_Z2.operators S_X2.operators)) =
-        ({0, 1, 4, 5} : Finset (Fin 6)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, S_Z2, S_X2,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma S_Z2_comm_S_X2 : S_Z2 * S_X2 = S_X2 * S_Z2 := by decide
 
 /-- Every Z-generator commutes with every X-generator. -/
 lemma ZGenerators_commute_XGenerators :
@@ -340,33 +300,11 @@ def logicalZ_2 : NQubitPauliGroupElement 6 := σ[IIIIZZ]
 
 /-- `X̄_1 = IIXXII` and `Z̄_1 = ZIIZZI` anticommute (overlap at qubit 3 only — odd parity). -/
 theorem logicalX_1_anticommutes_logicalZ_1 :
-    NQubitPauliGroupElement.Anticommute logicalX_1 logicalZ_1 := by
-  classical
-  pauli_anticomm_odd_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 6)
-              logicalX_1.operators logicalZ_1.operators)) =
-        ({3} : Finset (Fin 6)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalX_1, logicalZ_1,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+    NQubitPauliGroupElement.Anticommute logicalX_1 logicalZ_1 := by decide
 
 /-- `X̄_2 = IXIXXI` and `Z̄_2 = IIIIZZ` anticommute (overlap at qubit 4 only — odd parity). -/
 theorem logicalX_2_anticommutes_logicalZ_2 :
-    NQubitPauliGroupElement.Anticommute logicalX_2 logicalZ_2 := by
-  classical
-  pauli_anticomm_odd_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 6)
-              logicalX_2.operators logicalZ_2.operators)) =
-        ({4} : Finset (Fin 6)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalX_2, logicalZ_2,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+    NQubitPauliGroupElement.Anticommute logicalX_2 logicalZ_2 := by decide
 
 /-! ### Off-diagonal logical commutation (the k = 2 novelty) -/
 
@@ -383,18 +321,7 @@ theorem logicalX_1_commutes_logicalZ_2 :
 
 /-- `X̄_2 = IXIXXI` and `Z̄_1 = ZIIZZI` commute (anticommute at qubits 3,4; count 2). -/
 theorem logicalX_2_commutes_logicalZ_1 :
-    logicalX_2 * logicalZ_1 = logicalZ_1 * logicalX_2 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 6)
-              logicalX_2.operators logicalZ_1.operators)) =
-        ({3, 4} : Finset (Fin 6)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalX_2, logicalZ_1,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+    logicalX_2 * logicalZ_1 = logicalZ_1 * logicalX_2 := by decide
 
 /-- `Z̄_1 = ZIIZZI` and `Z̄_2 = IIIIZZ` commute (both Z-type — trivial). -/
 theorem logicalZ_1_commutes_logicalZ_2 :
@@ -416,18 +343,7 @@ with an explicit filter Finset. Supports of the filter Finsets:
 | `Z̄_2=IIIIZZ` (q4,5) | both Z | both Z | ∅, 0 | {4,5}, 2 |
 -/
 
-private lemma logicalX_1_commutes_S_Z1 : logicalX_1 * S_Z1 = S_Z1 * logicalX_1 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 6)
-              logicalX_1.operators S_Z1.operators)) =
-        ({2, 3} : Finset (Fin 6)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalX_1, S_Z1,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma logicalX_1_commutes_S_Z1 : logicalX_1 * S_Z1 = S_Z1 * logicalX_1 := by decide
 
 private lemma logicalX_1_commutes_S_Z2 : logicalX_1 * S_Z2 = S_Z2 * logicalX_1 := by
   pauli_comm_componentwise [logicalX_1, S_Z2]
@@ -438,31 +354,9 @@ private lemma logicalX_1_commutes_S_X1 : logicalX_1 * S_X1 = S_X1 * logicalX_1 :
 private lemma logicalX_1_commutes_S_X2 : logicalX_1 * S_X2 = S_X2 * logicalX_1 := by
   pauli_comm_componentwise [logicalX_1, S_X2]
 
-private lemma logicalX_2_commutes_S_Z1 : logicalX_2 * S_Z1 = S_Z1 * logicalX_2 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 6)
-              logicalX_2.operators S_Z1.operators)) =
-        ({1, 3} : Finset (Fin 6)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalX_2, S_Z1,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma logicalX_2_commutes_S_Z1 : logicalX_2 * S_Z1 = S_Z1 * logicalX_2 := by decide
 
-private lemma logicalX_2_commutes_S_Z2 : logicalX_2 * S_Z2 = S_Z2 * logicalX_2 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 6)
-              logicalX_2.operators S_Z2.operators)) =
-        ({1, 4} : Finset (Fin 6)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalX_2, S_Z2,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma logicalX_2_commutes_S_Z2 : logicalX_2 * S_Z2 = S_Z2 * logicalX_2 := by decide
 
 private lemma logicalX_2_commutes_S_X1 : logicalX_2 * S_X1 = S_X1 * logicalX_2 := by
   pauli_comm_componentwise [logicalX_2, S_X1]
@@ -476,31 +370,9 @@ private lemma logicalZ_1_commutes_S_Z1 : logicalZ_1 * S_Z1 = S_Z1 * logicalZ_1 :
 private lemma logicalZ_1_commutes_S_Z2 : logicalZ_1 * S_Z2 = S_Z2 * logicalZ_1 := by
   pauli_comm_componentwise [logicalZ_1, S_Z2]
 
-private lemma logicalZ_1_commutes_S_X1 : logicalZ_1 * S_X1 = S_X1 * logicalZ_1 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 6)
-              logicalZ_1.operators S_X1.operators)) =
-        ({0, 3} : Finset (Fin 6)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalZ_1, S_X1,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma logicalZ_1_commutes_S_X1 : logicalZ_1 * S_X1 = S_X1 * logicalZ_1 := by decide
 
-private lemma logicalZ_1_commutes_S_X2 : logicalZ_1 * S_X2 = S_X2 * logicalZ_1 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 6)
-              logicalZ_1.operators S_X2.operators)) =
-        ({0, 4} : Finset (Fin 6)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalZ_1, S_X2,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma logicalZ_1_commutes_S_X2 : logicalZ_1 * S_X2 = S_X2 * logicalZ_1 := by decide
 
 private lemma logicalZ_2_commutes_S_Z1 : logicalZ_2 * S_Z1 = S_Z1 * logicalZ_2 := by
   pauli_comm_componentwise [logicalZ_2, S_Z1]
@@ -511,18 +383,7 @@ private lemma logicalZ_2_commutes_S_Z2 : logicalZ_2 * S_Z2 = S_Z2 * logicalZ_2 :
 private lemma logicalZ_2_commutes_S_X1 : logicalZ_2 * S_X1 = S_X1 * logicalZ_2 := by
   pauli_comm_componentwise [logicalZ_2, S_X1]
 
-private lemma logicalZ_2_commutes_S_X2 : logicalZ_2 * S_X2 = S_X2 * logicalZ_2 := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 6)
-              logicalZ_2.operators S_X2.operators)) =
-        ({4, 5} : Finset (Fin 6)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalZ_2, S_X2,
-        NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma logicalZ_2_commutes_S_X2 : logicalZ_2 * S_X2 = S_X2 * logicalZ_2 := by decide
 
 /-- `X̄_1 = IIXXII` commutes with every element of the stabilizer. -/
 theorem logicalX_1_mem_centralizer :

--- a/QEC/Stabilizer/Codes/Small/Steane7.lean
+++ b/QEC/Stabilizer/Codes/Small/Steane7.lean
@@ -113,98 +113,29 @@ lemma XGenerators_are_XType :
 /-!
 ## Cross-commutation: Z generators commute with X generators
 
-We use `commutes_iff_even_anticommutes` and compute the anticommute set explicitly.
+Each pair is closed by `decide` through the global
+`DecidableEq (NQubitPauliGroupElement n)` instance from `PauliGroup/Commutation.lean`
+(kernel reduction of both products; the even-overlap reasoning is
+`commutes_iff_even_anticommutes`).
 -/
 
-private lemma Z1_comm_X1 : Z1 * X1 = X1 * Z1 := by
-  classical
-  pauli_comm_even_anticommutes
-  let p := NQubitPauliGroupElement.anticommutesAt (n := 7) Z1.operators X1.operators
-  have hfilter : (Finset.univ.filter p) = ({0, 1, 2, 4} : Finset (Fin 7)) := by
-    ext i; fin_cases i <;>
-      simp [p, NQubitPauliGroupElement.anticommutesAt, Z1, X1, NQubitPauliOperator.set,
-        NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma Z1_comm_X1 : Z1 * X1 = X1 * Z1 := by decide
 
-private lemma Z1_comm_X2 : Z1 * X2 = X2 * Z1 := by
-  classical
-  pauli_comm_even_anticommutes
-  let p := NQubitPauliGroupElement.anticommutesAt (n := 7) Z1.operators X2.operators
-  have hfilter : (Finset.univ.filter p) = ({0, 1} : Finset (Fin 7)) := by
-    ext i; fin_cases i <;>
-      simp [p, NQubitPauliGroupElement.anticommutesAt, Z1, X2, NQubitPauliOperator.set,
-        NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma Z1_comm_X2 : Z1 * X2 = X2 * Z1 := by decide
 
-private lemma Z1_comm_X3 : Z1 * X3 = X3 * Z1 := by
-  classical
-  pauli_comm_even_anticommutes
-  let p := NQubitPauliGroupElement.anticommutesAt (n := 7) Z1.operators X3.operators
-  have hfilter : (Finset.univ.filter p) = ({0, 2} : Finset (Fin 7)) := by
-    ext i; fin_cases i <;>
-      simp [p, NQubitPauliGroupElement.anticommutesAt, Z1, X3, NQubitPauliOperator.set,
-        NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma Z1_comm_X3 : Z1 * X3 = X3 * Z1 := by decide
 
-private lemma Z2_comm_X1 : Z2 * X1 = X1 * Z2 := by
-  classical
-  pauli_comm_even_anticommutes
-  let p := NQubitPauliGroupElement.anticommutesAt (n := 7) Z2.operators X1.operators
-  have hfilter : (Finset.univ.filter p) = ({0, 1} : Finset (Fin 7)) := by
-    ext i; fin_cases i <;>
-      simp [p, NQubitPauliGroupElement.anticommutesAt, Z2, X1, NQubitPauliOperator.set,
-        NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma Z2_comm_X1 : Z2 * X1 = X1 * Z2 := by decide
 
-private lemma Z2_comm_X2 : Z2 * X2 = X2 * Z2 := by
-  classical
-  pauli_comm_even_anticommutes
-  let p := NQubitPauliGroupElement.anticommutesAt (n := 7) Z2.operators X2.operators
-  have hfilter : (Finset.univ.filter p) = ({0, 1, 3, 5} : Finset (Fin 7)) := by
-    ext i; fin_cases i <;>
-      simp [p, NQubitPauliGroupElement.anticommutesAt, Z2, X2, NQubitPauliOperator.set,
-        NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma Z2_comm_X2 : Z2 * X2 = X2 * Z2 := by decide
 
-private lemma Z2_comm_X3 : Z2 * X3 = X3 * Z2 := by
-  classical
-  pauli_comm_even_anticommutes
-  let p := NQubitPauliGroupElement.anticommutesAt (n := 7) Z2.operators X3.operators
-  have hfilter : (Finset.univ.filter p) = ({0, 3} : Finset (Fin 7)) := by
-    ext i; fin_cases i <;>
-      simp [p, NQubitPauliGroupElement.anticommutesAt, Z2, X3, NQubitPauliOperator.set,
-        NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma Z2_comm_X3 : Z2 * X3 = X3 * Z2 := by decide
 
-private lemma Z3_comm_X1 : Z3 * X1 = X1 * Z3 := by
-  classical
-  pauli_comm_even_anticommutes
-  let p := NQubitPauliGroupElement.anticommutesAt (n := 7) Z3.operators X1.operators
-  have hfilter : (Finset.univ.filter p) = ({0, 2} : Finset (Fin 7)) := by
-    ext i; fin_cases i <;>
-      simp [p, NQubitPauliGroupElement.anticommutesAt, Z3, X1, NQubitPauliOperator.set,
-        NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma Z3_comm_X1 : Z3 * X1 = X1 * Z3 := by decide
 
-private lemma Z3_comm_X2 : Z3 * X2 = X2 * Z3 := by
-  classical
-  pauli_comm_even_anticommutes
-  let p := NQubitPauliGroupElement.anticommutesAt (n := 7) Z3.operators X2.operators
-  have hfilter : (Finset.univ.filter p) = ({0, 3} : Finset (Fin 7)) := by
-    ext i; fin_cases i <;>
-      simp [p, NQubitPauliGroupElement.anticommutesAt, Z3, X2, NQubitPauliOperator.set,
-        NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma Z3_comm_X2 : Z3 * X2 = X2 * Z3 := by decide
 
-private lemma Z3_comm_X3 : Z3 * X3 = X3 * Z3 := by
-  classical
-  pauli_comm_even_anticommutes
-  let p := NQubitPauliGroupElement.anticommutesAt (n := 7) Z3.operators X3.operators
-  have hfilter : (Finset.univ.filter p) = ({0, 2, 3, 6} : Finset (Fin 7)) := by
-    ext i; fin_cases i <;>
-      simp [p, NQubitPauliGroupElement.anticommutesAt, Z3, X3, NQubitPauliOperator.set,
-        NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma Z3_comm_X3 : Z3 * X3 = X3 * Z3 := by decide
 
 /-- Every Z-generator commutes with every X-generator (even intersection of row supports). -/
 lemma ZGenerators_commute_XGenerators :
@@ -344,44 +275,11 @@ lemma logicalY_eq_phase2_allY :
 theorem logicalX_anticommutes_logicalZ : NQubitPauliGroupElement.Anticommute logicalX logicalZ :=
   NQubitPauliOperator.allX_allZ_anticommute 7 (by decide)
 
-private lemma logicalX_commutes_Z1 : logicalX * Z1 = Z1 * logicalX := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 7) logicalX.operators Z1.operators)) =
-        ({0, 1, 2, 4} : Finset (Fin 7)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalX, Z1,
-        NQubitPauliOperator.X, NQubitPauliOperator.set, NQubitPauliOperator.identity,
-        PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma logicalX_commutes_Z1 : logicalX * Z1 = Z1 * logicalX := by decide
 
-private lemma logicalX_commutes_Z2 : logicalX * Z2 = Z2 * logicalX := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 7) logicalX.operators Z2.operators)) =
-        ({0, 1, 3, 5} : Finset (Fin 7)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalX, Z2,
-        NQubitPauliOperator.X, NQubitPauliOperator.set, NQubitPauliOperator.identity,
-        PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma logicalX_commutes_Z2 : logicalX * Z2 = Z2 * logicalX := by decide
 
-private lemma logicalX_commutes_Z3 : logicalX * Z3 = Z3 * logicalX := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 7) logicalX.operators Z3.operators)) =
-        ({0, 2, 3, 6} : Finset (Fin 7)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalX, Z3,
-        NQubitPauliOperator.X, NQubitPauliOperator.set, NQubitPauliOperator.identity,
-        PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma logicalX_commutes_Z3 : logicalX * Z3 = Z3 * logicalX := by decide
 
 private lemma logicalX_commutes_X1 : logicalX * X1 = X1 * logicalX := by
   pauli_comm_componentwise [logicalX, X1, NQubitPauliOperator.X]
@@ -417,44 +315,11 @@ private lemma logicalZ_commutes_Z2 : logicalZ * Z2 = Z2 * logicalZ := by
 private lemma logicalZ_commutes_Z3 : logicalZ * Z3 = Z3 * logicalZ := by
   pauli_comm_componentwise [logicalZ, Z3, NQubitPauliOperator.Z]
 
-private lemma logicalZ_commutes_X1 : logicalZ * X1 = X1 * logicalZ := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 7) logicalZ.operators X1.operators)) =
-        ({0, 1, 2, 4} : Finset (Fin 7)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalZ, X1,
-        NQubitPauliOperator.Z, NQubitPauliOperator.set, NQubitPauliOperator.identity,
-        PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma logicalZ_commutes_X1 : logicalZ * X1 = X1 * logicalZ := by decide
 
-private lemma logicalZ_commutes_X2 : logicalZ * X2 = X2 * logicalZ := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 7) logicalZ.operators X2.operators)) =
-        ({0, 1, 3, 5} : Finset (Fin 7)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalZ, X2,
-        NQubitPauliOperator.Z, NQubitPauliOperator.set, NQubitPauliOperator.identity,
-        PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma logicalZ_commutes_X2 : logicalZ * X2 = X2 * logicalZ := by decide
 
-private lemma logicalZ_commutes_X3 : logicalZ * X3 = X3 * logicalZ := by
-  classical
-  pauli_comm_even_anticommutes
-  have hfilter :
-      (Finset.univ.filter
-            (NQubitPauliGroupElement.anticommutesAt (n := 7) logicalZ.operators X3.operators)) =
-        ({0, 2, 3, 6} : Finset (Fin 7)) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, logicalZ, X3,
-        NQubitPauliOperator.Z, NQubitPauliOperator.set, NQubitPauliOperator.identity,
-        PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma logicalZ_commutes_X3 : logicalZ * X3 = X3 * logicalZ := by decide
 
 /-- Logical Z commutes with every element of the stabilizer. -/
 theorem logicalZ_mem_centralizer : logicalZ ∈ centralizer stabilizerGroup := by

--- a/QEC/Stabilizer/Codes/_TEMPLATE.lean
+++ b/QEC/Stabilizer/Codes/_TEMPLATE.lean
@@ -182,25 +182,18 @@ machinery in §6 / §12 works directly without typing predicates.
 /-!
 ## §4 — Cross-commutation (CSS: Z-generators commute with X-generators)
 
-For each `(z, x) ∈ ZGenerators × XGenerators`, prove `z * x = x * z`. The
-shape of the proof is:
+For each `(z, x) ∈ ZGenerators × XGenerators`, prove `z * x = x * z`. For
+concrete literal generators this is one line per pair — the global
+`DecidableEq (NQubitPauliGroupElement n)` instance in `PauliGroup/Commutation.lean`
+lets the kernel decide the product equality directly:
 
 ```lean
-private lemma Z1_comm_X1 : Z1 * X1 = X1 * Z1 := by
-  classical
-  pauli_comm_even_anticommutes
-  -- residual goal: even number of anticommuting qubits between Z1 and X1
-  have hfilter :
-      (Finset.univ.filter
-        (NQubitPauliGroupElement.anticommutesAt Z1.operators X1.operators)) =
-      (<the explicit Finset>) := by
-    ext i; fin_cases i <;>
-      simp [Finset.mem_filter, NQubitPauliGroupElement.anticommutesAt, Z1, X1,
-            NQubitPauliOperator.set, NQubitPauliOperator.identity, PauliOperator.mulOp]
-  rw [hfilter]; decide
+private lemma Z1_comm_X1 : Z1 * X1 = X1 * Z1 := by decide
 ```
 
-Then bundle into a `∀`-statement:
+Keep one named `private lemma` per pair (do NOT try to batch all pairs into a
+single `decide` over the generator lists — the nested evaluation blows
+`maxRecDepth`/heartbeats). Then bundle into a `∀`-statement:
 
 ```lean
 lemma ZGenerators_commute_XGenerators :
@@ -214,19 +207,16 @@ lemma ZGenerators_commute_XGenerators :
       | …
 ```
 
-The `pauli_comm_even_anticommutes` tactic is in `PauliGroup/CommutationTactics.lean`;
-it converts the commutation goal into a parity-of-anticommuting-qubits goal,
-which is then closed by computing the explicit `Finset` and `decide`-ing its
-cardinality is even.
-
-**Performance note.** For small `n` (≤ 9 with few generators), the whole
-batch may close as a single `by decide` on the symplectic check-matrix
-product without spelling out the per-pair filter Finsets. Try that first.
-For larger codes, the explicit-Finset approach is cleaner and reliably fast.
+**Parametric variant.** When the generators are symbolic (toric, rotated
+surface, `Repetition/N`), `decide` does not apply; use
+`pauli_comm_even_anticommutes` (in `PauliGroup/CommutationTactics.lean`) to
+convert the commutation goal into a parity-of-anticommuting-qubits goal,
+identify the anticommute `Finset` explicitly, and `decide` its cardinality —
+the pattern the concrete codes used before the global instance existed.
 
 **Non-CSS variant.** Without Z/X partition, prove pairwise commutation for
-*every* pair of generators (`m * (m-1)/2` cases for `m` generators); fall
-back to the same `pauli_comm_even_anticommutes` machinery.
+*every* pair of generators (`m * (m-1)/2` cases for `m` generators) — same
+one-line `by decide` shape (see `FiveQubit_5_1_3.lean` §4).
 -/
 
 /-!
@@ -425,9 +415,14 @@ The `(by decide)` discharges `Odd n` (anticommutation requires odd `n` for
 the all-X/all-Z pair to anticommute — true for Steane7 (n=7), false for
 [[4,2,2]] (n=4)).
 
-**Non-all-X variant.** For partial-support logicals, use
-`pauli_comm_even_anticommutes` like in §4 and compute the anticommute
-filter explicitly.
+**Non-all-X variant.** For partial-support literal logicals, `by decide`
+closes both commutation and anticommutation goals directly (the
+`Decidable (Anticommute p q)` instance lives in `PauliGroup/Commutation.lean`):
+
+```lean
+theorem logicalX_anticommutes_logicalZ :
+    NQubitPauliGroupElement.Anticommute logicalX logicalZ := by decide
+```
 
 **`k ≥ 2` variant.** You need *four* relations per logical qubit *pair*:
 
@@ -499,8 +494,8 @@ theorem logicalX_mem_centralizer :
    scope, both `_root_.mul_assoc` and `NQubitPauliGroupElement.mul_assoc`
    resolve. Qualify with `_root_.mul_assoc` (same for `one_mul`, `mul_one`).
 3. **Per-generator commutation lemmas (e.g. `logicalX_commutes_Z1`) need
-   to be separate `private lemma`s** before this theorem — define them with
-   the same `pauli_comm_even_anticommutes` + filter pattern from §4.
+   to be separate `private lemma`s** before this theorem — one-line
+   `by decide` each, same shape as §4.
 -/
 
 /-!

--- a/QEC/Stabilizer/Foundations/PauliGroup/Commutation.lean
+++ b/QEC/Stabilizer/Foundations/PauliGroup/Commutation.lean
@@ -243,12 +243,30 @@ and finally `Decidable (Anticommute p q)`. The `Anticommute` instance is
 is noncomputable, but the kernel can still reduce `decide` through it.
 (`native_decide` does not work for the same reason — prefer `decide`.) -/
 
--- (Stage-4 follow-up for stab_5_1_3 added a `DecidableEq
--- (NQubitPauliGroupElement n)` and `Decidable Anticommute` here, but they
--- caused a downstream synthesis failure in RotatedSurfaceCode3's
--- native_decide proof. They are temporarily removed pending a clean
--- resolution. stab_5_1_3's distance proof currently DOES NOT BUILD
--- against this configuration — needs refactor.)
+-- (History: these two instances were briefly global during Stage 4 of stab_5_1_3,
+-- were localised into `FiveQubit_5_1_3.lean` after they disrupted typeclass
+-- synthesis in RotatedSurfaceCode3.lean's `native_decide` proof, and are global
+-- again now that that proof is parked off `main` and `native_decide` is banned.
+-- If the parked branch `claude/z3z6-parked` is ever revived, its `native_decide`
+-- proofs will need re-checking against this instance pool.)
+
+/-- `DecidableEq` on `NQubitPauliGroupElement n` via field-wise decision, computable
+through the `DecidableEq (NQubitPauliOperator n)` instance from `Representation.lean`.
+Besides equality goals, this is what lets `decide` close concrete commutation checks
+`p * q = q * p` on literal elements — the pairwise-commutation lemmas of the concrete
+codes are one-line `by decide` proofs through this instance. -/
+instance instDecidableEq : DecidableEq (NQubitPauliGroupElement n) := fun p q =>
+  decidable_of_iff (p.phasePower = q.phasePower ∧ p.operators = q.operators)
+    ⟨fun ⟨h1, h2⟩ => by cases p; cases q; simp_all,
+     fun h => by cases h; exact ⟨rfl, rfl⟩⟩
+
+/-- `Decidable (Anticommute p q)`: `Anticommute` unfolds to an equality of two Pauli
+group elements, decided via `instDecidableEq`. Marked `noncomputable` because `*` on
+`NQubitPauliGroupElement` is noncomputable; `decide` still reduces through the
+kernel. (`native_decide` does not work for the same reason — prefer `decide`.) -/
+noncomputable instance instDecidableAnticommute (p q : NQubitPauliGroupElement n) :
+    Decidable (Anticommute p q) :=
+  show Decidable (p * q = minusOne n * (q * p)) from inferInstance
 
 /-- Anticommutation reduces to the mulOp phase differing by 2 (mod 4). -/
 lemma anticommutes_iff_mulOp_phasePower (p q : NQubitPauliGroupElement n) :


### PR DESCRIPTION
**Stacked on #73** (base is that PR's branch; GitHub will retarget to `main` when #73 merges).

## What

Makes concrete commutation checks decidable, then cashes that in across the literal code files: **+198/−927 lines**, no statement or name changes anywhere.

1. **Promote two instances to global** in [`PauliGroup/Commutation.lean`](https://github.com/Stavan-Jain/QECLean/blob/claude/pauli-decidable-commute/QEC/Stabilizer/Foundations/PauliGroup/Commutation.lean): the field-wise `DecidableEq (NQubitPauliGroupElement n)` and `Decidable (Anticommute p q)` (generalized from `n = 5` to all `n`). They had been quarantined as `local instance`s in `FiveQubit_5_1_3.lean` because they once disrupted typeclass synthesis in `RotatedSurfaceCode3.lean`'s `native_decide` proof — that proof is parked on `claude/z3z6-parked` and `native_decide` is banned, so the eviction reason is moot on `main`. The stale comment is replaced by a history note flagging the parked branch as the one place this could still bite.

2. **Sweep: 72 pairwise commutation/anticommutation lemmas become `by decide`** — every closed literal pair (generator×generator, logical×generator, logical×logical, logical anticommutation) in `Small/{Steane7, Shor9, FiveQubit_5_1_3, FourQubit_4_2_2, CSS_4_1_2, SixQubit_6_2_2}` and `Repetition/Three`. The old bodies were ~9–13 lines each (`pauli_comm_even_anticommutes` + explicit anticommute-`Finset` + `decide`). Kept as-is: the aggregate `∀`-lemmas (they reference the pair lemmas by name), the already-compact `pauli_comm_componentwise` one-liners, and the parameterized `weightOneAt_*` witness lemmas (free variables — not `decide`-able).

3. **Docs**: `_TEMPLATE.lean` §4/§11/§12 teach the one-line pattern (with the tactic+Finset approach kept as the parametric-family variant), and CLAUDE.md's helper entry is corrected — it had gone stale, claiming the `Anticommute` instance lived in `Commutation.lean` when it was actually file-local to FiveQubit.

## Measured constraints baked into the docs

- Per-pair `by decide` closes instantly at n = 7 and n = 9 with default budgets.
- Batching all pairs into one `decide` (`∀ p ∈ [...], ∀ q ∈ [...], …`) is **not** viable: `maxRecDepth` failure at 4096, whnf-heartbeat timeout at 65536. One named lemma per pair stays the pattern.

## Verification (the global-instance discipline from CLAUDE.md)

Full suite after the promotion, `LEAN_NUM_THREADS=3`: BB safe-floor leaves sequentially + full `lake build` (3476 jobs) + `QECLight` + `QECBlueprint` + `Playground.lean` + `scripts/AxiomCheck.lean` — axiom policy OK, 6179 declarations on exactly `[propext, Classical.choice, Quot.sound]` (count is lower than #73's 6247 because the deleted proof bodies carried ~70 auxiliary declarations). The build warning set is identical to `main`'s modulo line numbers — in particular the Toric/RotatedSurface `simp +decide` synthesis paths are unaffected, so the historical failure mode did not recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)