### PR TITLE
Notation pass: P[…] Pauli strings, ∂₁/∂₂/δ⁰, (L := L) cleanup, Code[[n, k, d]], |0101⟩ kets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,7 +280,10 @@ These are local to this codebase — search here before assuming mathlib has the
   **exactly** the literal `⟨phase, (NQubitPauliOperator.identity n).set i₀ op₀ …⟩`
   normal form (non-identity positions, increasing index order), so
   `rfl`/`decide`/`simp` behavior is identical to a hand-written `.set`-chain; a
-  delaborator displays literal-shaped elements back as `σ[…]` in goals. Concrete
+  delaborator displays literal-shaped elements back as `σ[…]` in goals. The
+  phase-less Pauli string is `P[…]` (`P[XZZXI] : NQubitPauliOperator 5`), which
+  elaborates to exactly the bare `.set` chain and displays back as `P[…]` (an
+  element with a non-literal phase shows as `⟨k, P[…]⟩`). Concrete
   literal codes (`Codes/Small/`, `Repetition/Three.lean`) use it; parametric
   families with symbolic indices (`Repetition/N.lean`, `Iceberg/N.lean`, toric)
   cannot.

--- a/Playground.lean
+++ b/Playground.lean
@@ -26,6 +26,12 @@ open Quantum.StabilizerGroup
 -- proved distance. (It is the repo's first non-CSS code.)
 #check FiveQubit_5_1_3.stabilizerCodeWithDistance
 
+-- The same object through the scoped `[[n, k, d]]` type notation: `Code[[5, 1, 3]]` is
+-- `StabilizerCodeWithDistance 5 1 3` (and `Code[[5, 1]]` is `StabilizerCode 5 1`). The
+-- `open Quantum.StabilizerGroup` above activates it.
+#check (FiveQubit_5_1_3.stabilizerCodeWithDistance : Code[[5, 1, 3]])
+#check (Steane7.stabilizerCode : Code[[7, 1]])
+
 -- The parametric toric code, for every `L ≥ 2`. (It lives under
 -- `Quantum.Stabilizer.Lattice`, not the `Quantum.StabilizerGroup` opened above.)
 #check @Quantum.Stabilizer.Lattice.toricHomologicalCode

--- a/QEC/Foundations/Basic.lean
+++ b/QEC/Foundations/Basic.lean
@@ -28,7 +28,8 @@ as a subtype.
 - **`NQubitBasis n`**: function type `Fin n → QubitBasis` for generic n-qubit systems
   (used with stabilizer / Pauli formalism).
 
-Standard kets **`ket0`**, **`ket1`** and basis vectors are defined here; `Gates.lean`
+Standard kets **`ket0`**, **`ket1`** and basis vectors are defined here, with the scoped
+Dirac notation `|0⟩`, `|01⟩`, `|0101⟩`, … (see the end of the file); `Gates.lean`
 builds unitary matrices on these spaces.
 -/
 
@@ -366,20 +367,75 @@ noncomputable def ket111 : ThreeQubitState :=
 /-!
 ## Dirac ket notation
 
-Scoped notation for the standard kets above, so proofs and statements can be written
-the way they are on paper: `|0⟩`, `|+⟩`, `|01⟩`, …
+Scoped notation for the computational-basis kets, so proofs and statements can be written
+the way they are on paper: `|0⟩`, `|+⟩`, `|01⟩`, `|0101⟩`, …
 
-Bring them into scope with `open scoped Quantum` (or `open Quantum`). They are
-`scoped` deliberately: the tokens begin with `|`, so an unqualified `open` would make
-`{x |0 ≤ x}`-style set-builders (no space after the bar) fail to parse in that file.
-Writing `{x | 0 ≤ x}` with the usual space is unaffected.
+`|b⟩` for a bitstring `b` of length `n ≥ 1` is the standard basis state of the
+corresponding `n`-qubit state type, i.e. exactly the pre-existing term for it:
+
+| length  | elaborates to                   | type              |
+|---------|---------------------------------|-------------------|
+| 1       | `ket0`, `ket1`                  | `Qubit`           |
+| 2       | `ket00`, …, `ket11`             | `TwoQubitState`   |
+| 3       | `ket000`, …, `ket111`           | `ThreeQubitState` |
+| `n ≥ 4` | `nQubitKet n ![b₀, …, bₙ₋₁]`    | `NQubitState n`   |
+
+The tuple-indexed state types stop at three qubits, so from four qubits on the only
+`n`-qubit state type is `NQubitState n`. `|+⟩` and `|-⟩` are the Hadamard-basis kets
+`ketPlus` and `ketMinus`.
+
+**Parsing.** The bitstring lexes as a single numeral token (`0101` is one `num`
+literal), and the macro reads that token's *source text* — `"0101"`, leading zeros
+included, where the literal's numeric value would lose them — accepting only the digits
+`0` and `1`. No new token is introduced: `|` and `⟩` are the ordinary bar and
+right-angle tokens, and the whole form is `atomic`, so `|x|` (absolute value) and
+`{x | p x}` (set-builder) parse exactly as before.
+
+Bring the notation into scope with `open scoped Quantum` (or `open Quantum`). It is
+`scoped` deliberately, like the rest of this file's notation, so that files which never
+mention kets do not get a term-level parser on the bar token. Each ket displays back as
+`|…⟩` in goals while the scope is open (`set_option pp.notation false` recovers the
+names).
 -/
 
-/-- Computational basis ket `|0⟩`, i.e. `ket0`. -/
-scoped notation "|0⟩" => ket0
+section KetNotation
 
-/-- Computational basis ket `|1⟩`, i.e. `ket1`. -/
-scoped notation "|1⟩" => ket1
+open Lean
+
+/-- `|b⟩` for a bitstring `b` (e.g. `|0⟩`, `|01⟩`, `|0101⟩`): the computational basis
+state of the `n`-qubit state type, `n` the length of `b` — `ket0`/`ket1` for one qubit,
+`ket00`…`ket11` for two, `ket000`…`ket111` for three, and `nQubitKet n ![b₀, …, bₙ₋₁]`
+from four qubits on. Scoped: `open scoped Quantum`. -/
+scoped syntax:max (name := ketLit) atomic("|" noWs num noWs "⟩") : term
+
+/-- The bit `0`/`1` as a numeral term (for the `![…]` of an `n ≥ 4` ket). -/
+private def bitLit (c : Char) : Term :=
+  ⟨(Syntax.mkNumLit (if c == '1' then "1" else "0")).raw⟩
+
+macro_rules
+  | `(|$b:num⟩) => do
+    let some s := b.raw.isLit? numLitKind
+      | Macro.throwErrorAt b "expected a bitstring of 0s and 1s"
+    unless s.all fun c => c == '0' || c == '1' do
+      Macro.throwErrorAt b s!"invalid ket bitstring '{s}': expected the digits 0 and 1 only"
+    match s with
+    | "0" => `(ket0)
+    | "1" => `(ket1)
+    | "00" => `(ket00)
+    | "01" => `(ket01)
+    | "10" => `(ket10)
+    | "11" => `(ket11)
+    | "000" => `(ket000)
+    | "001" => `(ket001)
+    | "010" => `(ket010)
+    | "011" => `(ket011)
+    | "100" => `(ket100)
+    | "101" => `(ket101)
+    | "110" => `(ket110)
+    | "111" => `(ket111)
+    | _ =>
+      let bits : Syntax.TSepArray `term "," := .ofElems (s.toList.toArray.map bitLit)
+      `(nQubitKet $(quote s.length) ![$bits,*])
 
 /-- Hadamard-basis ket `|+⟩ = (|0⟩ + |1⟩)/√2`, i.e. `ketPlus`. -/
 scoped notation "|+⟩" => ketPlus
@@ -387,16 +443,143 @@ scoped notation "|+⟩" => ketPlus
 /-- Hadamard-basis ket `|−⟩ = (|0⟩ − |1⟩)/√2`, i.e. `ketMinus`. -/
 scoped notation "|-⟩" => ketMinus
 
-/-- Two-qubit computational basis ket `|00⟩`, i.e. `ket00`. -/
-scoped notation "|00⟩" => ket00
+/-! ### Display
 
-/-- Two-qubit computational basis ket `|01⟩`, i.e. `ket01`. -/
-scoped notation "|01⟩" => ket01
+The named kets display back as `|…⟩` (one unexpander each), and an `n ≥ 4` ket
+`nQubitKet n ![b₀, …, bₙ₋₁]` with literal `n` and literal bits displays as
+`|b₀…bₙ₋₁⟩`. All of these are scoped with the notation. -/
 
-/-- Two-qubit computational basis ket `|10⟩`, i.e. `ket10`. -/
-scoped notation "|10⟩" => ket10
+/-- `ket0` displays as `|0⟩`. -/
+@[scoped app_unexpander Quantum.ket0] def unexpandKet0 : PrettyPrinter.Unexpander
+  | `($_:ident) => `(|0⟩)
+  | _ => throw ()
 
-/-- Two-qubit computational basis ket `|11⟩`, i.e. `ket11`. -/
-scoped notation "|11⟩" => ket11
+/-- `ket1` displays as `|1⟩`. -/
+@[scoped app_unexpander Quantum.ket1] def unexpandKet1 : PrettyPrinter.Unexpander
+  | `($_:ident) => `(|1⟩)
+  | _ => throw ()
+
+/-- `ket00` displays as `|00⟩`. -/
+@[scoped app_unexpander Quantum.ket00] def unexpandKet00 : PrettyPrinter.Unexpander
+  | `($_:ident) => `(|00⟩)
+  | _ => throw ()
+
+/-- `ket01` displays as `|01⟩`. -/
+@[scoped app_unexpander Quantum.ket01] def unexpandKet01 : PrettyPrinter.Unexpander
+  | `($_:ident) => `(|01⟩)
+  | _ => throw ()
+
+/-- `ket10` displays as `|10⟩`. -/
+@[scoped app_unexpander Quantum.ket10] def unexpandKet10 : PrettyPrinter.Unexpander
+  | `($_:ident) => `(|10⟩)
+  | _ => throw ()
+
+/-- `ket11` displays as `|11⟩`. -/
+@[scoped app_unexpander Quantum.ket11] def unexpandKet11 : PrettyPrinter.Unexpander
+  | `($_:ident) => `(|11⟩)
+  | _ => throw ()
+
+/-- `ket000` displays as `|000⟩`. -/
+@[scoped app_unexpander Quantum.ket000] def unexpandKet000 : PrettyPrinter.Unexpander
+  | `($_:ident) => `(|000⟩)
+  | _ => throw ()
+
+/-- `ket001` displays as `|001⟩`. -/
+@[scoped app_unexpander Quantum.ket001] def unexpandKet001 : PrettyPrinter.Unexpander
+  | `($_:ident) => `(|001⟩)
+  | _ => throw ()
+
+/-- `ket010` displays as `|010⟩`. -/
+@[scoped app_unexpander Quantum.ket010] def unexpandKet010 : PrettyPrinter.Unexpander
+  | `($_:ident) => `(|010⟩)
+  | _ => throw ()
+
+/-- `ket011` displays as `|011⟩`. -/
+@[scoped app_unexpander Quantum.ket011] def unexpandKet011 : PrettyPrinter.Unexpander
+  | `($_:ident) => `(|011⟩)
+  | _ => throw ()
+
+/-- `ket100` displays as `|100⟩`. -/
+@[scoped app_unexpander Quantum.ket100] def unexpandKet100 : PrettyPrinter.Unexpander
+  | `($_:ident) => `(|100⟩)
+  | _ => throw ()
+
+/-- `ket101` displays as `|101⟩`. -/
+@[scoped app_unexpander Quantum.ket101] def unexpandKet101 : PrettyPrinter.Unexpander
+  | `($_:ident) => `(|101⟩)
+  | _ => throw ()
+
+/-- `ket110` displays as `|110⟩`. -/
+@[scoped app_unexpander Quantum.ket110] def unexpandKet110 : PrettyPrinter.Unexpander
+  | `($_:ident) => `(|110⟩)
+  | _ => throw ()
+
+/-- `ket111` displays as `|111⟩`. -/
+@[scoped app_unexpander Quantum.ket111] def unexpandKet111 : PrettyPrinter.Unexpander
+  | `($_:ident) => `(|111⟩)
+  | _ => throw ()
+
+/-- A literal natural: a raw `Nat` literal or `OfNat.ofNat` of one. -/
+private def natLit? (e : Expr) : Option Nat :=
+  match e with
+  | .lit (.natVal k) => some k
+  | _ =>
+    if e.isAppOfArity ``OfNat.ofNat 3 then
+      match e.getArg! 1 with
+      | .lit (.natVal k) => some k
+      | _ => none
+    else none
+
+/-- The literal bits of a `![b₀, …, bₙ₋₁]` vector (a `Matrix.vecCons` chain ending in
+`Matrix.vecEmpty`), each a literal `0` or `1`; `none` on any other shape. -/
+private partial def vecBits? (e : Expr) (acc : Array Nat := #[]) : Option (Array Nat) :=
+  if e.isAppOfArity ``Matrix.vecCons 4 then do
+    let b ← natLit? (e.getArg! 2)
+    guard (b == 0 || b == 1)
+    vecBits? (e.getArg! 3) (acc.push b)
+  else if e.isAppOfArity ``Matrix.vecEmpty 1 then
+    some acc
+  else none
+
+open PrettyPrinter Delaborator SubExpr in
+/-- Delaborate `nQubitKet n ![b₀, …, bₙ₋₁]` with literal `n ≥ 4` and literal bits back to
+`|b₀…bₙ₋₁⟩`. Stays silent on any other shape, and on `n ≤ 3` (where `|…⟩` denotes the
+tuple-indexed kets, so displaying it would not round-trip). -/
+@[scoped app_delab Quantum.nQubitKet] def delabNQubitKet : Delab :=
+  whenPPOption getPPNotation <| whenNotPPOption getPPExplicit do
+    let e ← getExpr
+    unless e.isAppOfArity ``Quantum.nQubitKet 2 do failure
+    let some n := natLit? (e.getArg! 0) | failure
+    let some bits := vecBits? (e.getArg! 1) | failure
+    unless bits.size == n && 4 ≤ n do failure
+    let s := String.ofList (bits.toList.map fun b => if b == 1 then '1' else '0')
+    `(|$(Syntax.mkNumLit s)⟩)
+
+end KetNotation
+
+/-!
+### Round-trip tests
+
+Each ket literal elaborates to exactly the pre-existing term.
+-/
+
+section KetRoundTrip
+
+example : |0⟩ = ket0 := rfl
+example : |1⟩ = ket1 := rfl
+example : |00⟩ = ket00 := rfl
+example : |01⟩ = ket01 := rfl
+example : |10⟩ = ket10 := rfl
+example : |11⟩ = ket11 := rfl
+example : |000⟩ = ket000 := rfl
+example : |101⟩ = ket101 := rfl
+example : |111⟩ = ket111 := rfl
+example : |0101⟩ = nQubitKet 4 ![0, 1, 0, 1] := rfl
+example : |1000000⟩ = nQubitKet 7 ![1, 0, 0, 0, 0, 0, 0] := rfl
+example : (|0110⟩ : NQubitState 4).val = basisVec ![0, 1, 1, 0] := rfl
+example : |+⟩ = ketPlus := rfl
+example : |-⟩ = ketMinus := rfl
+
+end KetRoundTrip
 
 end Quantum

--- a/QEC/Foundations/Tensor.lean
+++ b/QEC/Foundations/Tensor.lean
@@ -190,78 +190,78 @@ noncomputable def X_q1q2q3_3 : ThreeQubitGate :=
   tensorGate X (tensorGate X X)
 
 /-- X ⊗ I ⊗ I: |000⟩ ↦ |100⟩. -/
-@[simp] lemma X_q1_3_on_ket000 : X_q1_3 • ket000 = ket100 := by
+@[simp] lemma X_q1_3_on_ket000 : X_q1_3 • |000⟩ = |100⟩ := by
   vec_expand_simp [X_q1_3, Matrix.mulVec, Xmat]
 
 /-- X ⊗ I ⊗ I: |001⟩ ↦ |101⟩. -/
-@[simp] lemma X_q1_3_on_ket001 : X_q1_3 • ket001 = ket101 := by
+@[simp] lemma X_q1_3_on_ket001 : X_q1_3 • |001⟩ = |101⟩ := by
   vec_expand_simp [X_q1_3, Matrix.mulVec, Xmat]
 
 /-- X ⊗ I ⊗ I: |010⟩ ↦ |110⟩. -/
-@[simp] lemma X_q1_3_on_ket010 : X_q1_3 • ket010 = ket110 := by
+@[simp] lemma X_q1_3_on_ket010 : X_q1_3 • |010⟩ = |110⟩ := by
   vec_expand_simp [X_q1_3, Matrix.mulVec, Xmat]
 
 /-- X ⊗ I ⊗ I: |011⟩ ↦ |111⟩. -/
-@[simp] lemma X_q1_3_on_ket011 : X_q1_3 • ket011 = ket111 := by
+@[simp] lemma X_q1_3_on_ket011 : X_q1_3 • |011⟩ = |111⟩ := by
   vec_expand_simp [X_q1_3, Matrix.mulVec, Xmat]
 
 /-- X ⊗ I ⊗ I: |100⟩ ↦ |000⟩. -/
-@[simp] lemma X_q1_3_on_ket100 : X_q1_3 • ket100 = ket000 := by
+@[simp] lemma X_q1_3_on_ket100 : X_q1_3 • |100⟩ = |000⟩ := by
   vec_expand_simp [X_q1_3, Matrix.mulVec, Xmat]
 
 /-- X ⊗ I ⊗ I: |101⟩ ↦ |001⟩. -/
-@[simp] lemma X_q1_3_on_ket101 : X_q1_3 • ket101 = ket001 := by
+@[simp] lemma X_q1_3_on_ket101 : X_q1_3 • |101⟩ = |001⟩ := by
   vec_expand_simp [X_q1_3, Matrix.mulVec, Xmat]
 
 /-- X ⊗ I ⊗ I: |110⟩ ↦ |010⟩. -/
-@[simp] lemma X_q1_3_on_ket110 : X_q1_3 • ket110 = ket010 := by
+@[simp] lemma X_q1_3_on_ket110 : X_q1_3 • |110⟩ = |010⟩ := by
   vec_expand_simp [X_q1_3, Matrix.mulVec, Xmat]
 
 /-- X ⊗ I ⊗ I: |111⟩ ↦ |011⟩. -/
-@[simp] lemma X_q1_3_on_ket111 : X_q1_3 • ket111 = ket011 := by
+@[simp] lemma X_q1_3_on_ket111 : X_q1_3 • |111⟩ = |011⟩ := by
   vec_expand_simp [X_q1_3, Matrix.mulVec, Xmat]
 
 /-- X ⊗ X ⊗ X: |000⟩ ↦ |111⟩. -/
-@[simp] lemma X_q1q2q3_on_ket000 : X_q1q2q3_3 • ket000 = ket111 := by
+@[simp] lemma X_q1q2q3_on_ket000 : X_q1q2q3_3 • |000⟩ = |111⟩ := by
   vec_expand_simp[X_q1q2q3_3, Matrix.mulVec, Xmat]
 
 /-- X ⊗ X ⊗ X: |111⟩ ↦ |000⟩. -/
-@[simp] lemma X_q1q2q3_on_ket111 : X_q1q2q3_3 • ket111 = ket000 := by
+@[simp] lemma X_q1q2q3_on_ket111 : X_q1q2q3_3 • |111⟩ = |000⟩ := by
   vec_expand_simp[X_q1q2q3_3, Matrix.mulVec, Xmat]
 
 /-! ### `X_q2_3` (I ⊗ X ⊗ I): flips the second bit -/
 
 
 /-- I ⊗ X ⊗ I: |000⟩ ↦ |010⟩. -/
-@[simp] lemma X_q2_3_on_ket000 : X_q2_3 • ket000 = ket010 := by
+@[simp] lemma X_q2_3_on_ket000 : X_q2_3 • |000⟩ = |010⟩ := by
   vec_expand_simp [X_q2_3, Matrix.mulVec, Xmat]
 
 /-- I ⊗ X ⊗ I: |001⟩ ↦ |011⟩. -/
-@[simp] lemma X_q2_3_on_ket001 : X_q2_3 • ket001 = ket011 := by
+@[simp] lemma X_q2_3_on_ket001 : X_q2_3 • |001⟩ = |011⟩ := by
   vec_expand_simp [X_q2_3, Matrix.mulVec, Xmat]
 
 /-- I ⊗ X ⊗ I: |010⟩ ↦ |000⟩. -/
-@[simp] lemma X_q2_3_on_ket010 : X_q2_3 • ket010 = ket000 := by
+@[simp] lemma X_q2_3_on_ket010 : X_q2_3 • |010⟩ = |000⟩ := by
   vec_expand_simp [X_q2_3, Matrix.mulVec, Xmat]
 
 /-- I ⊗ X ⊗ I: |011⟩ ↦ |001⟩. -/
-@[simp] lemma X_q2_3_on_ket011 : X_q2_3 • ket011 = ket001 := by
+@[simp] lemma X_q2_3_on_ket011 : X_q2_3 • |011⟩ = |001⟩ := by
   vec_expand_simp [X_q2_3, Matrix.mulVec, Xmat]
 
 /-- I ⊗ X ⊗ I: |100⟩ ↦ |110⟩. -/
-@[simp] lemma X_q2_3_on_ket100 : X_q2_3 • ket100 = ket110 := by
+@[simp] lemma X_q2_3_on_ket100 : X_q2_3 • |100⟩ = |110⟩ := by
   vec_expand_simp [X_q2_3, Matrix.mulVec, Xmat]
 
 /-- I ⊗ X ⊗ I: |101⟩ ↦ |111⟩. -/
-@[simp] lemma X_q2_3_on_ket101 : X_q2_3 • ket101 = ket111 := by
+@[simp] lemma X_q2_3_on_ket101 : X_q2_3 • |101⟩ = |111⟩ := by
   vec_expand_simp [X_q2_3, Matrix.mulVec, Xmat]
 
 /-- I ⊗ X ⊗ I: |110⟩ ↦ |100⟩. -/
-@[simp] lemma X_q2_3_on_ket110 : X_q2_3 • ket110 = ket100 := by
+@[simp] lemma X_q2_3_on_ket110 : X_q2_3 • |110⟩ = |100⟩ := by
   vec_expand_simp [X_q2_3, Matrix.mulVec, Xmat]
 
 /-- I ⊗ X ⊗ I: |111⟩ ↦ |101⟩. -/
-@[simp] lemma X_q2_3_on_ket111 : X_q2_3 • ket111 = ket101 := by
+@[simp] lemma X_q2_3_on_ket111 : X_q2_3 • |111⟩ = |101⟩ := by
   vec_expand_simp [X_q2_3, Matrix.mulVec, Xmat]
 
 
@@ -269,35 +269,35 @@ noncomputable def X_q1q2q3_3 : ThreeQubitGate :=
 
 
 /-- I ⊗ I ⊗ X: |000⟩ ↦ |001⟩. -/
-@[simp] lemma X_q3_3_on_ket000 : X_q3_3 • ket000 = ket001 := by
+@[simp] lemma X_q3_3_on_ket000 : X_q3_3 • |000⟩ = |001⟩ := by
   vec_expand_simp [X_q3_3, Matrix.mulVec, Xmat]
 
 /-- I ⊗ I ⊗ X: |001⟩ ↦ |000⟩. -/
-@[simp] lemma X_q3_3_on_ket001 : X_q3_3 • ket001 = ket000 := by
+@[simp] lemma X_q3_3_on_ket001 : X_q3_3 • |001⟩ = |000⟩ := by
   vec_expand_simp [X_q3_3, Matrix.mulVec, Xmat]
 
 /-- I ⊗ I ⊗ X: |010⟩ ↦ |011⟩. -/
-@[simp] lemma X_q3_3_on_ket010 : X_q3_3 • ket010 = ket011 := by
+@[simp] lemma X_q3_3_on_ket010 : X_q3_3 • |010⟩ = |011⟩ := by
   vec_expand_simp [X_q3_3, Matrix.mulVec, Xmat]
 
 /-- I ⊗ I ⊗ X: |011⟩ ↦ |010⟩. -/
-@[simp] lemma X_q3_3_on_ket011 : X_q3_3 • ket011 = ket010 := by
+@[simp] lemma X_q3_3_on_ket011 : X_q3_3 • |011⟩ = |010⟩ := by
   vec_expand_simp [X_q3_3, Matrix.mulVec, Xmat]
 
 /-- I ⊗ I ⊗ X: |100⟩ ↦ |101⟩. -/
-@[simp] lemma X_q3_3_on_ket100 : X_q3_3 • ket100 = ket101 := by
+@[simp] lemma X_q3_3_on_ket100 : X_q3_3 • |100⟩ = |101⟩ := by
   vec_expand_simp [X_q3_3, Matrix.mulVec, Xmat]
 
 /-- I ⊗ I ⊗ X: |101⟩ ↦ |100⟩. -/
-@[simp] lemma X_q3_3_on_ket101 : X_q3_3 • ket101 = ket100 := by
+@[simp] lemma X_q3_3_on_ket101 : X_q3_3 • |101⟩ = |100⟩ := by
   vec_expand_simp [X_q3_3, Matrix.mulVec, Xmat]
 
 /-- I ⊗ I ⊗ X: |110⟩ ↦ |111⟩. -/
-@[simp] lemma X_q3_3_on_ket110 : X_q3_3 • ket110 = ket111 := by
+@[simp] lemma X_q3_3_on_ket110 : X_q3_3 • |110⟩ = |111⟩ := by
   vec_expand_simp [X_q3_3, Matrix.mulVec, Xmat]
 
 /-- I ⊗ I ⊗ X: |111⟩ ↦ |110⟩. -/
-@[simp] lemma X_q3_3_on_ket111 : X_q3_3 • ket111 = ket110 := by
+@[simp] lemma X_q3_3_on_ket111 : X_q3_3 • |111⟩ = |110⟩ := by
   vec_expand_simp [X_q3_3, Matrix.mulVec, Xmat]
 
 /-- CNOT on qubits 1 (control) and 2 (target) of a 3-qubit register.
@@ -322,35 +322,35 @@ noncomputable def CNOT_q2_q3_3 : ThreeQubitGate :=
   tensorGate (1 : OneQubitGate) CNOT
 
 /-- CNOT with control q2 and target q3: |000⟩ ↦ |000⟩. -/
-@[simp] lemma CNOT_q2_q3_3_on_ket000 : CNOT_q2_q3_3 • ket000 = ket000 := by
+@[simp] lemma CNOT_q2_q3_3_on_ket000 : CNOT_q2_q3_3 • |000⟩ = |000⟩ := by
   vec_expand_simp [CNOT_q2_q3_3, Matrix.mulVec, CNOT, controllize, Xmat]
 
 /-- CNOT with control q2 and target q3: |001⟩ ↦ |001⟩. -/
-@[simp] lemma CNOT_q2_q3_3_on_ket001 : CNOT_q2_q3_3 • ket001 = ket001 := by
+@[simp] lemma CNOT_q2_q3_3_on_ket001 : CNOT_q2_q3_3 • |001⟩ = |001⟩ := by
   vec_expand_simp [CNOT_q2_q3_3,  Matrix.mulVec, CNOT, controllize, Xmat]
 
 /-- CNOT with control q2 and target q3: |010⟩ ↦ |011⟩. -/
-@[simp] lemma CNOT_q2_q3_3_on_ket010 : CNOT_q2_q3_3 • ket010 = ket011 := by
+@[simp] lemma CNOT_q2_q3_3_on_ket010 : CNOT_q2_q3_3 • |010⟩ = |011⟩ := by
   vec_expand_simp [CNOT_q2_q3_3,  Matrix.mulVec, CNOT, controllize, Xmat]
 
 /-- CNOT with control q2 and target q3: |011⟩ ↦ |010⟩. -/
-@[simp] lemma CNOT_q2_q3_3_on_ket011 : CNOT_q2_q3_3 • ket011 = ket010 := by
+@[simp] lemma CNOT_q2_q3_3_on_ket011 : CNOT_q2_q3_3 • |011⟩ = |010⟩ := by
   vec_expand_simp [CNOT_q2_q3_3,  Matrix.mulVec, CNOT, controllize, Xmat]
 
 /-- CNOT with control q2 and target q3: |100⟩ ↦ |100⟩. -/
-@[simp] lemma CNOT_q2_q3_3_on_ket100 : CNOT_q2_q3_3 • ket100 = ket100 := by
+@[simp] lemma CNOT_q2_q3_3_on_ket100 : CNOT_q2_q3_3 • |100⟩ = |100⟩ := by
   vec_expand_simp [CNOT_q2_q3_3,  Matrix.mulVec, CNOT, controllize, Xmat]
 
 /-- CNOT with control q2 and target q3: |101⟩ ↦ |101⟩. -/
-@[simp] lemma CNOT_q2_q3_3_on_ket101 : CNOT_q2_q3_3 • ket101 = ket101 := by
+@[simp] lemma CNOT_q2_q3_3_on_ket101 : CNOT_q2_q3_3 • |101⟩ = |101⟩ := by
   vec_expand_simp [CNOT_q2_q3_3,  Matrix.mulVec, CNOT, controllize, Xmat]
 
 /-- CNOT with control q2 and target q3: |110⟩ ↦ |111⟩. -/
-@[simp] lemma CNOT_q2_q3_3_on_ket110 : CNOT_q2_q3_3 • ket110 = ket111 := by
+@[simp] lemma CNOT_q2_q3_3_on_ket110 : CNOT_q2_q3_3 • |110⟩ = |111⟩ := by
   vec_expand_simp [CNOT_q2_q3_3,  Matrix.mulVec, CNOT, controllize, Xmat]
 
 /-- CNOT with control q2 and target q3: |111⟩ ↦ |110⟩. -/
-@[simp] lemma CNOT_q2_q3_3_on_ket111 : CNOT_q2_q3_3 • ket111 = ket110 := by
+@[simp] lemma CNOT_q2_q3_3_on_ket111 : CNOT_q2_q3_3 • |111⟩ = |110⟩ := by
   vec_expand_simp [CNOT_q2_q3_3,  Matrix.mulVec, CNOT, controllize, Xmat]
 
 end Quantum

--- a/QEC/Stabilizer/Codes/RotatedSurface/BoundaryMaps.lean
+++ b/QEC/Stabilizer/Codes/RotatedSurface/BoundaryMaps.lean
@@ -137,14 +137,38 @@ def rscBoundary1 (L : ℕ) :
     funext zf
     simp only [RingHom.id_apply, Pi.smul_apply, smul_eq_mul, Finset.mul_sum]
 
+/-!
+## Notation
+
+The scoped `RotatedSurfaceChain` notation renders the rotated-surface boundary
+maps as `∂₂ L c`, `∂₁ L c` (and `δ⁰ L s` for the Z-side cut map, declared next to
+it in `H1Dimension.lean`), mirroring the toric `ToricChain` scope. The lattice size
+stays an explicit argument, exactly as for the underlying constants, so the
+conversion is purely notational: `rscBoundary1` is still the declaration name
+for `simp [rscBoundary1]`, `unfold`, and lemma names. Enable with
+`open scoped RotatedSurfaceChain`.
+-/
+
+/-- `∂₂` is the rotated-surface face-boundary map `rscBoundary2 L`.
+Scoped: `open scoped RotatedSurfaceChain`. -/
+scoped[RotatedSurfaceChain] notation "∂₂" =>
+  Quantum.Stabilizer.Lattice.RotatedSurface.rscBoundary2
+
+/-- `∂₁` is the rotated-surface edge-boundary map `rscBoundary1 L`.
+Scoped: `open scoped RotatedSurfaceChain`. -/
+scoped[RotatedSurfaceChain] notation "∂₁" =>
+  Quantum.Stabilizer.Lattice.RotatedSurface.rscBoundary1
+
+open scoped RotatedSurfaceChain
+
 @[simp] theorem rscBoundary2_apply (L : ℕ) (c : XFaceIdx L → ZMod 2)
     (v : VtxIdx L) :
-    rscBoundary2 L c v =
+    ∂₂ L c v =
       ∑ xf : XFaceIdx L, c xf * (if v ∈ xSupport xf then 1 else 0) := rfl
 
 @[simp] theorem rscBoundary1_apply (L : ℕ) (c : VtxIdx L → ZMod 2)
     (zf : ZFaceIdx L) :
-    rscBoundary1 L c zf = ∑ v ∈ zSupport zf, c v := rfl
+    ∂₁ L c zf = ∑ v ∈ zSupport zf, c v := rfl
 
 /-! ## Intersection-cardinality lemmas -/
 
@@ -551,7 +575,7 @@ private lemma inter_card_even {L : ℕ} [Fact (Odd L)]
 
 /-- Chain-complex law: `∂₁ ∘ ∂₂ = 0`. -/
 theorem rscBoundary_comp_zero (L : ℕ) [Fact (Odd L)] :
-    (rscBoundary1 L).comp (rscBoundary2 L) = 0 := by
+    (∂₁ L).comp (∂₂ L) = 0 := by
   ext c zf
   simp only [LinearMap.comp_apply, rscBoundary1_apply, rscBoundary2_apply,
     LinearMap.zero_apply, Pi.zero_apply]
@@ -563,7 +587,7 @@ theorem rscBoundary_comp_zero (L : ℕ) [Fact (Odd L)] :
 /-- Pointwise corollary of `rscBoundary_comp_zero`. -/
 theorem rscBoundary_comp_zero_apply (L : ℕ) [Fact (Odd L)]
     (c : XFaceIdx L → ZMod 2) :
-    rscBoundary1 L (rscBoundary2 L c) = 0 := by
+    ∂₁ L (∂₂ L c) = 0 := by
   have h := congrArg (fun T => T c) (rscBoundary_comp_zero L)
   simpa using h
 

--- a/QEC/Stabilizer/Codes/RotatedSurface/ChainComplex.lean
+++ b/QEC/Stabilizer/Codes/RotatedSurface/ChainComplex.lean
@@ -21,6 +21,7 @@ namespace Lattice
 namespace RotatedSurface
 
 open scoped BigOperators
+open scoped RotatedSurfaceChain
 
 /-! ## Lattice-specific cycles / boundaries / `H₁`
 
@@ -32,11 +33,11 @@ variable (L : ℕ)
 
 /-- 1-cycles: kernel of `∂₁`. -/
 def rscCycles [Fact (Odd L)] : Submodule (ZMod 2) (VtxIdx L → ZMod 2) :=
-  LinearMap.ker (rscBoundary1 L)
+  LinearMap.ker (∂₁ L)
 
 /-- 1-boundaries: range of `∂₂`. -/
 def rscBoundaries : Submodule (ZMod 2) (VtxIdx L → ZMod 2) :=
-  LinearMap.range (rscBoundary2 L)
+  LinearMap.range (∂₂ L)
 
 /-- Every boundary is a cycle (`∂₁ ∘ ∂₂ = 0`). -/
 theorem rscBoundaries_le_rscCycles [Fact (Odd L)] :
@@ -104,8 +105,8 @@ noncomputable def rotatedSurfaceHomologicalCode [Fact (Odd L)] [Fact (3 ≤ L)] 
   fin0 := inferInstance
   fin1 := inferInstance
   fin2 := inferInstance
-  boundary1 := rscBoundary1 L
-  boundary2 := rscBoundary2 L
+  boundary1 := ∂₁ L
+  boundary2 := ∂₂ L
   boundary_comp := rscBoundary_comp_zero L
   numQubits := L * L
   numQubits_eq := by simp [Fintype.card_prod, Fintype.card_fin]
@@ -129,10 +130,10 @@ theorem rotatedSurfaceHomologicalCode_C2 :
     (rotatedSurfaceHomologicalCode L).C2 = XFaceIdx L := rfl
 
 theorem rotatedSurfaceHomologicalCode_boundary1 :
-    (rotatedSurfaceHomologicalCode L).boundary1 = rscBoundary1 L := rfl
+    (rotatedSurfaceHomologicalCode L).boundary1 = ∂₁ L := rfl
 
 theorem rotatedSurfaceHomologicalCode_boundary2 :
-    (rotatedSurfaceHomologicalCode L).boundary2 = rscBoundary2 L := rfl
+    (rotatedSurfaceHomologicalCode L).boundary2 = ∂₂ L := rfl
 
 theorem rotatedSurfaceHomologicalCode_numQubits :
     (rotatedSurfaceHomologicalCode L).numQubits = L * L := rfl

--- a/QEC/Stabilizer/Codes/RotatedSurface/DistanceX.lean
+++ b/QEC/Stabilizer/Codes/RotatedSurface/DistanceX.lean
@@ -36,6 +36,7 @@ namespace StabilizerGroup
 namespace RotatedSurfaceCodeN
 
 open scoped BigOperators
+open scoped RotatedSurfaceChain
 open NQubitPauliGroupElement
 open Stabilizer.Lattice
 
@@ -208,10 +209,10 @@ private lemma rowFilter_xSupport_card_even
 
 /-- `rowParity (rscBoundary2 (Pi.single xf 1)) y = 0`. -/
 private lemma rowParity_boundary2_single (xf : RotatedSurface.XFaceIdx L) (y : Fin L) :
-    rowParity L (RotatedSurface.rscBoundary2 L (Pi.single xf 1)) y = 0 := by
+    rowParity L (∂₂ L (Pi.single xf 1)) y = 0 := by
   classical
   unfold rowParity
-  rw [show (fun x : Fin L => RotatedSurface.rscBoundary2 L (Pi.single xf 1) (x, y)) =
+  rw [show (fun x : Fin L => ∂₂ L (Pi.single xf 1) (x, y)) =
       (fun x : Fin L => if (x, y) ∈ RotatedSurface.xSupport xf then (1 : ZMod 2) else 0) by
     funext x
     exact boundary2_singleFace_apply L xf (x, y)]
@@ -221,7 +222,7 @@ private lemma rowParity_boundary2_single (xf : RotatedSurface.XFaceIdx L) (y : F
 /-- `rowParity (rscBoundary2 f) y = 0` for every X-face chain `f`. -/
 theorem rowParity_rscBoundary2
     (f : RotatedSurface.XFaceIdx L → ZMod 2) (y : Fin L) :
-    rowParity L (RotatedSurface.rscBoundary2 L f) y = 0 := by
+    rowParity L (∂₂ L f) y = 0 := by
   classical
   have hf : f = ∑ xf : RotatedSurface.XFaceIdx L, f xf • (Pi.single xf (1 : ZMod 2)) := by
     funext xf
@@ -232,23 +233,23 @@ theorem rowParity_rscBoundary2
   -- ∑ x, (∑ xf, ∂₂(f xf • δ_xf))(x, y) = ∑ xf, f xf * (∑ x, ∂₂(δ_xf)(x, y)) = 0
   rw [show (fun x : Fin L =>
       (∑ xf : RotatedSurface.XFaceIdx L,
-        RotatedSurface.rscBoundary2 L (f xf • Pi.single xf 1)) (x, y)) =
+        ∂₂ L (f xf • Pi.single xf 1)) (x, y)) =
       (fun x : Fin L =>
         ∑ xf : RotatedSurface.XFaceIdx L,
-          RotatedSurface.rscBoundary2 L (f xf • Pi.single xf 1) (x, y)) by
+          ∂₂ L (f xf • Pi.single xf 1) (x, y)) by
     funext x; rw [Finset.sum_apply]]
   rw [Finset.sum_comm]
   apply Finset.sum_eq_zero
   intro xf _
   have h_smul : ∀ x : Fin L,
-      RotatedSurface.rscBoundary2 L (f xf • Pi.single xf 1) (x, y) =
-        f xf * RotatedSurface.rscBoundary2 L (Pi.single xf 1) (x, y) := fun x => by
+      ∂₂ L (f xf • Pi.single xf 1) (x, y) =
+        f xf * ∂₂ L (Pi.single xf 1) (x, y) := fun x => by
     rw [LinearMap.map_smul]
     simp [Pi.smul_apply, smul_eq_mul]
   rw [Finset.sum_congr rfl (fun x _ => h_smul x)]
   rw [← Finset.mul_sum]
-  rw [show ∑ x : Fin L, RotatedSurface.rscBoundary2 L (Pi.single xf 1) (x, y) =
-      rowParity L (RotatedSurface.rscBoundary2 L (Pi.single xf 1)) y from rfl]
+  rw [show ∑ x : Fin L, ∂₂ L (Pi.single xf 1) (x, y) =
+      rowParity L (∂₂ L (Pi.single xf 1)) y from rfl]
   rw [rowParity_boundary2_single]
   ring
 

--- a/QEC/Stabilizer/Codes/RotatedSurface/DistanceZ.lean
+++ b/QEC/Stabilizer/Codes/RotatedSurface/DistanceZ.lean
@@ -32,6 +32,7 @@ namespace StabilizerGroup
 namespace RotatedSurfaceCodeN
 
 open scoped BigOperators
+open scoped RotatedSurfaceChain
 open NQubitPauliGroupElement
 open Stabilizer.Lattice
 
@@ -194,11 +195,11 @@ private lemma colFilter_zSupport_card_even
 omit [Fact (Odd L)] in
 /-- `colParity (rscZCutMap (Pi.single zf 1)) x = 0`. -/
 private lemma colParity_zCutMap_single (zf : RotatedSurface.ZFaceIdx L) (x : Fin L) :
-    colParity L (RotatedSurface.rscZCutMap L (Pi.single zf 1)) x = 0 := by
+    colParity L (δ⁰ L (Pi.single zf 1)) x = 0 := by
   classical
   unfold colParity
   -- (rscZCutMap (Pi.single zf 1)) v = 1[v ∈ zSupport zf]
-  rw [show (fun y : Fin L => RotatedSurface.rscZCutMap L (Pi.single zf 1) (x, y)) =
+  rw [show (fun y : Fin L => δ⁰ L (Pi.single zf 1) (x, y)) =
       (fun y : Fin L => if (x, y) ∈ RotatedSurface.zSupport zf then (1 : ZMod 2) else 0) by
     funext y
     rw [RotatedSurface.rscZCutMap_apply]
@@ -218,7 +219,7 @@ omit [Fact (Odd L)] in
 /-- `colParity (rscZCutMap s) x = 0` for every Z-face chain `s`. -/
 theorem colParity_rscZCutMap
     (s : RotatedSurface.ZFaceIdx L → ZMod 2) (x : Fin L) :
-    colParity L (RotatedSurface.rscZCutMap L s) x = 0 := by
+    colParity L (δ⁰ L s) x = 0 := by
   classical
   have hs : s = ∑ zf : RotatedSurface.ZFaceIdx L, s zf • (Pi.single zf (1 : ZMod 2)) := by
     funext zf
@@ -228,23 +229,23 @@ theorem colParity_rscZCutMap
   unfold colParity
   rw [show (fun y : Fin L =>
       (∑ zf : RotatedSurface.ZFaceIdx L,
-        RotatedSurface.rscZCutMap L (s zf • Pi.single zf 1)) (x, y)) =
+        δ⁰ L (s zf • Pi.single zf 1)) (x, y)) =
       (fun y : Fin L =>
         ∑ zf : RotatedSurface.ZFaceIdx L,
-          RotatedSurface.rscZCutMap L (s zf • Pi.single zf 1) (x, y)) by
+          δ⁰ L (s zf • Pi.single zf 1) (x, y)) by
     funext y; rw [Finset.sum_apply]]
   rw [Finset.sum_comm]
   apply Finset.sum_eq_zero
   intro zf _
   have h_smul : ∀ y : Fin L,
-      RotatedSurface.rscZCutMap L (s zf • Pi.single zf 1) (x, y) =
-        s zf * RotatedSurface.rscZCutMap L (Pi.single zf 1) (x, y) := fun y => by
+      δ⁰ L (s zf • Pi.single zf 1) (x, y) =
+        s zf * δ⁰ L (Pi.single zf 1) (x, y) := fun y => by
     rw [LinearMap.map_smul]
     simp [Pi.smul_apply, smul_eq_mul]
   rw [Finset.sum_congr rfl (fun y _ => h_smul y)]
   rw [← Finset.mul_sum]
-  rw [show ∑ y : Fin L, RotatedSurface.rscZCutMap L (Pi.single zf 1) (x, y) =
-      colParity L (RotatedSurface.rscZCutMap L (Pi.single zf 1)) x from rfl]
+  rw [show ∑ y : Fin L, δ⁰ L (Pi.single zf 1) (x, y) =
+      colParity L (δ⁰ L (Pi.single zf 1)) x from rfl]
   rw [colParity_zCutMap_single]
   ring
 
@@ -252,7 +253,7 @@ omit [Fact (Odd L)] in
 /-- `colParity` vanishes on the dual-boundaries submodule (range of `rscZCutMap`). -/
 theorem colParity_eq_zero_of_mem_dualBoundaries
     {c : RotatedSurface.VtxIdx L → ZMod 2}
-    (hc : c ∈ LinearMap.range (RotatedSurface.rscZCutMap L)) (x : Fin L) :
+    (hc : c ∈ LinearMap.range (δ⁰ L)) (x : Fin L) :
     colParity L c x = 0 := by
   rcases hc with ⟨s, rfl⟩
   exact colParity_rscZCutMap L s x
@@ -279,7 +280,7 @@ def stabXMatrix : Matrix (RotatedSurface.XFaceIdx L) (RotatedSurface.VtxIdx L) (
 
 omit [Fact (Odd L)] [Fact (3 ≤ L)] in
 lemma rscBoundary2_eq_transpose_mulVecLin :
-    RotatedSurface.rscBoundary2 L = (stabXMatrix L).transpose.mulVecLin := by
+    ∂₂ L = (stabXMatrix L).transpose.mulVecLin := by
   apply LinearMap.ext
   intro c
   funext v
@@ -323,7 +324,7 @@ theorem rsc_rank_dualBoundary :
   have h_eq_rank :
       Module.finrank (ZMod 2)
           (LinearMap.range (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundary) =
-        Module.finrank (ZMod 2) (LinearMap.range (RotatedSurface.rscBoundary2 L)) := by
+        Module.finrank (ZMod 2) (LinearMap.range (∂₂ L)) := by
     rw [dualBoundary_eq_mulVecLin, rscBoundary2_eq_transpose_mulVecLin]
     change Matrix.rank (stabXMatrix L) = Matrix.rank (stabXMatrix L).transpose
     rw [Matrix.rank_transpose]
@@ -353,7 +354,7 @@ omit [Fact (Odd L)] [Fact (3 ≤ L)] in
 /-- Helper: `rscBoundary1 (Pi.single v 1) zf = 1[v ∈ zSupport zf]`. -/
 private lemma rscBoundary1_pi_single
     (v : RotatedSurface.VtxIdx L) (zf : RotatedSurface.ZFaceIdx L) :
-    RotatedSurface.rscBoundary1 L (Pi.single v 1) zf =
+    ∂₁ L (Pi.single v 1) zf =
       (if v ∈ RotatedSurface.zSupport zf then (1 : ZMod 2) else 0) := by
   classical
   rw [RotatedSurface.rscBoundary1_apply]
@@ -371,12 +372,12 @@ private lemma rscBoundary1_pi_single
 /-- Bridge: the abstract `cutMap` equals the lattice-side `rscZCutMap`. -/
 lemma cutMap_eq_rscZCutMap :
     (RotatedSurface.rotatedSurfaceHomologicalCode L).cutMap =
-      RotatedSurface.rscZCutMap L := by
+      δ⁰ L := by
   apply LinearMap.ext
   intro s
   funext v
   change ∑ zf : RotatedSurface.ZFaceIdx L,
-      s zf * RotatedSurface.rscBoundary1 L (Pi.single v 1) zf = _
+      s zf * ∂₁ L (Pi.single v 1) zf = _
   change _ = ∑ zf : RotatedSurface.ZFaceIdx L,
       s zf * (if v ∈ RotatedSurface.zSupport zf then (1 : ZMod 2) else 0)
   apply Finset.sum_congr rfl
@@ -475,7 +476,7 @@ theorem middleRowChain_not_mem_dualBoundaries :
     middleRowChain L ∉
       (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundaries := by
   intro h
-  have h_rsc : middleRowChain L ∈ LinearMap.range (RotatedSurface.rscZCutMap L) := by
+  have h_rsc : middleRowChain L ∈ LinearMap.range (δ⁰ L) := by
     rw [← cutMap_eq_rscZCutMap]
     exact h
   have h1 : colParity L (middleRowChain L)
@@ -550,7 +551,7 @@ theorem colParity_eq_one_of_nontrivial
   rw [colParity_middleRowChain]
   -- dualBoundaries unfolds to range cutMap; convert h_diff_boundary to range rscZCutMap.
   have h_diff_rsc : c - middleRowChain L ∈
-      LinearMap.range (RotatedSurface.rscZCutMap L) := by
+      LinearMap.range (δ⁰ L) := by
     rw [← cutMap_eq_rscZCutMap]
     exact h_diff_boundary
   rw [colParity_eq_zero_of_mem_dualBoundaries L h_diff_rsc x]

--- a/QEC/Stabilizer/Codes/RotatedSurface/H1Dimension.lean
+++ b/QEC/Stabilizer/Codes/RotatedSurface/H1Dimension.lean
@@ -24,6 +24,7 @@ namespace Lattice
 namespace RotatedSurface
 
 open scoped BigOperators
+open scoped RotatedSurfaceChain
 
 /-! ## Basic ambient facts -/
 
@@ -536,7 +537,7 @@ lemma zAnchorIdx_injective : Function.Injective (zAnchorIdx : ZFaceIdx L → ℕ
 Combining the X-anchor properties, the indicator family of X-stabs is
 linearly independent, so the boundary map `∂₂` is injective. -/
 
-theorem rscBoundary2_injective : Function.Injective (rscBoundary2 L) := by
+theorem rscBoundary2_injective : Function.Injective (∂₂ L) := by
   rw [← LinearMap.ker_eq_bot, Submodule.eq_bot_iff]
   intro f hf
   simp only [LinearMap.mem_ker] at hf
@@ -548,7 +549,7 @@ theorem rscBoundary2_injective : Function.Injective (rscBoundary2 L) := by
     S.exists_min_image xAnchorIdx hS_ne
   have hxf_min_ne : f xf_min ≠ 0 := (Finset.mem_filter.mp hxf_min_mem).2
   obtain ⟨v_min, hv_min_supp, hv_min_idx⟩ := xAnchor_mem_xSupport xf_min
-  have hval : (rscBoundary2 L f) v_min = f xf_min := by
+  have hval : (∂₂ L f) v_min = f xf_min := by
     rw [rscBoundary2_apply, Finset.sum_eq_single xf_min]
     · simp [hv_min_supp]
     · intro xf' _ hne'
@@ -566,22 +567,22 @@ theorem rscBoundary2_injective : Function.Injective (rscBoundary2 L) := by
           omega
         simp [hnotin]
     · intro h; exact absurd (Finset.mem_univ xf_min) h
-  have : (rscBoundary2 L f) v_min = 0 := by rw [hf]; rfl
+  have : (∂₂ L f) v_min = 0 := by rw [hf]; rfl
   rw [hval] at this
   exact hxf_min_ne this
 
 /-- The kernel of `rscBoundary2` is `⊥`. -/
 theorem rscBoundary2_ker_eq_bot :
-    LinearMap.ker (rscBoundary2 L) = ⊥ := by
+    LinearMap.ker (∂₂ L) = ⊥ := by
   rw [LinearMap.ker_eq_bot]
   exact rscBoundary2_injective
 
 /-- `rank(∂₂) = |XFaceIdx L|`. -/
 theorem rsc_rank_boundary2 :
-    Module.finrank (ZMod 2) (LinearMap.range (rscBoundary2 L)) =
+    Module.finrank (ZMod 2) (LinearMap.range (∂₂ L)) =
       Fintype.card (XFaceIdx L) := by
-  have hrn := LinearMap.finrank_range_add_finrank_ker (rscBoundary2 L)
-  rw [show Module.finrank (ZMod 2) (LinearMap.ker (rscBoundary2 L)) = 0 from ?_] at hrn
+  have hrn := LinearMap.finrank_range_add_finrank_ker (∂₂ L)
+  rw [show Module.finrank (ZMod 2) (LinearMap.ker (∂₂ L)) = 0 from ?_] at hrn
   · rw [rsc_finrank_C2] at hrn
     omega
   · rw [rscBoundary2_ker_eq_bot]
@@ -604,11 +605,16 @@ def rscZCutMap (L : ℕ) :
     funext v
     simp only [RingHom.id_apply, Pi.smul_apply, smul_eq_mul, Finset.mul_sum, mul_assoc]
 
+/-- `δ⁰` is the rotated-surface Z-side cut map `rscZCutMap L` (the transpose of `∂₁`,
+i.e. the coboundary `C⁰ → C¹`). Scoped: `open scoped RotatedSurfaceChain`. -/
+scoped[RotatedSurfaceChain] notation "δ⁰" =>
+  Quantum.Stabilizer.Lattice.RotatedSurface.rscZCutMap
+
 @[simp] theorem rscZCutMap_apply (L : ℕ) (s : ZFaceIdx L → ZMod 2) (v : VtxIdx L) :
-    rscZCutMap L s v =
+    δ⁰ L s v =
       ∑ zf : ZFaceIdx L, s zf * (if v ∈ zSupport zf then 1 else 0) := rfl
 
-theorem rscZCutMap_injective : Function.Injective (rscZCutMap L) := by
+theorem rscZCutMap_injective : Function.Injective (δ⁰ L) := by
   rw [← LinearMap.ker_eq_bot, Submodule.eq_bot_iff]
   intro s hs
   simp only [LinearMap.mem_ker] at hs
@@ -620,7 +626,7 @@ theorem rscZCutMap_injective : Function.Injective (rscZCutMap L) := by
     S.exists_min_image zAnchorIdx hS_ne
   have hzf_min_ne : s zf_min ≠ 0 := (Finset.mem_filter.mp hzf_min_mem).2
   obtain ⟨v_min, hv_min_supp, hv_min_idx⟩ := zAnchor_mem_zSupport zf_min
-  have hval : (rscZCutMap L s) v_min = s zf_min := by
+  have hval : (δ⁰ L s) v_min = s zf_min := by
     rw [rscZCutMap_apply, Finset.sum_eq_single zf_min]
     · simp [hv_min_supp]
     · intro zf' _ hne'
@@ -638,19 +644,19 @@ theorem rscZCutMap_injective : Function.Injective (rscZCutMap L) := by
           omega
         simp [hnotin]
     · intro h; exact absurd (Finset.mem_univ zf_min) h
-  have : (rscZCutMap L s) v_min = 0 := by rw [hs]; rfl
+  have : (δ⁰ L s) v_min = 0 := by rw [hs]; rfl
   rw [hval] at this
   exact hzf_min_ne this
 
-theorem rscZCutMap_ker_eq_bot : LinearMap.ker (rscZCutMap L) = ⊥ := by
+theorem rscZCutMap_ker_eq_bot : LinearMap.ker (δ⁰ L) = ⊥ := by
   rw [LinearMap.ker_eq_bot]; exact rscZCutMap_injective
 
 /-- `rank(rscZCutMap) = |ZFaceIdx L|`. -/
 theorem rsc_rank_zCutMap :
-    Module.finrank (ZMod 2) (LinearMap.range (rscZCutMap L)) =
+    Module.finrank (ZMod 2) (LinearMap.range (δ⁰ L)) =
       Fintype.card (ZFaceIdx L) := by
-  have hrn := LinearMap.finrank_range_add_finrank_ker (rscZCutMap L)
-  rw [show Module.finrank (ZMod 2) (LinearMap.ker (rscZCutMap L)) = 0 from ?_] at hrn
+  have hrn := LinearMap.finrank_range_add_finrank_ker (δ⁰ L)
+  rw [show Module.finrank (ZMod 2) (LinearMap.ker (δ⁰ L)) = 0 from ?_] at hrn
   · rw [rsc_finrank_C0] at hrn
     omega
   · rw [rscZCutMap_ker_eq_bot]
@@ -663,8 +669,8 @@ maps as mutual transposes, so they share the same rank. -/
 
 theorem rscBoundary1_rscZCutMap_transpose
     (c : VtxIdx L → ZMod 2) (s : ZFaceIdx L → ZMod 2) :
-    ∑ zf : ZFaceIdx L, rscBoundary1 L c zf * s zf =
-      ∑ v : VtxIdx L, c v * rscZCutMap L s v := by
+    ∑ zf : ZFaceIdx L, ∂₁ L c zf * s zf =
+      ∑ v : VtxIdx L, c v * δ⁰ L s v := by
   simp only [rscBoundary1_apply, rscZCutMap_apply]
   -- Helper: ∑ v ∈ zSupport zf, c v * s zf = ∑ v, if v ∈ zSupport zf then c v * s zf else 0.
   have hsplit : ∀ zf : ZFaceIdx L,
@@ -700,7 +706,7 @@ def stabZMatrix (L : ℕ) : Matrix (ZFaceIdx L) (VtxIdx L) (ZMod 2) :=
   fun zf v => if v ∈ zSupport zf then 1 else 0
 
 lemma rscBoundary1_eq_mulVecLin :
-    rscBoundary1 L = (stabZMatrix L).mulVecLin := by
+    ∂₁ L = (stabZMatrix L).mulVecLin := by
   apply LinearMap.ext
   intro c
   funext zf
@@ -715,7 +721,7 @@ lemma rscBoundary1_eq_mulVecLin :
   ext v; simp
 
 lemma rscZCutMap_eq_transpose_mulVecLin :
-    rscZCutMap L = (stabZMatrix L).transpose.mulVecLin := by
+    δ⁰ L = (stabZMatrix L).transpose.mulVecLin := by
   apply LinearMap.ext
   intro s
   funext v
@@ -727,15 +733,15 @@ lemma rscZCutMap_eq_transpose_mulVecLin :
 
 /-- `rank(∂₁) = rank(rscZCutMap)` via matrix transpose-rank. -/
 theorem rsc_rank_boundary1_eq_rank_zCutMap :
-    Module.finrank (ZMod 2) (LinearMap.range (rscBoundary1 L)) =
-      Module.finrank (ZMod 2) (LinearMap.range (rscZCutMap L)) := by
+    Module.finrank (ZMod 2) (LinearMap.range (∂₁ L)) =
+      Module.finrank (ZMod 2) (LinearMap.range (δ⁰ L)) := by
   rw [rscBoundary1_eq_mulVecLin, rscZCutMap_eq_transpose_mulVecLin]
   show Matrix.rank (stabZMatrix L) = Matrix.rank (stabZMatrix L).transpose
   rw [Matrix.rank_transpose]
 
 /-- `rank(∂₁) = |ZFaceIdx L|`. -/
 theorem rsc_rank_boundary1 :
-    Module.finrank (ZMod 2) (LinearMap.range (rscBoundary1 L)) =
+    Module.finrank (ZMod 2) (LinearMap.range (∂₁ L)) =
       Fintype.card (ZFaceIdx L) := by
   rw [rsc_rank_boundary1_eq_rank_zCutMap, rsc_rank_zCutMap]
 
@@ -745,7 +751,7 @@ theorem rsc_rank_boundary1 :
 theorem rsc_finrank_cycles :
     Module.finrank (ZMod 2) (rscCycles L) =
       L * L - Fintype.card (ZFaceIdx L) := by
-  have hrn := LinearMap.finrank_range_add_finrank_ker (rscBoundary1 L)
+  have hrn := LinearMap.finrank_range_add_finrank_ker (∂₁ L)
   rw [rsc_finrank_C1, rsc_rank_boundary1] at hrn
   -- finrank C1 (= L*L) = rank(∂₁) + dim ker = |ZFaceIdx| + dim ker
   -- dim Z₁ = dim ker (rscBoundary1) = L*L - |ZFaceIdx|
@@ -757,13 +763,13 @@ theorem rsc_finrank_cycles :
     have hLL : 1 ≤ L * L := by nlinarith
     omega
   -- rscCycles = ker rscBoundary1
-  show Module.finrank (ZMod 2) (LinearMap.ker (rscBoundary1 L)) = _
+  show Module.finrank (ZMod 2) (LinearMap.ker (∂₁ L)) = _
   omega
 
 /-- `dim(boundaries) = |XFaceIdx L|`. -/
 theorem rsc_finrank_boundaries :
     Module.finrank (ZMod 2) (rscBoundaries L) = Fintype.card (XFaceIdx L) := by
-  show Module.finrank (ZMod 2) (LinearMap.range (rscBoundary2 L)) = _
+  show Module.finrank (ZMod 2) (LinearMap.range (∂₂ L)) = _
   exact rsc_rank_boundary2
 
 /-- `dim(H₁) = 1` for the rotated surface code. -/

--- a/QEC/Stabilizer/Codes/RotatedSurface/StabilizerCode.lean
+++ b/QEC/Stabilizer/Codes/RotatedSurface/StabilizerCode.lean
@@ -35,6 +35,7 @@ namespace StabilizerGroup
 namespace RotatedSurfaceCodeN
 
 open scoped BigOperators
+open scoped RotatedSurfaceChain
 open NQubitPauliGroupElement
 open Stabilizer.Lattice
 -- Open `Lattice` to access `RotatedSurface.*` with one less prefix.
@@ -55,7 +56,7 @@ omit [Fact (Odd L)] [Fact (3 ≤ L)] in
 /-- `rscBoundary1 (Pi.single v 1) zf = 1[v ∈ zSupport zf]`. -/
 private lemma boundary1_pi_single (v : RotatedSurface.VtxIdx L)
     (zf : RotatedSurface.ZFaceIdx L) :
-    RotatedSurface.rscBoundary1 L (Pi.single v 1) zf =
+    ∂₁ L (Pi.single v 1) zf =
       (if v ∈ RotatedSurface.zSupport zf then (1 : ZMod 2) else 0) := by
   classical
   rw [RotatedSurface.rscBoundary1_apply]
@@ -81,7 +82,7 @@ lemma cutMap_singleVtx_apply (zf : RotatedSurface.ZFaceIdx L)
         ((RotatedSurface.rotatedSurfaceHomologicalCode L).singleVtx zf) v =
       ∑ zf' : RotatedSurface.ZFaceIdx L,
         (RotatedSurface.rotatedSurfaceHomologicalCode L).singleVtx zf zf' *
-          RotatedSurface.rscBoundary1 L (Pi.single v 1) zf' from rfl]
+          ∂₁ L (Pi.single v 1) zf' from rfl]
   rw [Finset.sum_eq_single zf]
   · -- (singleVtx zf zf) * (boundary1 (δ_v) zf) = (1 : ZMod 2) * _ = boundary1 (δ_v) zf
     have hone : (RotatedSurface.rotatedSurfaceHomologicalCode L).singleVtx zf zf =
@@ -104,7 +105,7 @@ lemma boundary2_singleFace_apply (xf : RotatedSurface.XFaceIdx L)
         ((RotatedSurface.rotatedSurfaceHomologicalCode L).singleFace xf) v =
       (if v ∈ RotatedSurface.xSupport xf then (1 : ZMod 2) else 0) := by
   classical
-  change RotatedSurface.rscBoundary2 L (Pi.single xf 1) v = _
+  change ∂₂ L (Pi.single xf 1) v = _
   rw [RotatedSurface.rscBoundary2_apply]
   by_cases hv : v ∈ RotatedSurface.xSupport xf
   · rw [if_pos hv, Finset.sum_eq_single xf]
@@ -485,7 +486,7 @@ theorem rowsLinearIndependent_generatorsList :
   -- (We work directly with index splits instead of introducing custom Embeddings.)
   --
   -- Z-half kernel: rscZCutMap (coeffsZ f) = 0.
-  have h_cz_ker : RotatedSurface.rscZCutMap L (coeffsZ L f) = 0 := by
+  have h_cz_ker : δ⁰ L (coeffsZ L f) = 0 := by
     funext v
     rw [Pi.zero_apply]
     -- Get the column equation at natAdd (rscQubitEquiv v).
@@ -594,7 +595,7 @@ theorem rowsLinearIndependent_generatorsList :
   -- For each k < nZ, f k = coeffsZ f (zfAt k) = 0.
   -- For each k ≥ nZ, similar via X-block.
   -- X-half kernel: rscBoundary2 (coeffsX f) = 0.
-  have h_cx_ker : RotatedSurface.rscBoundary2 L (coeffsX L f) = 0 := by
+  have h_cx_ker : ∂₂ L (coeffsX L f) = 0 := by
     funext v
     rw [Pi.zero_apply]
     set q := RotatedSurface.rscQubitEquiv L v with hq_def
@@ -768,7 +769,7 @@ def middleRowChain : RotatedSurface.VtxIdx L → ZMod 2 :=
 theorem middleColChain_mem_cycles :
     middleColChain L ∈ RotatedSurface.rscCycles L := by
   classical
-  change RotatedSurface.rscBoundary1 L (middleColChain L) = 0
+  change ∂₁ L (middleColChain L) = 0
   have h3 : 3 ≤ L := Fact.out
   have hmid_pos : 0 < (L - 1) / 2 := by omega
   have hmid_lt : (L - 1) / 2 < L - 1 := by omega

--- a/QEC/Stabilizer/Codes/Small/FiveQubit_5_1_3.lean
+++ b/QEC/Stabilizer/Codes/Small/FiveQubit_5_1_3.lean
@@ -6,6 +6,7 @@ import QEC.Stabilizer.Framework.Core.Logical.CodeDistance
 import QEC.Stabilizer.Framework.Core.CSS.CSSDistance
 import QEC.Stabilizer.Framework.Core.Logical.LogicalOperators
 import QEC.Stabilizer.Framework.Core.Stabilizer.StabilizerCode
+import QEC.Stabilizer.Framework.Core.CodeNotation
 import QEC.Stabilizer.Foundations.PauliGroup.Commutation
 import QEC.Stabilizer.Foundations.PauliGroup.CommutationTactics
 import QEC.Stabilizer.Foundations.PauliGroup.NQubitOperator
@@ -488,7 +489,7 @@ private def logicalOps5_1_3 : Fin 1 → LogicalQubitOps 5 stabilizerGroup :=
             logicalX_anticommutes_logicalZ⟩
 
 /-- The [[5, 1, 3]] five-qubit perfect code as a `StabilizerCode 5 1`. -/
-noncomputable def stabilizerCode : StabilizerCode 5 1 where
+noncomputable def stabilizerCode : Code[[5, 1]] where
   hk := by decide
   generatorsList := generatorsList
   generators_length := rfl
@@ -750,7 +751,7 @@ theorem code_has_distance_three : HasCodeDistance stabilizerCode 3 := by
       weight_two_anticomm_witness g hg_weight h_cent
 
 /-- The [[5, 1, 3]] perfect code packaged with its distance. -/
-noncomputable def stabilizerCodeWithDistance : StabilizerCodeWithDistance 5 1 3 where
+noncomputable def stabilizerCodeWithDistance : Code[[5, 1, 3]] where
   toStabilizerCode := stabilizerCode
   hasDistance      := code_has_distance_three
 

--- a/QEC/Stabilizer/Codes/Small/Steane7.lean
+++ b/QEC/Stabilizer/Codes/Small/Steane7.lean
@@ -11,6 +11,7 @@ import QEC.Stabilizer.Foundations.BinarySymplectic.CheckMatrix
 import QEC.Stabilizer.Foundations.BinarySymplectic.CheckMatrixDecidable
 import QEC.Stabilizer.Framework.Symplectic.SymplecticSpan
 import QEC.Stabilizer.Framework.Core.Stabilizer.StabilizerCode
+import QEC.Stabilizer.Framework.Core.CodeNotation
 import QEC.Stabilizer.Framework.Symplectic.IndependentEquiv
 import QEC.Stabilizer.Foundations.BinarySymplectic.SymplecticInner
 import QEC.Stabilizer.Foundations.PauliGroup.NQubitOperator
@@ -481,7 +482,7 @@ private def logicalOpsSteane7 : Fin 1 → LogicalQubitOps 7 stabilizerGroup :=
     logicalX_anticommutes_logicalZ⟩
 
 /-- The Steane code as a stabilizer code [[7, 1]]: one logical qubit. -/
-noncomputable def stabilizerCode : StabilizerCode 7 1 where
+noncomputable def stabilizerCode : Code[[7, 1]] where
   hk := by decide
   generatorsList := generatorsList
   generators_length := rfl

--- a/QEC/Stabilizer/Codes/Toric/BoundaryMaps.lean
+++ b/QEC/Stabilizer/Codes/Toric/BoundaryMaps.lean
@@ -62,24 +62,24 @@ scoped[ToricChain] notation "∂₁" => Quantum.Stabilizer.Lattice.toricBoundary
 open scoped ToricChain
 
 @[simp] lemma toricBoundary2_singleFace_apply_h (x y x' y' : Fin L) :
-    ∂₂ (L := L) (singleFace (L := L) (x, y)) (EdgeIdx.h x' y') =
+    ∂₂ (L := L) (singleFace (x, y)) (EdgeIdx.h x' y') =
       (if (x', y') = (x, y) then (1 : ZMod 2) else 0) +
       (if (x', prev L y') = (x, y) then (1 : ZMod 2) else 0) := by
   simp [toricBoundary2, singleFace]
 
 @[simp] lemma toricBoundary2_singleFace_apply_v (x y x' y' : Fin L) :
-    ∂₂ (L := L) (singleFace (L := L) (x, y)) (EdgeIdx.v x' y') =
+    ∂₂ (L := L) (singleFace (x, y)) (EdgeIdx.v x' y') =
       (if (x', y') = (x, y) then (1 : ZMod 2) else 0) +
       (if (prev L x', y') = (x, y) then (1 : ZMod 2) else 0) := by
   simp [toricBoundary2, singleFace]
 
 @[simp] lemma toricBoundary1_singleEdge_apply
     (e : EdgeIdx L) (v : VtxIdx L) :
-    ∂₁ (L := L) (singleEdge (L := L) e) v =
-      singleEdge (L := L) e (EdgeIdx.h v.1 v.2) +
-      singleEdge (L := L) e (EdgeIdx.h (prev L v.1) v.2) +
-      singleEdge (L := L) e (EdgeIdx.v v.1 v.2) +
-      singleEdge (L := L) e (EdgeIdx.v v.1 (prev L v.2)) := by
+    ∂₁ (L := L) (singleEdge e) v =
+      singleEdge e (EdgeIdx.h v.1 v.2) +
+      singleEdge e (EdgeIdx.h (prev L v.1) v.2) +
+      singleEdge e (EdgeIdx.v v.1 v.2) +
+      singleEdge e (EdgeIdx.v v.1 (prev L v.2)) := by
   simp [toricBoundary1]
 
 /-- Chain-complex law for toric boundaries. -/

--- a/QEC/Stabilizer/Codes/Toric/BoundaryMaps.lean
+++ b/QEC/Stabilizer/Codes/Toric/BoundaryMaps.lean
@@ -39,21 +39,43 @@ def toricBoundary1 : C1 L →ₗ[ZMod 2] C0 L where
     ext v
     simp [mul_add, add_assoc]
 
+/-!
+## Notation
+
+The scoped `ToricChain` notation renders the toric boundary maps the way the
+homological narrative writes them: `∂₂ L f`, `∂₁ L c` (and `δ⁰ L s` for the vertex
+cut map, declared next to it in `H1Dimension.lean`). The lattice size stays an
+explicit argument, exactly as for the underlying constants — `∂₁ L`, `∂₁ (L := L)` —
+so the conversion is purely notational: `toricBoundary1` is still the declaration
+name for `simp [toricBoundary1]`, `unfold`, and lemma names. Enable with
+`open scoped ToricChain`.
+-/
+
+/-- `∂₂` is the toric face-boundary map `toricBoundary2 : C2 L →ₗ[ZMod 2] C1 L`,
+with the lattice size explicit: `∂₂ L f`. Scoped: `open scoped ToricChain`. -/
+scoped[ToricChain] notation "∂₂" => Quantum.Stabilizer.Lattice.toricBoundary2
+
+/-- `∂₁` is the toric edge-boundary map `toricBoundary1 : C1 L →ₗ[ZMod 2] C0 L`,
+with the lattice size explicit: `∂₁ L c`. Scoped: `open scoped ToricChain`. -/
+scoped[ToricChain] notation "∂₁" => Quantum.Stabilizer.Lattice.toricBoundary1
+
+open scoped ToricChain
+
 @[simp] lemma toricBoundary2_singleFace_apply_h (x y x' y' : Fin L) :
-    toricBoundary2 (L := L) (singleFace (L := L) (x, y)) (EdgeIdx.h x' y') =
+    ∂₂ (L := L) (singleFace (L := L) (x, y)) (EdgeIdx.h x' y') =
       (if (x', y') = (x, y) then (1 : ZMod 2) else 0) +
       (if (x', prev L y') = (x, y) then (1 : ZMod 2) else 0) := by
   simp [toricBoundary2, singleFace]
 
 @[simp] lemma toricBoundary2_singleFace_apply_v (x y x' y' : Fin L) :
-    toricBoundary2 (L := L) (singleFace (L := L) (x, y)) (EdgeIdx.v x' y') =
+    ∂₂ (L := L) (singleFace (L := L) (x, y)) (EdgeIdx.v x' y') =
       (if (x', y') = (x, y) then (1 : ZMod 2) else 0) +
       (if (prev L x', y') = (x, y) then (1 : ZMod 2) else 0) := by
   simp [toricBoundary2, singleFace]
 
 @[simp] lemma toricBoundary1_singleEdge_apply
     (e : EdgeIdx L) (v : VtxIdx L) :
-    toricBoundary1 (L := L) (singleEdge (L := L) e) v =
+    ∂₁ (L := L) (singleEdge (L := L) e) v =
       singleEdge (L := L) e (EdgeIdx.h v.1 v.2) +
       singleEdge (L := L) e (EdgeIdx.h (prev L v.1) v.2) +
       singleEdge (L := L) e (EdgeIdx.v v.1 v.2) +
@@ -62,7 +84,7 @@ def toricBoundary1 : C1 L →ₗ[ZMod 2] C0 L where
 
 /-- Chain-complex law for toric boundaries. -/
 theorem toricBoundary_comp_zero :
-    (toricBoundary1 (L := L)).comp (toricBoundary2 (L := L)) = 0 := by
+    (∂₁ (L := L)).comp (∂₂ (L := L)) = 0 := by
   ext f v
   simp [LinearMap.comp_apply, toricBoundary1, toricBoundary2,
     add_assoc, add_comm, add_left_comm]
@@ -70,7 +92,7 @@ theorem toricBoundary_comp_zero :
   grind
 /-- Pointwise corollary of `toricBoundary_comp_zero`. -/
 theorem toricBoundary_comp_zero_apply (f : C2 L) :
-    toricBoundary1 (L := L) (toricBoundary2 (L := L) f) = 0 := by
+    ∂₁ (L := L) (∂₂ (L := L) f) = 0 := by
   have h := congrArg (fun T => T f) (toricBoundary_comp_zero (L := L))
   simpa using h
 

--- a/QEC/Stabilizer/Codes/Toric/ChainComplex.lean
+++ b/QEC/Stabilizer/Codes/Toric/ChainComplex.lean
@@ -27,6 +27,8 @@ namespace Quantum
 namespace Stabilizer
 namespace Lattice
 
+open scoped ToricChain
+
 /-- The toric edge-to-qubit equiv, built from `edgeToQubitIdx` (which is injective
 between equinumerous finite types). Returns an `EdgeIdx L ≃ Fin (toricNumQubits L)`
 so the abstract chain operator and the existing `toricXOperatorOfChain L` end up
@@ -55,8 +57,8 @@ noncomputable def toricHomologicalCode (L : ℕ) [Fact (0 < L)] :
   fin0 := inferInstance
   fin1 := inferInstance
   fin2 := inferInstance
-  boundary1 := toricBoundary1 (L := L)
-  boundary2 := toricBoundary2 (L := L)
+  boundary1 := ∂₁ (L := L)
+  boundary2 := ∂₂ (L := L)
   boundary_comp := toricBoundary_comp_zero (L := L)
   numQubits := Quantum.Stabilizer.Lattice.toricNumQubits L
   numQubits_eq := card_edgeIdx L
@@ -120,7 +122,7 @@ variable (L : ℕ) [Fact (0 < L)]
 `∑ v, ∂₁(δ_e) v * s v = ∑ e', δ_e e' * cutMap s e'` isolates the value
 at edge `e` on both sides. -/
 theorem toricHomologicalCode_cutMap_eq :
-    (toricHomologicalCode L).cutMap = toricVertexCutMap (L := L) := by
+    (toricHomologicalCode L).cutMap = δ⁰ (L := L) := by
   classical
   refine LinearMap.ext fun s => ?_
   funext e
@@ -146,14 +148,14 @@ theorem toricHomologicalCode_cutMap_eq :
   -- The two RHS sums are equal because the LHS sums are equal (both pair `∂₁ δ` with `s`).
   have hRHS :
       ∑ e' : EdgeIdx L, δ e' * (toricHomologicalCode L).cutMap s e'
-      = ∑ e' : EdgeIdx L, δ e' * toricVertexCutMap (L := L) s e' := by
+      = ∑ e' : EdgeIdx L, δ e' * δ⁰ (L := L) s e' := by
     have hLHS_eq :
         ∑ v : VtxIdx L, (toricHomologicalCode L).boundary1 δ v * s v
-        = ∑ v : VtxIdx L, toricBoundary1 (L := L) δ v * s v := rfl
+        = ∑ v : VtxIdx L, ∂₁ (L := L) δ v * s v := rfl
     exact h1.symm.trans (hLHS_eq.trans h2)
   -- Specialize `hpi` to both maps and chain.
   have hL := hpi ((toricHomologicalCode L).cutMap s)
-  have hR := hpi (toricVertexCutMap (L := L) s)
+  have hR := hpi (δ⁰ (L := L) s)
   exact hL.symm.trans (hRHS.trans hR)
 
 /-- The lattice `singleVtx v` is the abstract `singleVtx v`. -/

--- a/QEC/Stabilizer/Codes/Toric/ChainOps.lean
+++ b/QEC/Stabilizer/Codes/Toric/ChainOps.lean
@@ -31,6 +31,7 @@ namespace Stabilizer
 namespace Lattice
 
 open scoped BigOperators
+open scoped ToricChain
 
 -- ---------------------------------------------------------------------------
 -- Z-operator encoding (mirror of `toricXOperatorOfChain`)
@@ -221,7 +222,7 @@ lemma toricZOperatorOfChain_add (L : ℕ) (c c' : C1 L) :
 /-- `toricXOperatorOfChain` maps the boundary of a single face to the corresponding
 face stabilizer. -/
 lemma toricXOperatorOfChain_boundary_singleFace (L : ℕ) [Fact (2 ≤ L)] (x y : Fin L) :
-    toricXOperatorOfChain L (toricBoundary2 (L := L) (singleFace (x, y))) =
+    toricXOperatorOfChain L (∂₂ (L := L) (singleFace (x, y))) =
       StabilizerGroup.ToricCodeN.faceStab L x y := by
   unfold toricXOperatorOfChain StabilizerGroup.ToricCodeN.faceStab
   congr with q
@@ -268,7 +269,7 @@ set_option maxHeartbeats 800000 in
     equals the vertex stabilizer at `(xv, yv)`. -/
 lemma toricZOperatorOfChain_cutMap_singleVtx (L : ℕ) [Fact (2 ≤ L)]
     (xv yv : Fin L) :
-    toricZOperatorOfChain L (toricVertexCutMap (L := L) (singleVtx (xv, yv))) =
+    toricZOperatorOfChain L (δ⁰ (L := L) (singleVtx (xv, yv))) =
       StabilizerGroup.ToricCodeN.vertexStab L xv yv := by
   have hL0 : 0 < L := Nat.lt_of_lt_of_le (by decide : 0 < 2) (Fact.out : 2 ≤ L)
   haveI : Fact (0 < L) := ⟨hL0⟩

--- a/QEC/Stabilizer/Codes/Toric/CodeN.lean
+++ b/QEC/Stabilizer/Codes/Toric/CodeN.lean
@@ -35,6 +35,7 @@ both are equivalent via global Hadamard (X ↔ Z on every qubit).
 
 namespace Quantum
 open scoped BigOperators
+open scoped ToricChain
 
 namespace StabilizerGroup
 namespace ToricCodeN
@@ -615,11 +616,11 @@ of length `numQubits L - 2`. The full `generatorsList L` here has length
 
 /-- Alias for the toric `∂2` boundary map from the lattice chain-complex layer. -/
 abbrev toricBoundary2 (L : ℕ) [Fact (0 < L)] :=
-  Stabilizer.Lattice.toricBoundary2 (L := L)
+  ∂₂ (L := L)
 
 /-- Alias for the toric `∂1` boundary map from the lattice chain-complex layer. -/
 abbrev toricBoundary1 (L : ℕ) [Fact (0 < L)] :=
-  Stabilizer.Lattice.toricBoundary1 (L := L)
+  ∂₁ (L := L)
 
 /-- Alias for toric 1-cycles from the lattice homology layer. -/
 abbrev toricCycles (L : ℕ) [Fact (0 < L)] :=

--- a/QEC/Stabilizer/Codes/Toric/DistanceX.lean
+++ b/QEC/Stabilizer/Codes/Toric/DistanceX.lean
@@ -61,12 +61,12 @@ theorem horizontalLoopChain_not_mem_toricBoundaries (L : ℕ) [Fact (2 ≤ L)] :
 
 /-- Section-8 witness: canonical horizontal loop chain has edge-weight `L`. -/
 theorem horizontalLoopChain_edgeWeight_eq_L (L : ℕ) [Fact (2 ≤ L)] :
-    Stabilizer.Lattice.edgeWeight (L := L) (horizontalLoopChain L) = L := by
+    Stabilizer.Lattice.edgeWeight (horizontalLoopChain L) = L := by
   let z0 : Fin L := Stabilizer.Lattice.zeroCoord L
   let horizAtZero : Finset (Stabilizer.Lattice.EdgeIdx L) :=
     (Finset.univ.image (fun x : Fin L => Stabilizer.Lattice.EdgeIdx.h x z0))
   have hsupport :
-      Stabilizer.Lattice.edgeSupport (L := L) (horizontalLoopChain L) = horizAtZero := by
+      Stabilizer.Lattice.edgeSupport (horizontalLoopChain L) = horizAtZero := by
     ext e
     constructor
     · intro he
@@ -104,8 +104,8 @@ theorem horizontalLoopChain_edgeWeight_eq_L (L : ℕ) [Fact (2 ≤ L)] :
             exact hinj hab)
       _ = L := by simp
   calc
-    Stabilizer.Lattice.edgeWeight (L := L) (horizontalLoopChain L)
-        = (Stabilizer.Lattice.edgeSupport (L := L) (horizontalLoopChain L)).card := rfl
+    Stabilizer.Lattice.edgeWeight (horizontalLoopChain L)
+        = (Stabilizer.Lattice.edgeSupport (horizontalLoopChain L)).card := rfl
     _ = horizAtZero.card := by rw [hsupport]
     _ = L := hcard
 
@@ -224,7 +224,7 @@ theorem nontrivial_x_logical_weight_ge_L (L : ℕ) [Fact (2 ≤ L)]
         c ∉ Stabilizer.Lattice.toricBoundaries (L := L) := by
     rw [hc] at hgLogical;
     exact (Stabilizer.Lattice.xNontrivialLogical_iff_cycle_not_boundary L c).mp hgLogical;
-  have h_weight : Stabilizer.Lattice.edgeWeight (L := L) c ≥ L := by
+  have h_weight : Stabilizer.Lattice.edgeWeight c ≥ L := by
     have h_weight :
         Stabilizer.Lattice.hWrap (L := L) ⟨c, h_cycle.left⟩ ≠ 0 ∨
           Stabilizer.Lattice.vWrap (L := L) ⟨c, h_cycle.left⟩ ≠ 0 := by
@@ -408,13 +408,13 @@ theorem verticalLoopChain_not_mem_toricBoundaries (L : ℕ) [Fact (2 ≤ L)] :
 
 /-- The vertical X-loop chain has edge weight `L`. -/
 theorem verticalLoopChain_edgeWeight_eq_L (L : ℕ) [Fact (2 ≤ L)] :
-    Stabilizer.Lattice.edgeWeight (L := L) (verticalLoopChain L) = L := by
+    Stabilizer.Lattice.edgeWeight (verticalLoopChain L) = L := by
   haveI : Fact (0 < L) := ⟨lt_of_lt_of_le (by decide : 0 < 2) Fact.out⟩
   let z0 : Fin L := Stabilizer.Lattice.zeroCoord L
   let vertCol : Finset (Stabilizer.Lattice.EdgeIdx L) :=
     (Finset.univ.image (fun y : Fin L => Stabilizer.Lattice.EdgeIdx.v z0 y))
   have hsupport :
-      Stabilizer.Lattice.edgeSupport (L := L) (verticalLoopChain L) = vertCol := by
+      Stabilizer.Lattice.edgeSupport (verticalLoopChain L) = vertCol := by
     ext e
     constructor
     · intro he
@@ -446,8 +446,8 @@ theorem verticalLoopChain_edgeWeight_eq_L (L : ℕ) [Fact (2 ≤ L)] :
             (by intro a b hab; exact hinj hab)
       _ = L := by simp
   calc
-    Stabilizer.Lattice.edgeWeight (L := L) (verticalLoopChain L)
-        = (Stabilizer.Lattice.edgeSupport (L := L) (verticalLoopChain L)).card := rfl
+    Stabilizer.Lattice.edgeWeight (verticalLoopChain L)
+        = (Stabilizer.Lattice.edgeSupport (verticalLoopChain L)).card := rfl
     _ = vertCol.card := by rw [hsupport]
     _ = L := hcard
 

--- a/QEC/Stabilizer/Codes/Toric/DistanceZ.lean
+++ b/QEC/Stabilizer/Codes/Toric/DistanceZ.lean
@@ -97,14 +97,14 @@ theorem verticalVRowChain_not_mem_toricDualBoundaries (L : ℕ) [Fact (2 ≤ L)]
 
 /-- The vertical V-row chain has edge-weight `L`. -/
 theorem verticalVRowChain_edgeWeight_eq_L (L : ℕ) [Fact (2 ≤ L)] :
-    Stabilizer.Lattice.edgeWeight (L := L) (verticalVRowChain L) = L := by
+    Stabilizer.Lattice.edgeWeight (verticalVRowChain L) = L := by
   have hL0 : 0 < L := Nat.lt_of_lt_of_le (by decide : 0 < 2) (Fact.out : 2 ≤ L)
   haveI : Fact (0 < L) := ⟨hL0⟩
   let z0 : Fin L := Stabilizer.Lattice.zeroCoord L
   let vertAtZero : Finset (Stabilizer.Lattice.EdgeIdx L) :=
     (Finset.univ.image (fun x : Fin L => Stabilizer.Lattice.EdgeIdx.v x z0))
   have hsupport :
-      Stabilizer.Lattice.edgeSupport (L := L) (verticalVRowChain L) = vertAtZero := by
+      Stabilizer.Lattice.edgeSupport (verticalVRowChain L) = vertAtZero := by
     ext e
     constructor
     · intro he
@@ -142,8 +142,8 @@ theorem verticalVRowChain_edgeWeight_eq_L (L : ℕ) [Fact (2 ≤ L)] :
             exact hinj hab)
       _ = L := by simp
   calc
-    Stabilizer.Lattice.edgeWeight (L := L) (verticalVRowChain L)
-        = (Stabilizer.Lattice.edgeSupport (L := L) (verticalVRowChain L)).card := rfl
+    Stabilizer.Lattice.edgeWeight (verticalVRowChain L)
+        = (Stabilizer.Lattice.edgeSupport (verticalVRowChain L)).card := rfl
     _ = vertAtZero.card := by rw [hsupport]
     _ = L := hcard
 
@@ -274,7 +274,7 @@ theorem nontrivial_z_logical_weight_ge_L (L : ℕ) [Fact (2 ≤ L)]
         c ∉ Stabilizer.Lattice.toricDualBoundaries (L := L) := by
     rw [hc] at hgLogical
     exact (Stabilizer.Lattice.zNontrivialLogical_iff_dualCycle_not_dualBoundary L c).mp hgLogical
-  have h_weight : Stabilizer.Lattice.edgeWeight (L := L) c ≥ L := by
+  have h_weight : Stabilizer.Lattice.edgeWeight c ≥ L := by
     have h_invariant_nonzero :
         Stabilizer.Lattice.hRowAt (L := L) (Stabilizer.Lattice.zeroCoord L) c ≠ 0 ∨
           Stabilizer.Lattice.vColAt (L := L) (Stabilizer.Lattice.zeroCoord L) c ≠ 0 := by
@@ -467,13 +467,13 @@ theorem horizontalHRowChain_not_mem_toricDualBoundaries (L : ℕ) [Fact (2 ≤ L
 
 /-- The horizontal Z-row chain has edge weight `L`. -/
 theorem horizontalHRowChain_edgeWeight_eq_L (L : ℕ) [Fact (2 ≤ L)] :
-    Stabilizer.Lattice.edgeWeight (L := L) (horizontalHRowChain L) = L := by
+    Stabilizer.Lattice.edgeWeight (horizontalHRowChain L) = L := by
   haveI : Fact (0 < L) := ⟨lt_of_lt_of_le (by decide : 0 < 2) Fact.out⟩
   let z0 : Fin L := Stabilizer.Lattice.zeroCoord L
   let horizCol : Finset (Stabilizer.Lattice.EdgeIdx L) :=
     (Finset.univ.image (fun y : Fin L => Stabilizer.Lattice.EdgeIdx.h z0 y))
   have hsupport :
-      Stabilizer.Lattice.edgeSupport (L := L) (horizontalHRowChain L) = horizCol := by
+      Stabilizer.Lattice.edgeSupport (horizontalHRowChain L) = horizCol := by
     ext e
     constructor
     · intro he
@@ -505,8 +505,8 @@ theorem horizontalHRowChain_edgeWeight_eq_L (L : ℕ) [Fact (2 ≤ L)] :
             (by intro a b hab; exact hinj hab)
       _ = L := by simp
   calc
-    Stabilizer.Lattice.edgeWeight (L := L) (horizontalHRowChain L)
-        = (Stabilizer.Lattice.edgeSupport (L := L) (horizontalHRowChain L)).card := rfl
+    Stabilizer.Lattice.edgeWeight (horizontalHRowChain L)
+        = (Stabilizer.Lattice.edgeSupport (horizontalHRowChain L)).card := rfl
     _ = horizCol.card := by rw [hsupport]
     _ = L := hcard
 

--- a/QEC/Stabilizer/Codes/Toric/DualWrappingInvariants.lean
+++ b/QEC/Stabilizer/Codes/Toric/DualWrappingInvariants.lean
@@ -7,6 +7,7 @@ namespace Stabilizer
 namespace Lattice
 
 open scoped BigOperators
+open scoped ToricChain
 
 /-!
 # Dual wrapping invariants for the toric code (Z-type)
@@ -282,20 +283,20 @@ theorem toric_finrank_dualCycles :
   simp_all +decide ;
   have h_dual_boundary_range :
       Module.finrank (ZMod 2) (LinearMap.range (toricDualBoundary L)) =
-        Module.finrank (ZMod 2) (LinearMap.range (toricBoundary2 (L := L))) := by
+        Module.finrank (ZMod 2) (LinearMap.range (∂₂ (L := L))) := by
     have h_dual_boundary :
         LinearMap.rank (toricDualBoundary L) =
-          LinearMap.rank (toricBoundary2 (L := L)) := by
+          LinearMap.rank (∂₂ (L := L)) := by
       have h_dual_boundary :
           (toricDualBoundary L).toMatrix' =
-            (toricBoundary2 (L := L)).toMatrix'.transpose := by
+            (∂₂ (L := L)).toMatrix'.transpose := by
         ext ⟨x, y⟩ e; simp [LinearMap.toMatrix', toricDualBoundary, toricBoundary2];
         cases e <;> simp +decide [ Pi.single_apply ];
         · grind;
         · grind +splitImp
       have h_dual_boundary :
           Matrix.rank (toricDualBoundary L).toMatrix' =
-            Matrix.rank (toricBoundary2 (L := L)).toMatrix' := by
+            Matrix.rank (∂₂ (L := L)).toMatrix' := by
         rw [ h_dual_boundary, Matrix.rank_transpose ];
       convert h_dual_boundary using 1;
       simp +decide [ Matrix.rank, LinearMap.rank ];
@@ -314,10 +315,10 @@ theorem toric_finrank_dualBoundaries :
     Module.finrank (ZMod 2) (toricDualBoundaries (L := L)) = L * L - 1 := by
   -- By definition of `toricDualBoundaries`, we know that it is the range of the vertex cut map.
   have h_dualBoundaries_range :
-      toricDualBoundaries L = LinearMap.range (toricVertexCutMap (L := L)) := by
+      toricDualBoundaries L = LinearMap.range (δ⁰ (L := L)) := by
     exact rfl;
   rw [ h_dualBoundaries_range ];
-  have := LinearMap.finrank_range_add_finrank_ker ( toricVertexCutMap ( L := L ) );
+  have := LinearMap.finrank_range_add_finrank_ker ( δ⁰ ( L := L ) );
   rw [ show Module.finrank ( ZMod 2 ) ( C0 L ) = L * L from ?_ ] at this;
   · refine eq_tsub_of_add_eq ?_;
     convert this;

--- a/QEC/Stabilizer/Codes/Toric/H1Dimension.lean
+++ b/QEC/Stabilizer/Codes/Toric/H1Dimension.lean
@@ -7,6 +7,7 @@ namespace Stabilizer
 namespace Lattice
 
 open scoped BigOperators
+open scoped ToricChain
 
 variable (L : ℕ) [Fact (0 < L)]
 
@@ -50,17 +51,17 @@ theorem toric_boundaries_le_cycles :
 theorem toric_rank_nullity_boundary1 :
     Module.finrank (ZMod 2) (C1 L) =
       Module.finrank (ZMod 2) (toricCycles (L := L)) +
-        Module.finrank (ZMod 2) (LinearMap.range (toricBoundary1 (L := L))) := by
+        Module.finrank (ZMod 2) (LinearMap.range (∂₁ (L := L))) := by
   simpa [toricCycles, add_comm, add_left_comm, add_assoc] using
-    (LinearMap.finrank_range_add_finrank_ker (toricBoundary1 (L := L))).symm
+    (LinearMap.finrank_range_add_finrank_ker (∂₁ (L := L))).symm
 
 /-- Rank-nullity specialization for `∂₂`. -/
 theorem toric_rank_nullity_boundary2 :
     Module.finrank (ZMod 2) (C2 L) =
-      Module.finrank (ZMod 2) (LinearMap.ker (toricBoundary2 (L := L))) +
+      Module.finrank (ZMod 2) (LinearMap.ker (∂₂ (L := L))) +
         Module.finrank (ZMod 2) (toricBoundaries (L := L)) := by
   simpa [toricBoundaries, add_comm, add_left_comm, add_assoc] using
-    (LinearMap.finrank_range_add_finrank_ker (toricBoundary2 (L := L))).symm
+    (LinearMap.finrank_range_add_finrank_ker (∂₂ (L := L))).symm
 
 /-- The vertex cut map: sends a 0-chain `s` to the 1-chain whose value at edge `e`
 is the parity-difference of `s` at the two endpoints of `e`. This is the transpose
@@ -82,24 +83,29 @@ noncomputable def toricVertexCutMap : C0 L →ₗ[ZMod 2] C1 L := by
     ext e
     cases e <;> simp [mul_add]
 
+/-- `δ⁰` is the toric vertex cut map `toricVertexCutMap : C0 L →ₗ[ZMod 2] C1 L` (the
+transpose of `∂₁`, i.e. the coboundary `C⁰ → C¹`), with the lattice size explicit:
+`δ⁰ L s`. Scoped: `open scoped ToricChain`. -/
+scoped[ToricChain] notation "δ⁰" => Quantum.Stabilizer.Lattice.toricVertexCutMap
+
 /-
 The pairing ⟨∂₁ c, s⟩ = ⟨c, cutMap s⟩, showing ∂₁ and cutMap are transposes.
 -/
 set_option maxHeartbeats 400000 in
 -- This transpose-expansion proof is algebra-heavy and needs extra heartbeats.
 theorem toricBoundary1_cutMap_transpose (c : C1 L) (s : C0 L) :
-    ∑ v : VtxIdx L, toricBoundary1 (L := L) c v * s v =
-    ∑ e : EdgeIdx L, c e * toricVertexCutMap (L := L) s e := by
+    ∑ v : VtxIdx L, ∂₁ (L := L) c v * s v =
+    ∑ e : EdgeIdx L, c e * δ⁰ (L := L) s e := by
   -- Expand both sides using the definitions.
   have h_expand_lhs :
-      ∑ v : Fin L × Fin L, (toricBoundary1 L c v) * s v =
+      ∑ v : Fin L × Fin L, (∂₁ L c v) * s v =
         ∑ v : Fin L × Fin L,
           (c (EdgeIdx.h v.1 v.2) + c (EdgeIdx.h (prev L v.1) v.2) +
             c (EdgeIdx.v v.1 v.2) + c (EdgeIdx.v v.1 (prev L v.2))) * s v := by
     rfl
   generalize_proofs at *; (
   have h_expand_rhs :
-      ∑ e : EdgeIdx L, c e * (toricVertexCutMap L s e) =
+      ∑ e : EdgeIdx L, c e * (δ⁰ L s e) =
         ∑ x : Fin L, ∑ y : Fin L,
           (c (EdgeIdx.h x y) * (s (x, y) + s (next L x, y)) +
             c (EdgeIdx.v x y) * (s (x, y) + s (x, next L y))) := by
@@ -153,8 +159,8 @@ theorem toricBoundary1_cutMap_transpose (c : C1 L) (s : C0 L) :
 
 /-- `∂₁` and `toricVertexCutMap` are mutual transposes, so they have equal rank. -/
 theorem toric_rank_boundary1_eq_rank_cutMap :
-    Module.finrank (ZMod 2) (LinearMap.range (toricBoundary1 (L := L))) =
-      Module.finrank (ZMod 2) (LinearMap.range (toricVertexCutMap (L := L))) := by
+    Module.finrank (ZMod 2) (LinearMap.range (∂₁ (L := L))) =
+      Module.finrank (ZMod 2) (LinearMap.range (δ⁰ (L := L))) := by
   rw [ ← LinearMap.finrank_range_dualMap_eq_finrank_range ];
   fapply LinearEquiv.finrank_eq;
   symm;
@@ -194,7 +200,7 @@ theorem toric_rank_boundary1_eq_rank_cutMap :
 
 /-- The kernel of the toric vertex cut map consists exactly of the constant 0-chains. -/
 theorem mem_ker_cutMap_iff (s : C0 L) :
-    s ∈ LinearMap.ker (toricVertexCutMap (L := L)) ↔ ∃ c : ZMod 2, s = fun _ => c := by
+    s ∈ LinearMap.ker (δ⁰ (L := L)) ↔ ∃ c : ZMod 2, s = fun _ => c := by
   constructor
   · intro hs
     have h_const : ∀ x y : Fin L, s (x, y) = s (next L x, y) ∧ s (x, y) = s (x, next L y) := by
@@ -252,7 +258,7 @@ theorem mem_ker_cutMap_iff (s : C0 L) :
 
 /-- The kernel of the toric vertex cut map equals `span{constant 1}`. -/
 theorem ker_toricVertexCutMap_eq_span_one :
-    LinearMap.ker (toricVertexCutMap (L := L)) =
+    LinearMap.ker (δ⁰ (L := L)) =
       Submodule.span (ZMod 2) ({fun _ => 1} : Set (C0 L)) := by
   ext s
   rw [mem_ker_cutMap_iff, Submodule.mem_span_singleton]
@@ -262,16 +268,16 @@ theorem ker_toricVertexCutMap_eq_span_one :
 
 /-- Kernel-dimension result for the cut-map connectivity argument. -/
 theorem toric_finrank_ker_cutMap_eq_one :
-    Module.finrank (ZMod 2) (LinearMap.ker (toricVertexCutMap (L := L))) = 1 := by
+    Module.finrank (ZMod 2) (LinearMap.ker (δ⁰ (L := L))) = 1 := by
   rw [ker_toricVertexCutMap_eq_span_one, finrank_span_singleton]
   exact fun h => by simpa using congr_fun h (⟨0, Fact.out⟩, ⟨0, Fact.out⟩)
 
 /-- Target rank formula for `∂₁`. -/
 theorem toric_rank_boundary1 :
-    Module.finrank (ZMod 2) (LinearMap.range (toricBoundary1 (L := L))) = L * L - 1 := by
+    Module.finrank (ZMod 2) (LinearMap.range (∂₁ (L := L))) = L * L - 1 := by
   have hcut_rk :
-      Module.finrank (ZMod 2) (LinearMap.range (toricVertexCutMap (L := L))) = L * L - 1 := by
-    have hcut_rn := LinearMap.finrank_range_add_finrank_ker (toricVertexCutMap (L := L))
+      Module.finrank (ZMod 2) (LinearMap.range (δ⁰ (L := L))) = L * L - 1 := by
+    have hcut_rn := LinearMap.finrank_range_add_finrank_ker (δ⁰ (L := L))
     have hC0 := toric_finrank_C0 (L := L)
     have hker := toric_finrank_ker_cutMap_eq_one (L := L)
     omega
@@ -304,7 +310,7 @@ theorem toric_finrank_cycles :
 
 /-- The kernel of `∂₂` consists exactly of the constant 2-chains. -/
 theorem mem_ker_boundary2_iff (f : C2 L) :
-    f ∈ LinearMap.ker (toricBoundary2 (L := L)) ↔ ∃ c : ZMod 2, f = fun _ => c := by
+    f ∈ LinearMap.ker (∂₂ (L := L)) ↔ ∃ c : ZMod 2, f = fun _ => c := by
   constructor
   · intro hf
     have h_const : ∀ x y, f (x, next L y) = f (x, y) := by
@@ -368,7 +374,7 @@ theorem mem_ker_boundary2_iff (f : C2 L) :
 
 /-- The kernel of `∂₂` equals `span{constant 1}`. -/
 theorem ker_toricBoundary2_eq_span_one :
-    LinearMap.ker (toricBoundary2 (L := L)) =
+    LinearMap.ker (∂₂ (L := L)) =
       Submodule.span (ZMod 2) ({fun _ => 1} : Set (C2 L)) := by
   ext f
   rw [mem_ker_boundary2_iff, Submodule.mem_span_singleton]
@@ -378,7 +384,7 @@ theorem ker_toricBoundary2_eq_span_one :
 
 /-- Kernel-dimension result for `∂₂`. -/
 theorem toric_finrank_ker_boundary2_eq_one :
-    Module.finrank (ZMod 2) (LinearMap.ker (toricBoundary2 (L := L))) = 1 := by
+    Module.finrank (ZMod 2) (LinearMap.ker (∂₂ (L := L))) = 1 := by
   rw [ker_toricBoundary2_eq_span_one, finrank_span_singleton]
   exact fun h => by simpa using congr_fun h (⟨0, Fact.out⟩, ⟨0, Fact.out⟩)
 

--- a/QEC/Stabilizer/Codes/Toric/Homology.lean
+++ b/QEC/Stabilizer/Codes/Toric/Homology.lean
@@ -5,15 +5,17 @@ namespace Quantum
 namespace Stabilizer
 namespace Lattice
 
+open scoped ToricChain
+
 variable (L : ℕ) [Fact (0 < L)]
 
 /-- 1-cycles: kernel of `∂1`. -/
 def toricCycles : Submodule (ZMod 2) (C1 L) :=
-  LinearMap.ker (toricBoundary1 (L := L))
+  LinearMap.ker (∂₁ (L := L))
 
 /-- 1-boundaries: range of `∂2`. -/
 def toricBoundaries : Submodule (ZMod 2) (C1 L) :=
-  LinearMap.range (toricBoundary2 (L := L))
+  LinearMap.range (∂₂ (L := L))
 
 /-- Every boundary is a cycle (`im ∂2 ≤ ker ∂1`). -/
 theorem toricBoundaries_le_toricCycles :

--- a/QEC/Stabilizer/Codes/Toric/LogicalCorrespondenceX.lean
+++ b/QEC/Stabilizer/Codes/Toric/LogicalCorrespondenceX.lean
@@ -11,6 +11,7 @@ namespace Stabilizer
 namespace Lattice
 
 open scoped BigOperators
+open scoped ToricChain
 
 /-- Support membership of `toricXOperatorOfChain` at an indexed edge qubit. -/
 lemma mem_support_toricXOperatorOfChain_edgeToQubitIdx_iff
@@ -282,7 +283,7 @@ theorem evenIncidentOverlap_iff_boundary1_zero_at
         (if c (EdgeIdx.h (StabilizerGroup.ToricCodeN.prev L xv) yv) = 1 then 1 else 0) +
         (if c (EdgeIdx.v xv yv) = 1 then 1 else 0) +
         (if c (EdgeIdx.v xv (StabilizerGroup.ToricCodeN.prev L yv)) = 1 then 1 else 0)) : ℕ)
-      ↔ toricBoundary1 (L := L) c (xv, yv) = 0 := by
+      ↔ ∂₁ (L := L) c (xv, yv) = 0 := by
   simpa [toricBoundary1] using even_indicator_sum4_iff_zmod2_zero
     (c (EdgeIdx.h xv yv))
     (c (EdgeIdx.h (StabilizerGroup.ToricCodeN.prev L xv) yv))
@@ -295,7 +296,7 @@ theorem vertexCheckCommutes_iff_boundary1_zero_at
     (L : ℕ) [Fact (2 ≤ L)] (c : C1 L) (xv yv : Fin L) :
     StabilizerGroup.ToricCodeN.vertexStab L xv yv * toricXOperatorOfChain L c =
       toricXOperatorOfChain L c * StabilizerGroup.ToricCodeN.vertexStab L xv yv
-      ↔ toricBoundary1 (L := L) c (xv, yv) = 0 := by
+      ↔ ∂₁ (L := L) c (xv, yv) = 0 := by
   exact (vertexCheckCommutes_iff_evenIncidentOverlap L c xv yv).trans
     (evenIncidentOverlap_iff_boundary1_zero_at L c xv yv)
 
@@ -303,7 +304,7 @@ theorem vertexCheckCommutes_iff_boundary1_zero_at
 vanishing of the primal boundary map. -/
 theorem xCommutesWithZChecks_iff_boundary1_pointwise_zero
     (L : ℕ) [Fact (2 ≤ L)] (c : C1 L) :
-    xCommutesWithZChecks L c ↔ ∀ v : VtxIdx L, toricBoundary1 (L := L) c v = 0 := by
+    xCommutesWithZChecks L c ↔ ∀ v : VtxIdx L, ∂₁ (L := L) c v = 0 := by
   constructor
   · intro h v
     rcases v with ⟨xv, yv⟩
@@ -321,10 +322,10 @@ theorem xCommutesWithZChecks_iff_boundary1_pointwise_zero
 i.e. cycle membership. -/
 theorem boundary1_pointwise_zero_iff_mem_toricCycles
     (L : ℕ) [Fact (2 ≤ L)] (c : C1 L) :
-    (∀ v : VtxIdx L, toricBoundary1 (L := L) c v = 0) ↔ c ∈ toricCycles (L := L) := by
+    (∀ v : VtxIdx L, ∂₁ (L := L) c v = 0) ↔ c ∈ toricCycles (L := L) := by
   constructor
   · intro h
-    change toricBoundary1 (L := L) c = 0
+    change ∂₁ (L := L) c = 0
     ext v
     exact h v
   · intro h v

--- a/QEC/Stabilizer/Codes/Toric/LogicalCorrespondenceZ.lean
+++ b/QEC/Stabilizer/Codes/Toric/LogicalCorrespondenceZ.lean
@@ -10,6 +10,7 @@ namespace Stabilizer
 namespace Lattice
 
 open scoped BigOperators
+open scoped ToricChain
 
 /-!
 # Z-type logical correspondence for the toric code
@@ -50,7 +51,7 @@ def toricDualCycles (L : ℕ) [Fact (0 < L)] : Submodule (ZMod 2) (C1 L) :=
 
 /-- Dual boundaries: Z-chains that are products of vertex stabilizers. -/
 noncomputable def toricDualBoundaries (L : ℕ) [Fact (0 < L)] : Submodule (ZMod 2) (C1 L) :=
-  LinearMap.range (toricVertexCutMap (L := L))
+  LinearMap.range (δ⁰ (L := L))
 
 /-- Every dual boundary is a dual cycle (∂₂ᵀ ∘ ∂₁ᵀ = 0). -/
 theorem toricDualBoundaries_le_toricDualCycles (L : ℕ) [Fact (0 < L)] :
@@ -102,13 +103,13 @@ theorem toricHomologicalCode_dualBoundary_eq :
   -- Strategy: split EdgeIdx into h and v via `edgeIdxEquivSum`, expand
   -- `toricBoundary2 (Pi.single (x, y) 1)` pointwise, and identify the 4 nonzero terms.
   change ∑ e : EdgeIdx L,
-        c e * toricBoundary2 (L := L) (Pi.single (x, y) (1 : ZMod 2)) e
+        c e * ∂₂ (L := L) (Pi.single (x, y) (1 : ZMod 2)) e
     = c (EdgeIdx.h x y) + c (EdgeIdx.h x (StabilizerGroup.ToricCodeN.next L y))
       + c (EdgeIdx.v x y) + c (EdgeIdx.v (StabilizerGroup.ToricCodeN.next L x) y)
   -- Step 1: rewrite the EdgeIdx-sum as a `Sum`-sum via `edgeIdxEquivSum`.
   rw [← Equiv.sum_comp (edgeIdxEquivSum L).symm
         (fun e : EdgeIdx L =>
-          c e * toricBoundary2 (L := L) (Pi.single (x, y) (1 : ZMod 2)) e),
+          c e * ∂₂ (L := L) (Pi.single (x, y) (1 : ZMod 2)) e),
       Fintype.sum_sum_type]
   -- Step 2: reduce each VtxIdx-sum.
   -- h-edges:
@@ -129,7 +130,7 @@ theorem toricHomologicalCode_dualBoundary_eq :
   have hh :
       ∑ p : VtxIdx L,
           (fun e : EdgeIdx L =>
-              c e * toricBoundary2 (L := L) (Pi.single (x, y) (1 : ZMod 2)) e)
+              c e * ∂₂ (L := L) (Pi.single (x, y) (1 : ZMod 2)) e)
             ((edgeIdxEquivSum L).symm (Sum.inl p))
       = c (EdgeIdx.h x y) + c (EdgeIdx.h x (StabilizerGroup.ToricCodeN.next L y)) := by
     -- Rewrite `(edgeIdxEquivSum L).symm (Sum.inl p) = h p.1 p.2`
@@ -138,7 +139,7 @@ theorem toricHomologicalCode_dualBoundary_eq :
       rintro ⟨_, _⟩; rfl]
     -- Unfold `toricBoundary2 (Pi.single (x, y) 1) (h p.1 p.2)`.
     have heval : ∀ p : VtxIdx L,
-        toricBoundary2 (L := L) (Pi.single (x, y) (1 : ZMod 2)) (EdgeIdx.h p.1 p.2)
+        ∂₂ (L := L) (Pi.single (x, y) (1 : ZMod 2)) (EdgeIdx.h p.1 p.2)
           = (if (p.1, p.2) = (x, y) then (1 : ZMod 2) else 0)
             + (if (p.1, StabilizerGroup.ToricCodeN.prev L p.2) = (x, y)
                 then 1 else 0) := by
@@ -183,14 +184,14 @@ theorem toricHomologicalCode_dualBoundary_eq :
   have hv :
       ∑ p : VtxIdx L,
           (fun e : EdgeIdx L =>
-              c e * toricBoundary2 (L := L) (Pi.single (x, y) (1 : ZMod 2)) e)
+              c e * ∂₂ (L := L) (Pi.single (x, y) (1 : ZMod 2)) e)
             ((edgeIdxEquivSum L).symm (Sum.inr p))
       = c (EdgeIdx.v x y) + c (EdgeIdx.v (StabilizerGroup.ToricCodeN.next L x) y) := by
     simp only [show ∀ p : VtxIdx L,
         (edgeIdxEquivSum L).symm (Sum.inr p) = EdgeIdx.v p.1 p.2 by
       rintro ⟨_, _⟩; rfl]
     have heval : ∀ p : VtxIdx L,
-        toricBoundary2 (L := L) (Pi.single (x, y) (1 : ZMod 2)) (EdgeIdx.v p.1 p.2)
+        ∂₂ (L := L) (Pi.single (x, y) (1 : ZMod 2)) (EdgeIdx.v p.1 p.2)
           = (if (p.1, p.2) = (x, y) then (1 : ZMod 2) else 0)
             + (if (StabilizerGroup.ToricCodeN.prev L p.1, p.2) = (x, y)
                 then 1 else 0) := by

--- a/QEC/Stabilizer/Codes/Toric/StabilizerCode.lean
+++ b/QEC/Stabilizer/Codes/Toric/StabilizerCode.lean
@@ -204,7 +204,7 @@ private lemma vertexStab_listProd_eq_chain (L : ℕ) [Fact (2 ≤ L)]
     (lst.map (fun p => vertexStab L p.1 p.2)).prod =
       Stabilizer.Lattice.toricZOperatorOfChain L
         (δ⁰ (L := L)
-          ((lst.map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum)) := by
+          ((lst.map (fun p => Stabilizer.Lattice.singleVtx p)).sum)) := by
   haveI : Fact (0 < L) := ⟨lt_of_lt_of_le (by decide : 0 < 2) Fact.out⟩
   induction lst with
   | nil =>
@@ -222,7 +222,7 @@ private lemma faceStab_listProd_eq_chain (L : ℕ) [Fact (2 ≤ L)]
     (lst.map (fun p => faceStab L p.1 p.2)).prod =
       Stabilizer.Lattice.toricXOperatorOfChain L
         (∂₂ (L := L)
-          ((lst.map (fun p => Stabilizer.Lattice.singleFace (L := L) p)).sum)) := by
+          ((lst.map (fun p => Stabilizer.Lattice.singleFace p)).sum)) := by
   haveI : Fact (0 < L) := ⟨lt_of_lt_of_le (by decide : 0 < 2) Fact.out⟩
   induction lst with
   | nil =>
@@ -236,7 +236,7 @@ private lemma faceStab_listProd_eq_chain (L : ℕ) [Fact (2 ≤ L)]
 /-- The sum (as 0-chains) of `singleVtx p` over all `p ∈ coords L` is the
 constant-1 chain. -/
 private lemma sum_singleVtx_coords (L : ℕ) [Fact (0 < L)] :
-    ((coords L).map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum =
+    ((coords L).map (fun p => Stabilizer.Lattice.singleVtx p)).sum =
       (fun _ => (1 : ZMod 2)) := by
   have h_nodup : (coords L).Nodup := by
     change ((List.finRange L).product (List.finRange L)).Nodup
@@ -244,14 +244,14 @@ private lemma sum_singleVtx_coords (L : ℕ) [Fact (0 < L)] :
   have h_finset_eq : (coords L).toFinset = (Finset.univ : Finset (Fin L × Fin L)) := by
     ext p
     refine ⟨fun _ => Finset.mem_univ _, fun _ => List.mem_toFinset.mpr (mem_coords L p)⟩
-  rw [show ((coords L).map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum =
-      ∑ p ∈ Finset.univ, Stabilizer.Lattice.singleVtx (L := L) p from ?_]
+  rw [show ((coords L).map (fun p => Stabilizer.Lattice.singleVtx p)).sum =
+      ∑ p ∈ Finset.univ, Stabilizer.Lattice.singleVtx p from ?_]
   · ext v
     rw [Finset.sum_apply]
     rw [Finset.sum_eq_single v]
     · simp [Stabilizer.Lattice.singleVtx]
     · intro b _ hbne
-      have : Stabilizer.Lattice.singleVtx (L := L) b v = 0 :=
+      have : Stabilizer.Lattice.singleVtx b v = 0 :=
         Stabilizer.Lattice.singleVtx_apply_ne hbne.symm
       exact this
     · intro hcontra; exact absurd (Finset.mem_univ v) hcontra
@@ -260,7 +260,7 @@ private lemma sum_singleVtx_coords (L : ℕ) [Fact (0 < L)] :
 
 /-- Symmetric: sum of `singleFace p` over `coords L` is the constant-1 2-chain. -/
 private lemma sum_singleFace_coords (L : ℕ) [Fact (0 < L)] :
-    ((coords L).map (fun p => Stabilizer.Lattice.singleFace (L := L) p)).sum =
+    ((coords L).map (fun p => Stabilizer.Lattice.singleFace p)).sum =
       (fun _ => (1 : ZMod 2)) := by
   have h_nodup : (coords L).Nodup := by
     change ((List.finRange L).product (List.finRange L)).Nodup
@@ -268,8 +268,8 @@ private lemma sum_singleFace_coords (L : ℕ) [Fact (0 < L)] :
   have h_finset_eq : (coords L).toFinset = (Finset.univ : Finset (Fin L × Fin L)) := by
     ext p
     refine ⟨fun _ => Finset.mem_univ _, fun _ => List.mem_toFinset.mpr (mem_coords L p)⟩
-  rw [show ((coords L).map (fun p => Stabilizer.Lattice.singleFace (L := L) p)).sum =
-      ∑ p ∈ Finset.univ, Stabilizer.Lattice.singleFace (L := L) p from ?_]
+  rw [show ((coords L).map (fun p => Stabilizer.Lattice.singleFace p)).sum =
+      ∑ p ∈ Finset.univ, Stabilizer.Lattice.singleFace p from ?_]
   · ext v
     rw [Finset.sum_apply]
     rw [Finset.sum_eq_single v]
@@ -282,9 +282,9 @@ private lemma sum_singleFace_coords (L : ℕ) [Fact (0 < L)] :
 
 /-- Decompose `coords L` sum as `coordsTrimmed L` sum plus origin. -/
 private lemma sum_singleVtx_coords_eq_trimmed_add_origin (L : ℕ) [Fact (0 < L)] :
-    ((coords L).map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum =
-      ((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum
-        + Stabilizer.Lattice.singleVtx (L := L) (originCoord L) := by
+    ((coords L).map (fun p => Stabilizer.Lattice.singleVtx p)).sum =
+      ((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx p)).sum
+        + Stabilizer.Lattice.singleVtx (originCoord L) := by
   have h_nodup : (coords L).Nodup := by
     change ((List.finRange L).product (List.finRange L)).Nodup
     exact List.Nodup.product (List.nodup_finRange L) (List.nodup_finRange L)
@@ -302,11 +302,11 @@ private lemma sum_singleVtx_coords_eq_trimmed_add_origin (L : ℕ) [Fact (0 < L)
       (coords L).toFinset = (Finset.univ : Finset (Fin L × Fin L)) from h_finset_eq) ▸
       Finset.mem_univ p), h⟩⟩
   -- Convert both sides to Finset.sum and apply Finset.sum_erase_eq_sub-style.
-  rw [show ((coords L).map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum =
-      ∑ p ∈ Finset.univ, Stabilizer.Lattice.singleVtx (L := L) p from ?_,
-      show ((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum =
+  rw [show ((coords L).map (fun p => Stabilizer.Lattice.singleVtx p)).sum =
+      ∑ p ∈ Finset.univ, Stabilizer.Lattice.singleVtx p from ?_,
+      show ((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx p)).sum =
       ∑ p ∈ (Finset.univ : Finset (Fin L × Fin L)).erase (originCoord L),
-        Stabilizer.Lattice.singleVtx (L := L) p from ?_]
+        Stabilizer.Lattice.singleVtx p from ?_]
   · rw [Finset.sum_erase_add _ _ (Finset.mem_univ (originCoord L))]
   · rw [show ((Finset.univ : Finset (Fin L × Fin L)).erase (originCoord L)) =
         (coordsTrimmed L).toFinset from h_trim_finset.symm]
@@ -316,9 +316,9 @@ private lemma sum_singleVtx_coords_eq_trimmed_add_origin (L : ℕ) [Fact (0 < L)
 
 /-- Symmetric: decompose `coords L` face sum. -/
 private lemma sum_singleFace_coords_eq_trimmed_add_origin (L : ℕ) [Fact (0 < L)] :
-    ((coords L).map (fun p => Stabilizer.Lattice.singleFace (L := L) p)).sum =
-      ((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleFace (L := L) p)).sum
-        + Stabilizer.Lattice.singleFace (L := L) (originCoord L) := by
+    ((coords L).map (fun p => Stabilizer.Lattice.singleFace p)).sum =
+      ((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleFace p)).sum
+        + Stabilizer.Lattice.singleFace (originCoord L) := by
   have h_nodup : (coords L).Nodup := by
     change ((List.finRange L).product (List.finRange L)).Nodup
     exact List.Nodup.product (List.nodup_finRange L) (List.nodup_finRange L)
@@ -335,11 +335,11 @@ private lemma sum_singleFace_coords_eq_trimmed_add_origin (L : ℕ) [Fact (0 < L
     refine ⟨fun ⟨_, h⟩ => h, fun h => ⟨List.mem_toFinset.mp ((show
       (coords L).toFinset = (Finset.univ : Finset (Fin L × Fin L)) from h_finset_eq) ▸
       Finset.mem_univ p), h⟩⟩
-  rw [show ((coords L).map (fun p => Stabilizer.Lattice.singleFace (L := L) p)).sum =
-      ∑ p ∈ Finset.univ, Stabilizer.Lattice.singleFace (L := L) p from ?_,
-      show ((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleFace (L := L) p)).sum =
+  rw [show ((coords L).map (fun p => Stabilizer.Lattice.singleFace p)).sum =
+      ∑ p ∈ Finset.univ, Stabilizer.Lattice.singleFace p from ?_,
+      show ((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleFace p)).sum =
       ∑ p ∈ (Finset.univ : Finset (Fin L × Fin L)).erase (originCoord L),
-        Stabilizer.Lattice.singleFace (L := L) p from ?_]
+        Stabilizer.Lattice.singleFace p from ?_]
   · rw [Finset.sum_erase_add _ _ (Finset.mem_univ (originCoord L))]
   · rw [show ((Finset.univ : Finset (Fin L × Fin L)).erase (originCoord L)) =
         (coordsTrimmed L).toFinset from h_trim_finset.symm]
@@ -357,14 +357,14 @@ private theorem dropped_vertex_in_closure_remaining (L : ℕ) [Fact (2 ≤ L)] :
   have h_decomp := sum_singleVtx_coords_eq_trimmed_add_origin L
   have h_const := sum_singleVtx_coords L
   have h_trim_plus_origin :
-      ((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum
-        + Stabilizer.Lattice.singleVtx (L := L) (originCoord L) =
+      ((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx p)).sum
+        + Stabilizer.Lattice.singleVtx (originCoord L) =
       (fun _ : Fin L × Fin L => (1 : ZMod 2)) := h_decomp ▸ h_const
   have h_cutMap_trim_eq :
       δ⁰ (L := L)
-          (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum)
+          (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx p)).sum)
         = δ⁰ (L := L)
-            (Stabilizer.Lattice.singleVtx (L := L) (originCoord L)) := by
+            (Stabilizer.Lattice.singleVtx (originCoord L)) := by
     have h_apply := congrArg (δ⁰ (L := L)) h_trim_plus_origin
     rw [LinearMap.map_add, toricVertexCutMap_constOne] at h_apply
     -- h_apply : cutMap trim + cutMap (singleVtx origin) = 0.
@@ -375,25 +375,25 @@ private theorem dropped_vertex_in_closure_remaining (L : ℕ) [Fact (2 ≤ L)] :
         _ = 0 := by rw [h2, zero_mul]
     ext e
     have he : (δ⁰ (L := L)
-        (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum)) e +
+        (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx p)).sum)) e +
         (δ⁰ (L := L)
-        (Stabilizer.Lattice.singleVtx (L := L) (originCoord L))) e = 0 :=
+        (Stabilizer.Lattice.singleVtx (originCoord L))) e = 0 :=
       congrFun h_apply e
     have heq : (δ⁰ (L := L)
-        (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum)) e =
+        (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx p)).sum)) e =
         (δ⁰ (L := L)
-        (Stabilizer.Lattice.singleVtx (L := L) (originCoord L))) e := by
+        (Stabilizer.Lattice.singleVtx (originCoord L))) e := by
       have hself := h_self_zero (δ⁰ (L := L)
-        (Stabilizer.Lattice.singleVtx (L := L) (originCoord L)) e)
+        (Stabilizer.Lattice.singleVtx (originCoord L)) e)
       -- From he and hself, conclude
       have : (δ⁰ (L := L)
-        (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum)) e +
+        (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx p)).sum)) e +
         (δ⁰ (L := L)
-        (Stabilizer.Lattice.singleVtx (L := L) (originCoord L))) e =
+        (Stabilizer.Lattice.singleVtx (originCoord L))) e =
         (δ⁰ (L := L)
-        (Stabilizer.Lattice.singleVtx (L := L) (originCoord L))) e +
+        (Stabilizer.Lattice.singleVtx (originCoord L))) e +
         (δ⁰ (L := L)
-        (Stabilizer.Lattice.singleVtx (L := L) (originCoord L))) e := by
+        (Stabilizer.Lattice.singleVtx (originCoord L))) e := by
         rw [he, hself]
       exact add_right_cancel this
     exact heq
@@ -425,14 +425,14 @@ private theorem dropped_face_in_closure_remaining (L : ℕ) [Fact (2 ≤ L)] :
   have h_decomp := sum_singleFace_coords_eq_trimmed_add_origin L
   have h_const := sum_singleFace_coords L
   have h_trim_plus_origin :
-      ((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleFace (L := L) p)).sum
-        + Stabilizer.Lattice.singleFace (L := L) (originCoord L) =
+      ((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleFace p)).sum
+        + Stabilizer.Lattice.singleFace (originCoord L) =
       (fun _ : Fin L × Fin L => (1 : ZMod 2)) := h_decomp ▸ h_const
   have h_b2_trim_eq :
       ∂₂ (L := L)
-          (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleFace (L := L) p)).sum)
+          (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleFace p)).sum)
         = ∂₂ (L := L)
-            (Stabilizer.Lattice.singleFace (L := L) (originCoord L)) := by
+            (Stabilizer.Lattice.singleFace (originCoord L)) := by
     have h_apply := congrArg (∂₂ (L := L)) h_trim_plus_origin
     rw [LinearMap.map_add, toricBoundary2_constOne] at h_apply
     have h_self_zero : ∀ a : ZMod 2, a + a = 0 := fun a => by
@@ -441,20 +441,20 @@ private theorem dropped_face_in_closure_remaining (L : ℕ) [Fact (2 ≤ L)] :
         _ = 0 := by rw [h2, zero_mul]
     ext e
     have he : (∂₂ (L := L)
-        (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleFace (L := L) p)).sum)) e +
+        (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleFace p)).sum)) e +
         (∂₂ (L := L)
-        (Stabilizer.Lattice.singleFace (L := L) (originCoord L))) e = 0 :=
+        (Stabilizer.Lattice.singleFace (originCoord L))) e = 0 :=
       congrFun h_apply e
     have hself := h_self_zero (∂₂ (L := L)
-      (Stabilizer.Lattice.singleFace (L := L) (originCoord L)) e)
+      (Stabilizer.Lattice.singleFace (originCoord L)) e)
     have : (∂₂ (L := L)
-      (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleFace (L := L) p)).sum)) e +
+      (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleFace p)).sum)) e +
       (∂₂ (L := L)
-      (Stabilizer.Lattice.singleFace (L := L) (originCoord L))) e =
+      (Stabilizer.Lattice.singleFace (originCoord L))) e =
       (∂₂ (L := L)
-      (Stabilizer.Lattice.singleFace (L := L) (originCoord L))) e +
+      (Stabilizer.Lattice.singleFace (originCoord L))) e +
       (∂₂ (L := L)
-      (Stabilizer.Lattice.singleFace (L := L) (originCoord L))) e := by
+      (Stabilizer.Lattice.singleFace (originCoord L))) e := by
       rw [he, hself]
     exact add_right_cancel this
   have h_prod_eq : (generatorsListXTrimmed L).prod = faceStab L (zeroCoord L) (zeroCoord L) := by
@@ -1123,14 +1123,14 @@ private lemma coordsTrimmed_not_mem_origin (L : ℕ) [Fact (0 < L)] :
 trimmed coords whose `cutMap` is `0` must have all-zero coefficients. -/
 private lemma trimmed_combo_singleVtx_eq_zero (L : ℕ) [Fact (0 < L)]
     (c : Fin (coordsTrimmed L).length → ZMod 2)
-    (hker : (∑ i, c i • Stabilizer.Lattice.singleVtx (L := L) ((coordsTrimmed L).get i)) ∈
+    (hker : (∑ i, c i • Stabilizer.Lattice.singleVtx ((coordsTrimmed L).get i)) ∈
         LinearMap.ker (δ⁰ (L := L))) :
     ∀ i, c i = 0 := by
   classical
   rw [Stabilizer.Lattice.mem_ker_cutMap_iff] at hker
   obtain ⟨k, hk⟩ := hker
   -- Evaluate at origin: sum is 0 (origin ∉ trimmed), so k = 0.
-  have h_orig : (∑ i, c i • Stabilizer.Lattice.singleVtx (L := L)
+  have h_orig : (∑ i, c i • Stabilizer.Lattice.singleVtx
       ((coordsTrimmed L).get i)) (originCoord L) = 0 := by
     rw [Finset.sum_apply]
     apply Finset.sum_eq_zero
@@ -1140,7 +1140,7 @@ private lemma trimmed_combo_singleVtx_eq_zero (L : ℕ) [Fact (0 < L)]
       intro heq
       rw [heq] at this
       exact coordsTrimmed_not_mem_origin L this
-    change c i * Stabilizer.Lattice.singleVtx (L := L) ((coordsTrimmed L).get i)
+    change c i * Stabilizer.Lattice.singleVtx ((coordsTrimmed L).get i)
         (originCoord L) = 0
     rw [Stabilizer.Lattice.singleVtx_apply_ne (Ne.symm h_get_ne)]
     ring
@@ -1149,18 +1149,18 @@ private lemma trimmed_combo_singleVtx_eq_zero (L : ℕ) [Fact (0 < L)]
     rw [h_orig] at this
     exact this.symm
   -- So the sum is identically 0.
-  have h_sum_zero : (∑ i, c i • Stabilizer.Lattice.singleVtx (L := L)
+  have h_sum_zero : (∑ i, c i • Stabilizer.Lattice.singleVtx
       ((coordsTrimmed L).get i)) = 0 := by
     rw [hk]; ext; simp [hk_zero]
   -- Extract each c j = 0 by evaluating at (coordsTrimmed L).get j.
   intro j
-  have h_at_j : (∑ i, c i • Stabilizer.Lattice.singleVtx (L := L)
+  have h_at_j : (∑ i, c i • Stabilizer.Lattice.singleVtx
       ((coordsTrimmed L).get i)) ((coordsTrimmed L).get j) = 0 := by
     rw [h_sum_zero]; rfl
   rw [Finset.sum_apply] at h_at_j
   rw [Finset.sum_eq_single j] at h_at_j
   · change c j = 0
-    have : c j * Stabilizer.Lattice.singleVtx (L := L) ((coordsTrimmed L).get j)
+    have : c j * Stabilizer.Lattice.singleVtx ((coordsTrimmed L).get j)
         ((coordsTrimmed L).get j) = 0 := h_at_j
     rw [Stabilizer.Lattice.singleVtx_apply_self] at this
     simpa using this
@@ -1168,7 +1168,7 @@ private lemma trimmed_combo_singleVtx_eq_zero (L : ℕ) [Fact (0 < L)]
     have hne : (coordsTrimmed L).get i ≠ (coordsTrimmed L).get j := by
       intro heq
       exact hij (List.nodup_iff_injective_get.mp (coordsTrimmed_nodup L) heq)
-    change c i * Stabilizer.Lattice.singleVtx (L := L) ((coordsTrimmed L).get i)
+    change c i * Stabilizer.Lattice.singleVtx ((coordsTrimmed L).get i)
         ((coordsTrimmed L).get j) = 0
     rw [Stabilizer.Lattice.singleVtx_apply_ne (Ne.symm hne)]
     ring
@@ -1177,13 +1177,13 @@ private lemma trimmed_combo_singleVtx_eq_zero (L : ℕ) [Fact (0 < L)]
 /-- Face-side block kernel collapse: same as Z-side but for `singleFace` and `boundary2`. -/
 private lemma trimmed_combo_singleFace_eq_zero (L : ℕ) [Fact (0 < L)]
     (c : Fin (coordsTrimmed L).length → ZMod 2)
-    (hker : (∑ i, c i • Stabilizer.Lattice.singleFace (L := L) ((coordsTrimmed L).get i)) ∈
+    (hker : (∑ i, c i • Stabilizer.Lattice.singleFace ((coordsTrimmed L).get i)) ∈
         LinearMap.ker (∂₂ (L := L))) :
     ∀ i, c i = 0 := by
   classical
   rw [Stabilizer.Lattice.mem_ker_boundary2_iff] at hker
   obtain ⟨k, hk⟩ := hker
-  have h_orig : (∑ i, c i • Stabilizer.Lattice.singleFace (L := L)
+  have h_orig : (∑ i, c i • Stabilizer.Lattice.singleFace
       ((coordsTrimmed L).get i)) (originCoord L) = 0 := by
     rw [Finset.sum_apply]
     apply Finset.sum_eq_zero
@@ -1193,7 +1193,7 @@ private lemma trimmed_combo_singleFace_eq_zero (L : ℕ) [Fact (0 < L)]
       intro heq
       rw [heq] at this
       exact coordsTrimmed_not_mem_origin L this
-    change c i * Stabilizer.Lattice.singleFace (L := L) ((coordsTrimmed L).get i)
+    change c i * Stabilizer.Lattice.singleFace ((coordsTrimmed L).get i)
         (originCoord L) = 0
     rw [Stabilizer.Lattice.singleFace_apply_ne (Ne.symm h_get_ne)]
     ring
@@ -1201,16 +1201,16 @@ private lemma trimmed_combo_singleFace_eq_zero (L : ℕ) [Fact (0 < L)]
     have := congr_fun hk (originCoord L)
     rw [h_orig] at this
     exact this.symm
-  have h_sum_zero : (∑ i, c i • Stabilizer.Lattice.singleFace (L := L)
+  have h_sum_zero : (∑ i, c i • Stabilizer.Lattice.singleFace
       ((coordsTrimmed L).get i)) = 0 := by
     rw [hk]; ext; simp [hk_zero]
   intro j
-  have h_at_j : (∑ i, c i • Stabilizer.Lattice.singleFace (L := L)
+  have h_at_j : (∑ i, c i • Stabilizer.Lattice.singleFace
       ((coordsTrimmed L).get i)) ((coordsTrimmed L).get j) = 0 := by
     rw [h_sum_zero]; rfl
   rw [Finset.sum_apply] at h_at_j
   rw [Finset.sum_eq_single j] at h_at_j
-  · have : c j * Stabilizer.Lattice.singleFace (L := L) ((coordsTrimmed L).get j)
+  · have : c j * Stabilizer.Lattice.singleFace ((coordsTrimmed L).get j)
         ((coordsTrimmed L).get j) = 0 := h_at_j
     rw [Stabilizer.Lattice.singleFace_apply_self] at this
     simpa using this
@@ -1218,7 +1218,7 @@ private lemma trimmed_combo_singleFace_eq_zero (L : ℕ) [Fact (0 < L)]
     have hne : (coordsTrimmed L).get i ≠ (coordsTrimmed L).get j := by
       intro heq
       exact hij (List.nodup_iff_injective_get.mp (coordsTrimmed_nodup L) heq)
-    change c i * Stabilizer.Lattice.singleFace (L := L) ((coordsTrimmed L).get i)
+    change c i * Stabilizer.Lattice.singleFace ((coordsTrimmed L).get i)
         ((coordsTrimmed L).get j) = 0
     rw [Stabilizer.Lattice.singleFace_apply_ne (Ne.symm hne)]
     ring
@@ -1247,7 +1247,7 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
         simp [generatorsListZTrimmed]
       omega⟩
   -- The Z-half of the sum at each edge yields the chain combination.
-  have h_chain_Z : (∑ i, cZ i • Stabilizer.Lattice.singleVtx (L := L)
+  have h_chain_Z : (∑ i, cZ i • Stabilizer.Lattice.singleVtx
       ((coordsTrimmed L).get i)) ∈
       LinearMap.ker (δ⁰ (L := L)) := by
     rw [LinearMap.mem_ker]
@@ -1327,14 +1327,14 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
           ⟨k.val, by have := k.isLt; omega⟩
           (Fin.natAdd (numQubits L) (Stabilizer.Lattice.edgeToQubitIdx L e)) =
         δ⁰ (L := L)
-          (Stabilizer.Lattice.singleVtx (L := L) ((coordsTrimmed L).get k)) e := by
+          (Stabilizer.Lattice.singleVtx ((coordsTrimmed L).get k)) e := by
       intro k
       have hp_eq := get_packaged_Z L k (by have := k.isLt; omega)
       unfold NQubitPauliGroupElement.checkMatrix
       rw [hp_eq, toSymplectic_vertexStab_Z_eq, qubitToEdgeIdx_edgeToQubitIdx]
     have h_col' : ∑ k : Fin (coordsTrimmed L).length, cZ k *
         δ⁰ (L := L)
-          (Stabilizer.Lattice.singleVtx (L := L) ((coordsTrimmed L).get k)) e = 0 := by
+          (Stabilizer.Lattice.singleVtx ((coordsTrimmed L).get k)) e = 0 := by
       rw [← h_col]
       apply Finset.sum_congr rfl
       intro k _
@@ -1347,9 +1347,9 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
     intro k _
     rw [LinearMap.map_smul]
     change cZ k • δ⁰ (L := L)
-        (Stabilizer.Lattice.singleVtx (L := L) ((coordsTrimmed L).get k)) e =
+        (Stabilizer.Lattice.singleVtx ((coordsTrimmed L).get k)) e =
       cZ k * δ⁰ (L := L)
-        (Stabilizer.Lattice.singleVtx (L := L) ((coordsTrimmed L).get k)) e
+        (Stabilizer.Lattice.singleVtx ((coordsTrimmed L).get k)) e
     rw [smul_eq_mul]
   -- Now apply Z-block kernel collapse to get cZ = 0.
   have hZ_zero : ∀ i, cZ i = 0 := trimmed_combo_singleVtx_eq_zero L cZ h_chain_Z
@@ -1363,7 +1363,7 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
         simp [generatorsListZTrimmed, generatorsListXTrimmed]
       have := i.isLt
       omega⟩
-  have h_chain_X : (∑ i, cX i • Stabilizer.Lattice.singleFace (L := L)
+  have h_chain_X : (∑ i, cX i • Stabilizer.Lattice.singleFace
       ((coordsTrimmed L).get i)) ∈
       LinearMap.ker (∂₂ (L := L)) := by
     rw [LinearMap.mem_ker]
@@ -1447,7 +1447,7 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
           ⟨nZ + k.val, by have := k.isLt; omega⟩
           (Fin.castAdd (numQubits L) (Stabilizer.Lattice.edgeToQubitIdx L e)) =
         ∂₂ (L := L)
-          (Stabilizer.Lattice.singleFace (L := L) ((coordsTrimmed L).get k)) e := by
+          (Stabilizer.Lattice.singleFace ((coordsTrimmed L).get k)) e := by
       intro k
       have hge : nZ ≤ nZ + k.val := Nat.le_add_right _ _
       have hsub : nZ + k.val - nZ < nZ := by
@@ -1467,7 +1467,7 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
       rw [hcoord_eq]
     have h_col' : ∑ k : Fin (coordsTrimmed L).length, cX k *
         ∂₂ (L := L)
-          (Stabilizer.Lattice.singleFace (L := L) ((coordsTrimmed L).get k)) e = 0 := by
+          (Stabilizer.Lattice.singleFace ((coordsTrimmed L).get k)) e = 0 := by
       rw [← h_col]
       apply Finset.sum_congr rfl
       intro k _
@@ -1479,9 +1479,9 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
     intro k _
     rw [LinearMap.map_smul]
     change cX k • ∂₂ (L := L)
-        (Stabilizer.Lattice.singleFace (L := L) ((coordsTrimmed L).get k)) e =
+        (Stabilizer.Lattice.singleFace ((coordsTrimmed L).get k)) e =
       cX k * ∂₂ (L := L)
-        (Stabilizer.Lattice.singleFace (L := L) ((coordsTrimmed L).get k)) e
+        (Stabilizer.Lattice.singleFace ((coordsTrimmed L).get k)) e
     rw [smul_eq_mul]
   have hX_zero : ∀ i, cX i = 0 := trimmed_combo_singleFace_eq_zero L cX h_chain_X
   -- Combine: f = 0.

--- a/QEC/Stabilizer/Codes/Toric/StabilizerCode.lean
+++ b/QEC/Stabilizer/Codes/Toric/StabilizerCode.lean
@@ -32,6 +32,7 @@ namespace StabilizerGroup
 namespace ToricCodeN
 
 open NQubitPauliGroupElement
+open scoped ToricChain
 open Stabilizer.Lattice
 
 -- ---------------------------------------------------------------------------
@@ -183,14 +184,14 @@ lemma generators_commute_packaged (L : ℕ) [Fact (2 ≤ L)] :
 /-- The cut map sends the constant-1 0-chain to the zero 1-chain (each edge
 collects `1 + 1 = 0` from its two incident vertices). -/
 private lemma toricVertexCutMap_constOne (L : ℕ) [Fact (0 < L)] :
-    Stabilizer.Lattice.toricVertexCutMap (L := L) (fun _ : Fin L × Fin L => (1 : ZMod 2)) = 0 := by
+    δ⁰ (L := L) (fun _ : Fin L × Fin L => (1 : ZMod 2)) = 0 := by
   ext e
   have h : (1 : ZMod 2) + 1 = 0 := by decide
   cases e <;> simp [Stabilizer.Lattice.toricVertexCutMap, h]
 
 /-- `∂₂` sends the constant-1 2-chain to zero (each edge collects `1 + 1 = 0`). -/
 private lemma toricBoundary2_constOne (L : ℕ) [Fact (0 < L)] :
-    Stabilizer.Lattice.toricBoundary2 (L := L) (fun _ : Fin L × Fin L => (1 : ZMod 2)) = 0 := by
+    ∂₂ (L := L) (fun _ : Fin L × Fin L => (1 : ZMod 2)) = 0 := by
   ext e
   have h : (1 : ZMod 2) + 1 = 0 := by decide
   cases e <;> simp [Stabilizer.Lattice.toricBoundary2, h]
@@ -202,7 +203,7 @@ private lemma vertexStab_listProd_eq_chain (L : ℕ) [Fact (2 ≤ L)]
     (lst : List (Fin L × Fin L)) :
     (lst.map (fun p => vertexStab L p.1 p.2)).prod =
       Stabilizer.Lattice.toricZOperatorOfChain L
-        (Stabilizer.Lattice.toricVertexCutMap (L := L)
+        (δ⁰ (L := L)
           ((lst.map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum)) := by
   haveI : Fact (0 < L) := ⟨lt_of_lt_of_le (by decide : 0 < 2) Fact.out⟩
   induction lst with
@@ -220,7 +221,7 @@ private lemma faceStab_listProd_eq_chain (L : ℕ) [Fact (2 ≤ L)]
     (lst : List (Fin L × Fin L)) :
     (lst.map (fun p => faceStab L p.1 p.2)).prod =
       Stabilizer.Lattice.toricXOperatorOfChain L
-        (Stabilizer.Lattice.toricBoundary2 (L := L)
+        (∂₂ (L := L)
           ((lst.map (fun p => Stabilizer.Lattice.singleFace (L := L) p)).sum)) := by
   haveI : Fact (0 < L) := ⟨lt_of_lt_of_le (by decide : 0 < 2) Fact.out⟩
   induction lst with
@@ -360,11 +361,11 @@ private theorem dropped_vertex_in_closure_remaining (L : ℕ) [Fact (2 ≤ L)] :
         + Stabilizer.Lattice.singleVtx (L := L) (originCoord L) =
       (fun _ : Fin L × Fin L => (1 : ZMod 2)) := h_decomp ▸ h_const
   have h_cutMap_trim_eq :
-      Stabilizer.Lattice.toricVertexCutMap (L := L)
+      δ⁰ (L := L)
           (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum)
-        = Stabilizer.Lattice.toricVertexCutMap (L := L)
+        = δ⁰ (L := L)
             (Stabilizer.Lattice.singleVtx (L := L) (originCoord L)) := by
-    have h_apply := congrArg (Stabilizer.Lattice.toricVertexCutMap (L := L)) h_trim_plus_origin
+    have h_apply := congrArg (δ⁰ (L := L)) h_trim_plus_origin
     rw [LinearMap.map_add, toricVertexCutMap_constOne] at h_apply
     -- h_apply : cutMap trim + cutMap (singleVtx origin) = 0.
     -- In ZMod 2, a + b = 0 implies a = b.
@@ -373,25 +374,25 @@ private theorem dropped_vertex_in_closure_remaining (L : ℕ) [Fact (2 ≤ L)] :
       calc a + a = (2 : ZMod 2) * a := by ring
         _ = 0 := by rw [h2, zero_mul]
     ext e
-    have he : (Stabilizer.Lattice.toricVertexCutMap (L := L)
+    have he : (δ⁰ (L := L)
         (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum)) e +
-        (Stabilizer.Lattice.toricVertexCutMap (L := L)
+        (δ⁰ (L := L)
         (Stabilizer.Lattice.singleVtx (L := L) (originCoord L))) e = 0 :=
       congrFun h_apply e
-    have heq : (Stabilizer.Lattice.toricVertexCutMap (L := L)
+    have heq : (δ⁰ (L := L)
         (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum)) e =
-        (Stabilizer.Lattice.toricVertexCutMap (L := L)
+        (δ⁰ (L := L)
         (Stabilizer.Lattice.singleVtx (L := L) (originCoord L))) e := by
-      have hself := h_self_zero (Stabilizer.Lattice.toricVertexCutMap (L := L)
+      have hself := h_self_zero (δ⁰ (L := L)
         (Stabilizer.Lattice.singleVtx (L := L) (originCoord L)) e)
       -- From he and hself, conclude
-      have : (Stabilizer.Lattice.toricVertexCutMap (L := L)
+      have : (δ⁰ (L := L)
         (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum)) e +
-        (Stabilizer.Lattice.toricVertexCutMap (L := L)
+        (δ⁰ (L := L)
         (Stabilizer.Lattice.singleVtx (L := L) (originCoord L))) e =
-        (Stabilizer.Lattice.toricVertexCutMap (L := L)
+        (δ⁰ (L := L)
         (Stabilizer.Lattice.singleVtx (L := L) (originCoord L))) e +
-        (Stabilizer.Lattice.toricVertexCutMap (L := L)
+        (δ⁰ (L := L)
         (Stabilizer.Lattice.singleVtx (L := L) (originCoord L))) e := by
         rw [he, hself]
       exact add_right_cancel this
@@ -428,31 +429,31 @@ private theorem dropped_face_in_closure_remaining (L : ℕ) [Fact (2 ≤ L)] :
         + Stabilizer.Lattice.singleFace (L := L) (originCoord L) =
       (fun _ : Fin L × Fin L => (1 : ZMod 2)) := h_decomp ▸ h_const
   have h_b2_trim_eq :
-      Stabilizer.Lattice.toricBoundary2 (L := L)
+      ∂₂ (L := L)
           (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleFace (L := L) p)).sum)
-        = Stabilizer.Lattice.toricBoundary2 (L := L)
+        = ∂₂ (L := L)
             (Stabilizer.Lattice.singleFace (L := L) (originCoord L)) := by
-    have h_apply := congrArg (Stabilizer.Lattice.toricBoundary2 (L := L)) h_trim_plus_origin
+    have h_apply := congrArg (∂₂ (L := L)) h_trim_plus_origin
     rw [LinearMap.map_add, toricBoundary2_constOne] at h_apply
     have h_self_zero : ∀ a : ZMod 2, a + a = 0 := fun a => by
       have h2 : (2 : ZMod 2) = 0 := by decide
       calc a + a = (2 : ZMod 2) * a := by ring
         _ = 0 := by rw [h2, zero_mul]
     ext e
-    have he : (Stabilizer.Lattice.toricBoundary2 (L := L)
+    have he : (∂₂ (L := L)
         (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleFace (L := L) p)).sum)) e +
-        (Stabilizer.Lattice.toricBoundary2 (L := L)
+        (∂₂ (L := L)
         (Stabilizer.Lattice.singleFace (L := L) (originCoord L))) e = 0 :=
       congrFun h_apply e
-    have hself := h_self_zero (Stabilizer.Lattice.toricBoundary2 (L := L)
+    have hself := h_self_zero (∂₂ (L := L)
       (Stabilizer.Lattice.singleFace (L := L) (originCoord L)) e)
-    have : (Stabilizer.Lattice.toricBoundary2 (L := L)
+    have : (∂₂ (L := L)
       (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleFace (L := L) p)).sum)) e +
-      (Stabilizer.Lattice.toricBoundary2 (L := L)
+      (∂₂ (L := L)
       (Stabilizer.Lattice.singleFace (L := L) (originCoord L))) e =
-      (Stabilizer.Lattice.toricBoundary2 (L := L)
+      (∂₂ (L := L)
       (Stabilizer.Lattice.singleFace (L := L) (originCoord L))) e +
-      (Stabilizer.Lattice.toricBoundary2 (L := L)
+      (∂₂ (L := L)
       (Stabilizer.Lattice.singleFace (L := L) (originCoord L))) e := by
       rw [he, hself]
     exact add_right_cancel this
@@ -988,15 +989,15 @@ private lemma toSymplectic_vertexStab_Z_eq (L : ℕ) [Fact (2 ≤ L)]
     (p : Fin L × Fin L) (i : Fin (numQubits L)) :
     NQubitPauliOperator.toSymplectic (vertexStab L p.1 p.2).operators
         (Fin.natAdd (numQubits L) i) =
-      Stabilizer.Lattice.toricVertexCutMap (L := L)
+      δ⁰ (L := L)
         (Stabilizer.Lattice.singleVtx p) (qubitToEdgeIdx L i) := by
   haveI : Fact (0 < L) := ⟨lt_of_lt_of_le (by decide : 0 < 2) Fact.out⟩
   rw [NQubitPauliOperator.toSymplectic_Z_part]
   rw [show vertexStab L p.1 p.2 = Stabilizer.Lattice.toricZOperatorOfChain L
-        (Stabilizer.Lattice.toricVertexCutMap (L := L) (Stabilizer.Lattice.singleVtx p)) from
+        (δ⁰ (L := L) (Stabilizer.Lattice.singleVtx p)) from
     (Stabilizer.Lattice.toricZOperatorOfChain_cutMap_singleVtx L p.1 p.2).symm]
   rw [Stabilizer.Lattice.toricZOperatorOfChain_op_at]
-  set v := Stabilizer.Lattice.toricVertexCutMap (L := L)
+  set v := δ⁰ (L := L)
     (Stabilizer.Lattice.singleVtx p) (qubitToEdgeIdx L i) with hv
   rcases zmod2_zero_or_one v with h0 | h1
   · -- v = 0: no edge index has chain value 1 at i; symplectic = 0.
@@ -1022,15 +1023,15 @@ private lemma toSymplectic_faceStab_X_eq (L : ℕ) [Fact (2 ≤ L)]
     (p : Fin L × Fin L) (i : Fin (numQubits L)) :
     NQubitPauliOperator.toSymplectic (faceStab L p.1 p.2).operators
         (Fin.castAdd (numQubits L) i) =
-      Stabilizer.Lattice.toricBoundary2 (L := L)
+      ∂₂ (L := L)
         (Stabilizer.Lattice.singleFace p) (qubitToEdgeIdx L i) := by
   haveI : Fact (0 < L) := ⟨lt_of_lt_of_le (by decide : 0 < 2) Fact.out⟩
   rw [NQubitPauliOperator.toSymplectic_X_part]
   rw [show faceStab L p.1 p.2 = Stabilizer.Lattice.toricXOperatorOfChain L
-        (Stabilizer.Lattice.toricBoundary2 (L := L) (Stabilizer.Lattice.singleFace p)) from
+        (∂₂ (L := L) (Stabilizer.Lattice.singleFace p)) from
     (Stabilizer.Lattice.toricXOperatorOfChain_boundary_singleFace L p.1 p.2).symm]
   rw [Stabilizer.Lattice.toricXOperatorOfChain_op_at]
-  set v := Stabilizer.Lattice.toricBoundary2 (L := L)
+  set v := ∂₂ (L := L)
     (Stabilizer.Lattice.singleFace p) (qubitToEdgeIdx L i) with hv
   rcases zmod2_zero_or_one v with h0 | h1
   · rw [if_neg ?_]
@@ -1123,7 +1124,7 @@ trimmed coords whose `cutMap` is `0` must have all-zero coefficients. -/
 private lemma trimmed_combo_singleVtx_eq_zero (L : ℕ) [Fact (0 < L)]
     (c : Fin (coordsTrimmed L).length → ZMod 2)
     (hker : (∑ i, c i • Stabilizer.Lattice.singleVtx (L := L) ((coordsTrimmed L).get i)) ∈
-        LinearMap.ker (Stabilizer.Lattice.toricVertexCutMap (L := L))) :
+        LinearMap.ker (δ⁰ (L := L))) :
     ∀ i, c i = 0 := by
   classical
   rw [Stabilizer.Lattice.mem_ker_cutMap_iff] at hker
@@ -1177,7 +1178,7 @@ private lemma trimmed_combo_singleVtx_eq_zero (L : ℕ) [Fact (0 < L)]
 private lemma trimmed_combo_singleFace_eq_zero (L : ℕ) [Fact (0 < L)]
     (c : Fin (coordsTrimmed L).length → ZMod 2)
     (hker : (∑ i, c i • Stabilizer.Lattice.singleFace (L := L) ((coordsTrimmed L).get i)) ∈
-        LinearMap.ker (Stabilizer.Lattice.toricBoundary2 (L := L))) :
+        LinearMap.ker (∂₂ (L := L))) :
     ∀ i, c i = 0 := by
   classical
   rw [Stabilizer.Lattice.mem_ker_boundary2_iff] at hker
@@ -1248,7 +1249,7 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
   -- The Z-half of the sum at each edge yields the chain combination.
   have h_chain_Z : (∑ i, cZ i • Stabilizer.Lattice.singleVtx (L := L)
       ((coordsTrimmed L).get i)) ∈
-      LinearMap.ker (Stabilizer.Lattice.toricVertexCutMap (L := L)) := by
+      LinearMap.ker (δ⁰ (L := L)) := by
     rw [LinearMap.mem_ker]
     ext e
     -- Specialize hsum at column Fin.natAdd (numQubits L) (edgeToQubitIdx L e).
@@ -1325,14 +1326,14 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
         NQubitPauliGroupElement.checkMatrix (generatorsListPackaged L)
           ⟨k.val, by have := k.isLt; omega⟩
           (Fin.natAdd (numQubits L) (Stabilizer.Lattice.edgeToQubitIdx L e)) =
-        Stabilizer.Lattice.toricVertexCutMap (L := L)
+        δ⁰ (L := L)
           (Stabilizer.Lattice.singleVtx (L := L) ((coordsTrimmed L).get k)) e := by
       intro k
       have hp_eq := get_packaged_Z L k (by have := k.isLt; omega)
       unfold NQubitPauliGroupElement.checkMatrix
       rw [hp_eq, toSymplectic_vertexStab_Z_eq, qubitToEdgeIdx_edgeToQubitIdx]
     have h_col' : ∑ k : Fin (coordsTrimmed L).length, cZ k *
-        Stabilizer.Lattice.toricVertexCutMap (L := L)
+        δ⁰ (L := L)
           (Stabilizer.Lattice.singleVtx (L := L) ((coordsTrimmed L).get k)) e = 0 := by
       rw [← h_col]
       apply Finset.sum_congr rfl
@@ -1345,9 +1346,9 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
     apply Finset.sum_congr rfl
     intro k _
     rw [LinearMap.map_smul]
-    change cZ k • Stabilizer.Lattice.toricVertexCutMap (L := L)
+    change cZ k • δ⁰ (L := L)
         (Stabilizer.Lattice.singleVtx (L := L) ((coordsTrimmed L).get k)) e =
-      cZ k * Stabilizer.Lattice.toricVertexCutMap (L := L)
+      cZ k * δ⁰ (L := L)
         (Stabilizer.Lattice.singleVtx (L := L) ((coordsTrimmed L).get k)) e
     rw [smul_eq_mul]
   -- Now apply Z-block kernel collapse to get cZ = 0.
@@ -1364,7 +1365,7 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
       omega⟩
   have h_chain_X : (∑ i, cX i • Stabilizer.Lattice.singleFace (L := L)
       ((coordsTrimmed L).get i)) ∈
-      LinearMap.ker (Stabilizer.Lattice.toricBoundary2 (L := L)) := by
+      LinearMap.ker (∂₂ (L := L)) := by
     rw [LinearMap.mem_ker]
     ext e
     have h_col := congr_fun hsum (Fin.castAdd (numQubits L)
@@ -1445,7 +1446,7 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
         NQubitPauliGroupElement.checkMatrix (generatorsListPackaged L)
           ⟨nZ + k.val, by have := k.isLt; omega⟩
           (Fin.castAdd (numQubits L) (Stabilizer.Lattice.edgeToQubitIdx L e)) =
-        Stabilizer.Lattice.toricBoundary2 (L := L)
+        ∂₂ (L := L)
           (Stabilizer.Lattice.singleFace (L := L) ((coordsTrimmed L).get k)) e := by
       intro k
       have hge : nZ ≤ nZ + k.val := Nat.le_add_right _ _
@@ -1465,7 +1466,7 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
         omega
       rw [hcoord_eq]
     have h_col' : ∑ k : Fin (coordsTrimmed L).length, cX k *
-        Stabilizer.Lattice.toricBoundary2 (L := L)
+        ∂₂ (L := L)
           (Stabilizer.Lattice.singleFace (L := L) ((coordsTrimmed L).get k)) e = 0 := by
       rw [← h_col]
       apply Finset.sum_congr rfl
@@ -1477,9 +1478,9 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
     apply Finset.sum_congr rfl
     intro k _
     rw [LinearMap.map_smul]
-    change cX k • Stabilizer.Lattice.toricBoundary2 (L := L)
+    change cX k • ∂₂ (L := L)
         (Stabilizer.Lattice.singleFace (L := L) ((coordsTrimmed L).get k)) e =
-      cX k * Stabilizer.Lattice.toricBoundary2 (L := L)
+      cX k * ∂₂ (L := L)
         (Stabilizer.Lattice.singleFace (L := L) ((coordsTrimmed L).get k)) e
     rw [smul_eq_mul]
   have hX_zero : ∀ i, cX i = 0 := trimmed_combo_singleFace_eq_zero L cX h_chain_X

--- a/QEC/Stabilizer/Codes/Toric/WrappingInvariants.lean
+++ b/QEC/Stabilizer/Codes/Toric/WrappingInvariants.lean
@@ -8,6 +8,7 @@ namespace Stabilizer
 namespace Lattice
 
 open scoped BigOperators
+open scoped ToricChain
 
 variable (L : ℕ)
 
@@ -83,7 +84,7 @@ theorem hAt_independent_on_cycles (c : toricCycles (L := L)) (x0 x1 : Fin L) :
           c.val (EdgeIdx.h x y) + c.val (EdgeIdx.h (prev L x) y) +
             c.val (EdgeIdx.v x y) + c.val (EdgeIdx.v x (prev L y)) = 0 := by
         intro y
-        have h_cycle : toricBoundary1 (L := L) c.val (x, y) = 0 := by
+        have h_cycle : ∂₁ (L := L) c.val (x, y) = 0 := by
           exact c.2 |> fun h => by simp ;
         convert h_cycle using 1;
       aesop;
@@ -183,7 +184,7 @@ theorem h_boundary_zero (b : toricBoundaries (L := L)) :
             simp [two_mul]
       _ = 0 := by simp [h2]
   change (∑ y : Fin L,
-      toricBoundary2 (L := L) f (EdgeIdx.h z0 y)) = 0
+      ∂₂ (L := L) f (EdgeIdx.h z0 y)) = 0
   simpa [toricBoundary2, Finset.sum_add_distrib, hsum_prev] using hdouble_zero
 
 /-- Boundaries have trivial `v` invariant. -/
@@ -211,7 +212,7 @@ theorem v_boundary_zero (b : toricBoundaries (L := L)) :
             simp [two_mul]
       _ = 0 := by simp [h2]
   change (∑ x : Fin L,
-      toricBoundary2 (L := L) f (EdgeIdx.v x z0)) = 0
+      ∂₂ (L := L) f (EdgeIdx.v x z0)) = 0
   simpa [toricBoundary2, Finset.sum_add_distrib, hsum_prev] using hdouble_zero
 
 /-- Quotient-level `(h,v)` map is well-defined. -/
@@ -258,7 +259,7 @@ theorem phi_surjective :
   obtain ⟨c, hc⟩ : ∃ c : C1 L,
       (∀ x' : Fin L, ∀ y' : Fin L, c (EdgeIdx.h x' y') = if y' = zeroCoord L then x else 0) ∧
       (∀ x' : Fin L, ∀ y' : Fin L, c (EdgeIdx.v x' y') = if x' = zeroCoord L then y else 0) ∧
-      toricBoundary1 (L := L) c = 0 := by
+      ∂₁ (L := L) c = 0 := by
     refine ⟨
       (fun e =>
         match e with

--- a/QEC/Stabilizer/Codes/_TEMPLATE.lean
+++ b/QEC/Stabilizer/Codes/_TEMPLATE.lean
@@ -120,6 +120,10 @@ Conventions:
   `-σ[…]` = phase `-1`, `-iσ[…]` = phase `-i`.)
 - 0-based qubit indexing: the k-th letter is the operator on qubit k.
 - One `def` per generator. Name them `Z1, Z2, …, X1, X2, …`.
+- The bare Pauli string with no phase (an `NQubitPauliOperator n`) is `P[…]`:
+  `σ[ZZZIZII].operators = P[ZZZIZII]` by `rfl`, and `P[…]` elaborates to exactly
+  the bare `.set` chain. Reach for it in `operators`-level statements (support,
+  check-matrix rows) rather than spelling the chain out.
 
 **Non-CSS variant.** Mixed-Pauli generators use the same notation (e.g., the
 5-qubit perfect code's `σ[XZZXI]`); there is no Z/X partition.

--- a/QEC/Stabilizer/Foundations/PauliGroup/Notation.lean
+++ b/QEC/Stabilizer/Foundations/PauliGroup/Notation.lean
@@ -12,16 +12,21 @@ way the physics literature does:
 - `-σ[XXIXII]` — phase `-1` (`phasePower = 2`)
 - `-iσ[XXIXII]` — phase `-i` (`phasePower = 3`)
 
+and for the bare Pauli string with no phase at all, an `NQubitPauliOperator`:
+
+- `P[XXIXII]` — the operator part on its own, i.e. `σ[XXIXII].operators`
+
 The letters between the brackets form a single identifier over the alphabet `X`, `Y`,
 `Z`, `I`, read left to right as qubits `0, 1, …`; the number of letters fixes the number
-of qubits, so `σ[XIZ] : NQubitPauliGroupElement 3` with no ascription needed.
+of qubits, so `σ[XIZ] : NQubitPauliGroupElement 3` and `P[XIZ] : NQubitPauliOperator 3`
+with no ascription needed.
 
 The notation is **scoped**: enable it with `open scoped Pauli`. It must be opt-in
 because any notation whose leading token is `σ[` takes over that token from `GetElem`
-indexing (`σ[i]`) for variables named `σ` (likewise `iσ[…]` for variables named `iσ`).
-The phase prefixes are part of the leading token (`-σ[`, `iσ[`, `-iσ[`): write them with
-no space before `σ[`, and keep spaces around a binary `-` (`a - σ[XX]`) when you mean
-subtraction with the scope open.
+indexing (`σ[i]`) for variables named `σ` (likewise `iσ[…]` for variables named `iσ`, and
+`P[…]` for variables named `P`). The phase prefixes are part of the leading token (`-σ[`,
+`iσ[`, `-iσ[`): write them with no space before `σ[`, and keep spaces around a binary `-`
+(`a - σ[XX]`) when you mean subtraction with the scope open.
 
 ## Elaboration guarantee
 
@@ -32,20 +37,24 @@ concrete code files:
 ⟨phase, ((NQubitPauliOperator.identity n).set i₀ op₀).set i₁ op₁ ⋯⟩
 ```
 
-with `.set` applied only at the non-identity positions, in increasing index order. The
-notation is a macro (pure syntax expansion into that form), so kernel-reduction behavior
-and every existing `simp`/`decide`/`rfl` proof over such literals are unchanged. In
-particular there is deliberately no `ofList`-style helper on the elaboration path: a list
-lookup is an O(n) walk under kernel reduction (see the axiom-policy notes in
-`CLAUDE.md`), whereas the `.set` chain is the form all existing proofs already consume.
+with `.set` applied only at the non-identity positions, in increasing index order, and
+`P[…]` elaborates to exactly the operator half of that form, the bare `.set` chain (so
+`P[II…I]` is `NQubitPauliOperator.identity n` itself). The notation is a macro (pure
+syntax expansion into that form), so kernel-reduction behavior and every existing
+`simp`/`decide`/`rfl` proof over such literals are unchanged. In particular there is
+deliberately no `ofList`-style helper on the elaboration path: a list lookup is an O(n)
+walk under kernel reduction (see the axiom-policy notes in `CLAUDE.md`), whereas the
+`.set` chain is the form all existing proofs already consume.
 
 ## Delaborator
 
 Terms of exactly that literal shape (literal phase, literal indices, `PauliOperator`
 constructors, literal qubit count) display back as `σ[…]`/`iσ[…]`/`-σ[…]`/`-iσ[…]` in
-goals and diagnostics. Anything else — variable phase or operators, symbolic indices, a
-partially reduced chain — is left to the default printer. The delaborator is registered
-globally, so the display is independent of whether the scope is open;
+goals and diagnostics, and a literal-shaped `.set` chain on its own displays as `P[…]`
+(so an element whose phase is not a literal shows as `⟨k, P[…]⟩`; a bare `identity n`
+keeps its name). Anything else — variable phase or operators, symbolic indices, a
+partially reduced chain — is left to the default printer. The delaborators are
+registered globally, so the display is independent of whether the scope is open;
 `set_option pp.notation false` (or `pp.explicit true`) recovers the raw term.
 -/
 
@@ -71,6 +80,12 @@ scoped syntax:max (name := negSigma) "-σ[" ident "]" : term
 Scoped: enable with `open scoped Pauli`. -/
 scoped syntax:max (name := negISigma) "-iσ[" ident "]" : term
 
+/-- `P[XZIX]` is the bare Pauli string, an `NQubitPauliOperator` with no phase, whose
+operator at qubit `k` is the `k`-th letter (letters `X`, `Y`, `Z`, `I`; qubit count =
+letter count); it is `σ[XZIX].operators`. Scoped: enable with `open scoped Pauli`.
+Elaborates to the literal `(NQubitPauliOperator.identity n).set i₀ op₀ …` normal form. -/
+scoped syntax:max (name := pauliString) "P[" ident "]" : term
+
 /-- Split the letters identifier of a `σ[…]`-family literal into its characters, checking
 that the identifier is a single atomic name over the alphabet `X`, `Y`, `Z`, `I`. -/
 def pauliLetters (stx : Syntax) : MacroM (List Char) := do
@@ -82,10 +97,11 @@ def pauliLetters (stx : Syntax) : MacroM (List Char) := do
       Macro.throwErrorAt stx s!"invalid Pauli letter '{c}': expected X, Y, Z, or I"
   return cs
 
-/-- Expand a `σ[…]`-family literal with the given `phasePower` into the canonical normal
-form `NQubitPauliGroupElement.mk phase ((NQubitPauliOperator.identity n).set i₀ op₀ …)`,
-setting only the non-identity positions, in increasing index order. -/
-def expandSigma (phase : Nat) (letters : Syntax) : MacroM Term := do
+/-- Expand the letters of a literal into the canonical operator-string normal form
+`(NQubitPauliOperator.identity n).set i₀ op₀ …`, setting only the non-identity positions,
+in increasing index order. This is the expansion of `P[…]`, and the operator half of the
+`σ[…]` family. -/
+def expandPauliString (letters : Syntax) : MacroM Term := do
   let cs ← pauliLetters letters
   let mut ops : Term ← `(Quantum.NQubitPauliOperator.identity $(quote cs.length))
   let mut i : Nat := 0
@@ -97,6 +113,13 @@ def expandSigma (phase : Nat) (letters : Syntax) : MacroM Term := do
         | _ => `(Quantum.PauliOperator.Z)
       ops ← `(Quantum.NQubitPauliOperator.set $ops $(quote i) $opStx)
     i := i + 1
+  return ops
+
+/-- Expand a `σ[…]`-family literal with the given `phasePower` into the canonical normal
+form `NQubitPauliGroupElement.mk phase ((NQubitPauliOperator.identity n).set i₀ op₀ …)`,
+whose operator part is the `expandPauliString` chain. -/
+def expandSigma (phase : Nat) (letters : Syntax) : MacroM Term := do
+  let ops ← expandPauliString letters
   `(Quantum.NQubitPauliGroupElement.mk $(quote phase) $ops)
 
 macro_rules
@@ -104,11 +127,13 @@ macro_rules
   | `(iσ[$letters:ident]) => expandSigma 1 letters
   | `(-σ[$letters:ident]) => expandSigma 2 letters
   | `(-iσ[$letters:ident]) => expandSigma 3 letters
+  | `(P[$letters:ident]) => expandPauliString letters
 
 /-!
 ## Delaborator
 
-Displays literal-shaped `NQubitPauliGroupElement.mk` applications back as `σ[…]`.
+Displays literal-shaped `NQubitPauliGroupElement.mk` applications back as `σ[…]`, and
+literal-shaped `NQubitPauliOperator.set` chains back as `P[…]`.
 -/
 
 section Delaborator
@@ -153,6 +178,16 @@ partial def setChain? (e : Expr) (acc : List (Nat × Char) := []) :
   else
     none
 
+/-- The letters identifier of a literal chain over `n > 0` qubits whose indices are all
+in range, or `none` otherwise. Later (outer) `.set`s override earlier ones, so the
+innermost-first assignment list is folded left to right. -/
+def lettersOf? (n : Nat) (sets : List (Nat × Char)) : Option Ident := do
+  guard (0 < n)
+  guard (sets.all fun ic => ic.1 < n)
+  let letters := String.ofList <| (List.range n).map fun j =>
+    sets.foldl (fun acc ic => if ic.1 == j then ic.2 else acc) 'I'
+  return mkIdent (.mkSimple letters)
+
 /-- Delaborate literal-shaped `NQubitPauliGroupElement.mk` applications back to the
 `σ[…]`/`iσ[…]`/`-σ[…]`/`-iσ[…]` notation. Fires only when the phase is a literal
 `0`–`3`, the operator part is a literal `set`-chain over `identity n` with in-range
@@ -164,18 +199,27 @@ def delabSigma : Delab :=
     unless e.isAppOfArity ``Quantum.NQubitPauliGroupElement.mk 3 do failure
     let some phase := natLitOf? (e.getArg! 1) | failure
     let some (n, sets) := setChain? (e.getArg! 2) | failure
-    unless 0 < n do failure
-    unless sets.all (fun ic => ic.1 < n) do failure
-    -- Later (outer) `.set`s override earlier ones, so fold innermost-first.
-    let letters := String.ofList <| (List.range n).map fun j =>
-      sets.foldl (fun acc ic => if ic.1 == j then ic.2 else acc) 'I'
-    let letters := mkIdent (.mkSimple letters)
+    let some letters := lettersOf? n sets | failure
     match phase with
     | 0 => `(σ[$letters])
     | 1 => `(iσ[$letters])
     | 2 => `(-σ[$letters])
     | 3 => `(-iσ[$letters])
     | _ => failure
+
+/-- Delaborate literal-shaped `NQubitPauliOperator.set` chains back to the `P[…]`
+notation. Fires only on a `set` application whose whole chain is literal over
+`identity n` with in-range literal indices and `n > 0`; stays silent otherwise (in
+particular a bare `identity n` keeps its name). An over-applied chain — the operator
+string evaluated at a qubit, `P[XIZ] i` — is handled by `withOverApp`, so the extra
+arguments follow the notation. -/
+@[app_delab Quantum.NQubitPauliOperator.set]
+def delabPauliString : Delab :=
+  whenPPOption getPPNotation <| whenNotPPOption getPPExplicit <| withOverApp 4 do
+    let e ← getExpr
+    let some (n, sets) := setChain? e | failure
+    let some letters := lettersOf? n sets | failure
+    `(P[$letters])
 
 end Delaborator
 
@@ -184,7 +228,8 @@ end Pauli
 /-!
 ## Round-trip tests
 
-Each phase prefix elaborates to exactly the hand-written literal normal form.
+Each phase prefix elaborates to exactly the hand-written literal normal form, and `P[…]`
+to exactly its operator half.
 -/
 
 section RoundTrip
@@ -219,5 +264,17 @@ example : σ[XIZ].phasePower = 0 := rfl
 example : σ[XIZ].operators 2 = PauliOperator.Z := rfl
 
 example : σ[XIZ].operators 1 = PauliOperator.I := rfl
+
+example :
+    P[XIZ] = ((NQubitPauliOperator.identity 3).set 0 PauliOperator.X).set 2 PauliOperator.Z :=
+  rfl
+
+example : P[III] = NQubitPauliOperator.identity 3 := rfl
+
+example : P[XIZ] 2 = PauliOperator.Z := rfl
+
+example : σ[XIZ].operators = P[XIZ] := rfl
+
+example : (⟨1, P[YY]⟩ : NQubitPauliGroupElement 2) = iσ[YY] := rfl
 
 end RoundTrip

--- a/QEC/Stabilizer/Framework/Core.lean
+++ b/QEC/Stabilizer/Framework/Core.lean
@@ -1,6 +1,7 @@
 import QEC.Stabilizer.Framework.Core.Stabilizer
 import QEC.Stabilizer.Framework.Core.Logical
 import QEC.Stabilizer.Framework.Core.CSS
+import QEC.Stabilizer.Framework.Core.CodeNotation
 
 /-!
 # Framework.Core
@@ -9,4 +10,6 @@ Abstract stabilizer-formalism content, split into three buckets:
 - `QEC.Stabilizer.Framework.Core.Stabilizer` — stabilizer-group + codespace + centralizer
 - `QEC.Stabilizer.Framework.Core.Logical`    — logical-operator theory + code distance
 - `QEC.Stabilizer.Framework.Core.CSS`        — CSS-code theory
+- `QEC.Stabilizer.Framework.Core.CodeNotation` — scoped `Code[[n, k]]` /
+  `Code[[n, k, d]]` type notation for the bundled codes
 -/

--- a/QEC/Stabilizer/Framework/Core/CodeNotation.lean
+++ b/QEC/Stabilizer/Framework/Core/CodeNotation.lean
@@ -1,0 +1,57 @@
+import QEC.Stabilizer.Framework.Core.Logical.CodeDistance
+
+/-!
+# `[[n, k, d]]` code-parameter notation
+
+Scoped type notation for the two bundled code structures, following the standard
+`[[n, k, d]]` parameter convention described in `CodeDistance.lean`:
+
+- `Code[[n, k]]` is `StabilizerCode n k` — `n` physical qubits, `k` logical qubits;
+- `Code[[n, k, d]]` is `StabilizerCodeWithDistance n k d` — additionally, a proved
+  distance `d`.
+
+Bare `[[n, k]]` already parses as a nested list literal, hence the `Code` prefix: the
+leading token is `Code[[`, and the closing brackets are two ordinary `]` tokens (a single
+`]]` token would break every nested `[[…]]` / `#[#[…]]` literal in scope). The notation
+lives in the `Quantum.StabilizerGroup` scope, so it is active inside that namespace and
+after `open Quantum.StabilizerGroup` / `open scoped Quantum.StabilizerGroup`, and each
+form has an unexpander so goals and `#check` output display `Code[[7, 1]]` rather than
+`StabilizerCode 7 1`.
+-/
+
+namespace Quantum.StabilizerGroup
+
+/-- `Code[[n, k]]` is the type `StabilizerCode n k` of `[[n, k]]` stabilizer codes:
+`n` physical qubits, `k` logical qubits. Scoped: `open scoped Quantum.StabilizerGroup`. -/
+scoped notation:max "Code[[" n ", " k "]" "]" => StabilizerCode n k
+
+/-- `Code[[n, k, d]]` is the type `StabilizerCodeWithDistance n k d` of `[[n, k, d]]`
+stabilizer codes packaged with a proof that their distance is `d`.
+Scoped: `open scoped Quantum.StabilizerGroup`. -/
+scoped notation:max "Code[[" n ", " k ", " d "]" "]" => StabilizerCodeWithDistance n k d
+
+end Quantum.StabilizerGroup
+
+/-!
+## Round-trip tests
+
+Each form is the corresponding structure type, definitionally and syntactically.
+-/
+
+section RoundTrip
+
+open Quantum.StabilizerGroup
+
+example : Code[[7, 1]] = StabilizerCode 7 1 := rfl
+
+example : Code[[5, 1, 3]] = StabilizerCodeWithDistance 5 1 3 := rfl
+
+example (n k : ℕ) : Code[[n, k]] = StabilizerCode n k := rfl
+
+example (n k d : ℕ) : Code[[n, k, d]] = StabilizerCodeWithDistance n k d := rfl
+
+example (C : Code[[7, 1]]) : Code[[7, 1]] := C
+
+example (C : Code[[5, 1, 3]]) : Code[[5, 1]] := C.toStabilizerCode
+
+end RoundTrip

--- a/QECWidgets/Demo.lean
+++ b/QECWidgets/Demo.lean
@@ -25,6 +25,7 @@ on the command. The `example`s at the bottom show the in-proof panels.
 namespace QECWidgets.Demo
 
 open Quantum Quantum.StabilizerGroup ProofWidgets
+open scoped Pauli
 
 /-! ## Single terms: generators and logicals of the Steane code -/
 
@@ -42,9 +43,9 @@ open Quantum Quantum.StabilizerGroup ProofWidgets
 
 #pauli_strip (Steane7.X1 * Steane7.Z1)
 
-#pauli_strip (⟨3,
-    (((NQubitPauliOperator.identity 7).set 0 PauliOperator.X).set 2 PauliOperator.X).set 3
-      PauliOperator.X |>.set 6 PauliOperator.X⟩ : NQubitPauliGroupElement 7)
+-- An inline literal with phase −i, written with the scoped `σ[…]` construction
+-- notation (`open scoped Pauli`): `-iσ[…]` is `phasePower = 3`.
+#pauli_strip (-iσ[XIXXIIX])
 
 /-! ## Propositions: commutation views -/
 


### PR DESCRIPTION
Coordinated notation pass over the library: five workstreams, one commit each, all
scoped, all with delaborators/unexpanders, and nothing on a kernel-facing path changes
its elaborated form. No declaration is renamed or deleted; no `sorry`, no `native_decide`,
no linter suppressions.

## A — `σ[…]` Pauli literals: `P[…]` phase-less strings + demo migration

PR #73 already landed `σ[…]`/`iσ[…]`/`-σ[…]`/`-iσ[…]` and migrated the literal codes.
This commit completes the workstream:

- **`P[XZIX] : NQubitPauliOperator 4`** (`open scoped Pauli`): the bare Pauli string, i.e.
  `σ[XZIX].operators`. A macro expands it to exactly the
  `(NQubitPauliOperator.identity n).set i₀ op₀ …` chain (non-identity positions,
  increasing index order; `P[II…I]` is `identity n` itself), and the σ-family now
  expands through the same helper. No `ofList`-style function on the elaboration path.
- **Delaborator** on `NQubitPauliOperator.set`: literal chains display as `P[…]`
  (over-applied ones as `P[…] i`), so an element with a non-literal phase shows as
  `⟨k, P[…]⟩`; a bare `identity n` keeps its name. Silent on every other shape.
- Round-trip `example … := rfl` tests; `QECWidgets/Demo.lean`'s inline
  `⟨3, .set-chain⟩` literal is now `-iσ[XIXXIIX]`; `_TEMPLATE.lean` §1 and
  CLAUDE.md's helper list document `P[…]`.
- The remaining `.set` chains under `QEC/` are all parametric (symbolic indices) and
  cannot be literals.

## B — boundary-map notation `∂₁` / `∂₂` / `δ⁰`

Two scoped notation namespaces, one per family, declared next to the definitions:

- `open scoped ToricChain`: `∂₁` = `toricBoundary1`, `∂₂` = `toricBoundary2`,
  `δ⁰` = `toricVertexCutMap`.
- `open scoped RotatedSurfaceChain`: `∂₁` = `rscBoundary1`, `∂₂` = `rscBoundary2`,
  `δ⁰` = `rscZCutMap`.

The lattice size stays an explicit argument exactly as for the underlying constants
(`∂₁ L c`, `∂₁ (L := L)`), so the conversion is purely textual: `notation` gives each
an unexpander (goals show `(∂₁ L) c v`), declaration names are untouched, and the
bare-name uses in `simp [toricBoundary1]` / `unfold` lists stay as names (a notation
node is not an identifier there). Token check: `∂` is not an identifier character and
mathlib's `∂` notations (`∫ … ∂μ`, `∂_{v}`, Heyting `∂ `) are all distinct tokens;
`δ⁰` cannot collide with a variable `δ` (superscripts are not identifier characters).
Sites: 173 applied occurrences converted across 17 files (12 toric, 5 rotated-surface);
26 bare-name uses inside `simp`/`rw` lists and 4 after `unfold` stay as names on purpose;
definition sites and the two `ToricCodeN` aliases are untouched. Warnings per file and kind
are identical before and after.

## C — drop the `(L := L)` noise on single-cell chains

`singleVtx` / `singleEdge` / `singleFace` (and the same-shape siblings `edgeSupport` /
`edgeWeight` in the same file) already take `L` implicitly, inferred from the cell
index or chain argument. The `(L := L)` named argument at
their call sites was pure noise: all 96 annotations (BoundaryMaps 7, DistanceX 9,
DistanceZ 9, StabilizerCode 71) are deleted and every site elaborates without it, so none
had to be kept. Other `(L := L)` users in these files (`toricCycles`, `hAt`, `vColAt`, `prev`, …)
either take `L` explicitly by design or have nothing to infer it from, and are left alone.
No signature or name changed.

## D — `Code[[n, k]]` / `Code[[n, k, d]]` type notation

New module `Framework/Core/CodeNotation.lean` (wired into the `Core` umbrella), scoped
to `Quantum.StabilizerGroup`: `Code[[n, k]]` is `StabilizerCode n k` and
`Code[[n, k, d]]` is `StabilizerCodeWithDistance n k d`, each with an unexpander. The
leading token is `Code[[` (bare `[[…]]` is a nested list) and the closer is two ordinary
`]` tokens — a single `]]` token would break every nested `[[…]]` / `#[#[…]]` literal in
scope (checked). Used in the Steane `[[7, 1]]` and five-qubit `[[5, 1]]` / `[[5, 1, 3]]`
packagings and in `Playground.lean`.

## E — n-qubit bitstring kets `|0101⟩`

`QEC/Foundations/Basic.lean`: the eight fixed `|0⟩ … |11⟩` notations become one scoped
syntax `|b⟩` for any bitstring, elaborating to the pre-existing term of the corresponding
state type: `ket0`/`ket1 : Qubit`, `ket00…ket11 : TwoQubitState`,
`ket000…ket111 : ThreeQubitState`, and `nQubitKet n ![b₀, …, bₙ₋₁] : NQubitState n` from
four qubits on (the tuple-indexed state types stop at three). The parse crux: `0101`
lexes as one numeral token, so the macro reads the token's *source text* (leading zeros
kept) and accepts only `0`/`1`; no new token is introduced (`|` and `⟩` already exist,
the form is `atomic`), so `|x|` and `{x | p x}` are unaffected. Scoped unexpanders for the
fourteen named kets and a scoped delaborator for `nQubitKet n ![…]` (`n ≥ 4`) display
them back; rfl round-trip tests cover every case; `Tensor.lean`'s three-qubit lemma
statements now use `|000⟩`-style kets.

## Verification

Full pre-push suite on the final tree (16 GB machine, `LEAN_NUM_THREADS=3`), all green:

- the three BB safe-floor leaves built sequentially first (`MImFloorY0/Y1/Y4`), then
  `lake build` — the whole library from `Basic.lean` up, since E touches the root module;
- `lake build QECLight QECBlueprint QECWidgets QEC.Stabilizer.Codes._TEMPLATE`;
- `lake env lean Playground.lean` (its `#check`s print `Code[[5, 1, 3]]` / `Code[[7, 1]]`);
- `lake env lean scripts/AxiomCheck.lean`: 6288 declarations across 167 modules depend on
  only `[propext, Classical.choice, Quot.sound]`;
- `bash scripts/check-umbrellas.sh`.

Each commit was built green on its own before the next workstream started (A: QECLight +
QECWidgets; B: Toric + RotatedSurface, with warnings identical per file and kind before and
after the conversion; C: Toric; D: QECLight + QECWidgets + Playground; E: the full suite
above). No new warnings in any edited file. Delaborator output was checked in the LSP against
the built library: `P[XIZ] i`, `⟨k, P[XZ]⟩`, `(∂₁ L) c v`, `∂₁ L ∘ₗ ∂₂ L`, `(δ⁰ L) s`,
`Code[[7, 1]]`, `|0101⟩`, `X_q1_2 • |01⟩`, and `|x|` / `{x | 0 ≤ x}` still parse with the
ket scope open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
