### PR TITLE
docs(pauli): describe the file-local Anticommute decidability instances

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,16 +289,17 @@ These are local to this codebase — search here before assuming mathlib has the
 - `NQubitPauliGroupElement.commutes_iff_even_anticommutes` — main parity-based
   commutation lemma for general Paulis (the "count of anticommuting qubits is
   even" characterization)
-- **`Decidable (NQubitPauliGroupElement.Anticommute p q)`** (in
-  `PauliGroup/Commutation.lean`) — closes `Anticommute p q` goals via
-  `by decide`. The instance is `noncomputable` because `Mul` on
-  `NQubitPauliGroupElement` is itself noncomputable, but `decide` still
-  reduces through the kernel. `native_decide` does **not** work for
-  the same reason — prefer `decide`. Builds on the computable
-  `DecidableEq (NQubitPauliOperator n)` from `Representation.lean`
-  (the `Classical.decEq` override has been removed). Used heavily by
-  the [[5,1,3]] distance proof for the 105-case weight-{1,2}
-  anti-witness tables.
+- **`Decidable (NQubitPauliGroupElement.Anticommute p q)`** is a
+  **file-local** instance, not a global one: `Codes/Small/FiveQubit_5_1_3.lean`
+  (§ "Local Decidable instances") declares `local instance`s for
+  `DecidableEq (NQubitPauliGroupElement n)` and `Decidable (Anticommute p q)`
+  on top of the computable `DecidableEq (NQubitPauliOperator n)` from
+  `Representation.lean`, and its 105-case weight-{1,2} anti-witness tables
+  close by `decide` (the instance is `noncomputable` because `Mul` is;
+  `native_decide` does **not** work — prefer `decide`). A new non-CSS code
+  that needs this should copy those two instances rather than make them
+  global, per the `local instance` discipline above — see the note in
+  `PauliGroup/Commutation.lean` § "Decidability of equality and `Anticommute`".
 - `StabilizerGroup`, `.toSubgroup`, `.is_abelian`, `.one_mem`,
   `.neg_identity_not_mem`, `.codespaceSubmodule`
 - `IsNontrivialLogicalOperator` has **three** conditions (see

--- a/QEC/Stabilizer/Foundations/PauliGroup/Commutation.lean
+++ b/QEC/Stabilizer/Foundations/PauliGroup/Commutation.lean
@@ -236,19 +236,22 @@ def Anticommute (p q : NQubitPauliGroupElement n) : Prop :=
 /-! ### Decidability of equality and `Anticommute`
 
 `DecidableEq (NQubitPauliOperator n)` is computable (via the underlying
-function type `Fin n → PauliOperator`, see `Representation.lean`). We
-derive `DecidableEq (NQubitPauliGroupElement n)` from field-wise decision
-and finally `Decidable (Anticommute p q)`. The `Anticommute` instance is
-`noncomputable` because the `Mul` instance on `NQubitPauliGroupElement`
-is noncomputable, but the kernel can still reduce `decide` through it.
-(`native_decide` does not work for the same reason — prefer `decide`.) -/
+function type `Fin n → PauliOperator`, see `Representation.lean`). From it one
+can derive `DecidableEq (NQubitPauliGroupElement n)` by field-wise decision and
+then `Decidable (Anticommute p q)` (which unfolds to an equality of two group
+elements); the latter is necessarily `noncomputable`, because the `Mul`
+instance on `NQubitPauliGroupElement` is, but the kernel still reduces
+`decide` through it (`native_decide` does not work for the same reason —
+prefer `decide`).
 
--- (Stage-4 follow-up for stab_5_1_3 added a `DecidableEq
--- (NQubitPauliGroupElement n)` and `Decidable Anticommute` here, but they
--- caused a downstream synthesis failure in RotatedSurfaceCode3's
--- native_decide proof. They are temporarily removed pending a clean
--- resolution. stab_5_1_3's distance proof currently DOES NOT BUILD
--- against this configuration — needs refactor.)
+Neither instance is declared here, on purpose. They were once added globally
+and disrupted typeclass synthesis in an unrelated `native_decide` proof
+(`RotatedSurfaceCode3`, since parked on `claude/z3z6-parked`) — the footgun
+recorded under "Global vs. `local instance` discipline" in `CLAUDE.md`. They
+now live as `local instance`s in `Codes/Small/FiveQubit_5_1_3.lean`
+(§ "Local Decidable instances"), where the [[5,1,3]] distance proof needs
+them; copy them from there into any other file that wants `decide` on
+`Anticommute`. -/
 
 /-- Anticommutation reduces to the mulOp phase differing by 2 (mod 4). -/
 lemma anticommutes_iff_mulOp_phasePower (p q : NQubitPauliGroupElement n) :


### PR DESCRIPTION
Docs-only. Two notes still described a global `Decidable (NQubitPauliGroupElement.Anticommute p q)` instance in `PauliGroup/Commutation.lean`, and contradicted each other and the code:

- **CLAUDE.md**, "Project-specific helpers": said the instance lives in `Commutation.lean` and closes the [[5,1,3]] anti-witness tables by `decide`. `Commutation.lean` declares no such instance.
- **`Commutation.lean`** § "Decidability of equality and `Anticommute`": a trailing comment said the instances were "temporarily removed" and that the [[5,1,3]] distance proof "currently DOES NOT BUILD — needs refactor". Stale on both counts: the instances were localised to `Codes/Small/FiveQubit_5_1_3.lean` (§ "Local Decidable instances"), which builds on `main`, and the `native_decide` proof they had disrupted (`RotatedSurfaceCode3`) is parked on `claude/z3z6-parked`.

Both notes now describe the actual state: `DecidableEq (NQubitPauliGroupElement n)` and `Decidable (Anticommute p q)` are `local instance`s in `FiveQubit_5_1_3.lean` (on top of the computable `DecidableEq (NQubitPauliOperator n)` from `Representation.lean`), kept file-local per the "Global vs. `local instance` discipline" rule, with the `decide`-not-`native_decide` advice retained; any new non-CSS code that needs `decide` on `Anticommute` is pointed at that file to copy them from.

Verification: `lake build QEC.Stabilizer.Foundations.PauliGroup.Commutation QEC.Stabilizer.Codes.Small.FiveQubit_5_1_3` in a fresh worktree of `main`, no errors. The CLAUDE.md hunk sits a few bullets below the σ-notation bullet that #75 edits; the hunks do not overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
