### PR TITLE
Notation pass 2: σ[n | i ↦ Z], poly[…]/⋆, ⟪p, q⟫ₛ, U ⊳ M, dim₂/Z₁/B₁/H₁, C.logicalX

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -292,19 +292,23 @@ These are local to this codebase — search here before assuming mathlib has the
   `⟨0, ((NQubitPauliOperator.identity n).set i Z).set j Z⟩` with the `.set`s in
   the written order, and displays back the same way.
 - **Other scoped notations** (each is a pure macro onto the pre-existing term, with a
-  delaborator/unexpander printing it back; bare names stay in `simp`/`rw`/`unfold` lists):
+  delaborator/unexpander that is scoped with it, so a goal only ever shows syntax the
+  current file can parse; bare names stay in `simp`/`rw`/`unfold` lists):
   `⟪p, q⟫ₛ` (scope `Quantum.NQubitPauliGroupElement`, `BinarySymplectic/SymplecticInner.lean`)
-  = `NQubitPauliOperator.symplecticInner p.operators q.operators`, with the plain defs
-  `NQubitPauliGroupElement.symplecticInner` (protected) and `.symp`;
-  `U ⊳ M` (scope `Quantum`, `Foundations/Gates.lean`) = `conjBy U M`, plus
-  `Coe (QuantumGate α) (Matrix α α ℂ)` and `G₁ ⊗ᵍ G₂` for gates;
+  = `NQubitPauliOperator.symplecticInner p.operators q.operators`;
+  `U ⊳ M` (scope `Quantum`, `Foundations/Gates.lean`) = `conjBy U M` — `conjBy_def` is a
+  `simp` lemma, so state conjugation lemmas in the matrix-product form — and
+  `G₁ ⊗ᵍ G₂` = `tensorGate G₁ G₂` (`Foundations/Tensor.lean`);
   `a ⋆ b` = `conv a b` and `poly[x^3 + y + y^2]` for the indicator-function polynomials
-  (scope `Quantum.Stabilizer.Homological.BB`, `Homological/BBChainComplex.lean`);
+  (scope `Quantum.Stabilizer.Homological.BB`, `Homological/BBChainComplex.lean`; the `+`
+  is a union of distinct exponent points, so check them against the group's orders);
   `dim₂ V` = `Module.finrank (ZMod 2) V` (scope `Homology`, `Homological/Code.lean`);
   `Z₁ L`/`B₁ L`/`H₁ L` = `toricCycles L`/`toricBoundaries L`/`toricH1 L` and
   `Z¹ L`/`B¹ L` for the dual cycles/boundaries (scope `ToricChain`), and the same
-  `Z₁`/`B₁`/`H₁` for `rscCycles`/`rscBoundaries`/`rscH1` (scope `RotatedSurfaceChain`);
-  `C.logicalX ℓ`/`C.logicalZ ℓ` are the names goals print for `(C.logicalOps ℓ).xOp`/`.zOp`.
+  `Z₁`/`B₁`/`H₁` for `rscCycles`/`rscBoundaries`/`rscH1` (scope `RotatedSurfaceChain` —
+  the two scopes bind the same tokens, so open one per file).
+- `C.logicalX ℓ`/`C.logicalZ ℓ` are reducible abbreviations of `(C.logicalOps ℓ).xOp`/`.zOp`
+  (`Core/Stabilizer/StabilizerCode.lean`); goals print whichever spelling a term carries.
 - `NQubitPauliGroupElement.toMatrix`, `.mulOp`, `.phasePower`, `.operators`
 - `NQubitPauliGroupElement.Anticommute`, `.anticommutesAt`
 - `NQubitPauliGroupElement.commutes_iff_even_anticommutes` — main parity-based

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,9 +284,13 @@ These are local to this codebase — search here before assuming mathlib has the
   phase-less Pauli string is `P[…]` (`P[XZZXI] : NQubitPauliOperator 5`), which
   elaborates to exactly the bare `.set` chain and displays back as `P[…]` (an
   element with a non-literal phase shows as `⟨k, P[…]⟩`). Concrete
-  literal codes (`Codes/Small/`, `Repetition/Three.lean`) use it; parametric
-  families with symbolic indices (`Repetition/N.lean`, `Iceberg/N.lean`, toric)
-  cannot.
+  literal codes (`Codes/Small/`, `Repetition/Three.lean`) use it. Parametric
+  families with symbolic qubit counts / indices (`Repetition/N.lean`,
+  `Iceberg/N.lean`, `Toric/CodeN.lean`) use the **symbolic form**
+  `σ[n | i ↦ Z, j ↦ Z]` (same leading tokens: `iσ[n | …]`, `-σ[n | …]`,
+  `-iσ[n | …]`, `P[n | …]`; letters `X`/`Y`/`Z`), which elaborates to exactly
+  `⟨0, ((NQubitPauliOperator.identity n).set i Z).set j Z⟩` with the `.set`s in
+  the written order, and displays back the same way.
 - `NQubitPauliGroupElement.toMatrix`, `.mulOp`, `.phasePower`, `.operators`
 - `NQubitPauliGroupElement.Anticommute`, `.anticommutesAt`
 - `NQubitPauliGroupElement.commutes_iff_even_anticommutes` — main parity-based

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,7 +280,10 @@ These are local to this codebase — search here before assuming mathlib has the
   **exactly** the literal `⟨phase, (NQubitPauliOperator.identity n).set i₀ op₀ …⟩`
   normal form (non-identity positions, increasing index order), so
   `rfl`/`decide`/`simp` behavior is identical to a hand-written `.set`-chain; a
-  delaborator displays literal-shaped elements back as `σ[…]` in goals. Concrete
+  delaborator displays literal-shaped elements back as `σ[…]` in goals. The
+  phase-less Pauli string is `P[…]` (`P[XZZXI] : NQubitPauliOperator 5`), which
+  elaborates to exactly the bare `.set` chain and displays back as `P[…]` (an
+  element with a non-literal phase shows as `⟨k, P[…]⟩`). Concrete
   literal codes (`Codes/Small/`, `Repetition/Three.lean`) use it; parametric
   families with symbolic indices (`Repetition/N.lean`, `Iceberg/N.lean`, toric)
   cannot.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,6 +291,20 @@ These are local to this codebase — search here before assuming mathlib has the
   `-iσ[n | …]`, `P[n | …]`; letters `X`/`Y`/`Z`), which elaborates to exactly
   `⟨0, ((NQubitPauliOperator.identity n).set i Z).set j Z⟩` with the `.set`s in
   the written order, and displays back the same way.
+- **Other scoped notations** (each is a pure macro onto the pre-existing term, with a
+  delaborator/unexpander printing it back; bare names stay in `simp`/`rw`/`unfold` lists):
+  `⟪p, q⟫ₛ` (scope `Quantum.NQubitPauliGroupElement`, `BinarySymplectic/SymplecticInner.lean`)
+  = `NQubitPauliOperator.symplecticInner p.operators q.operators`, with the plain defs
+  `NQubitPauliGroupElement.symplecticInner` (protected) and `.symp`;
+  `U ⊳ M` (scope `Quantum`, `Foundations/Gates.lean`) = `conjBy U M`, plus
+  `Coe (QuantumGate α) (Matrix α α ℂ)` and `G₁ ⊗ᵍ G₂` for gates;
+  `a ⋆ b` = `conv a b` and `poly[x^3 + y + y^2]` for the indicator-function polynomials
+  (scope `Quantum.Stabilizer.Homological.BB`, `Homological/BBChainComplex.lean`);
+  `dim₂ V` = `Module.finrank (ZMod 2) V` (scope `Homology`, `Homological/Code.lean`);
+  `Z₁ L`/`B₁ L`/`H₁ L` = `toricCycles L`/`toricBoundaries L`/`toricH1 L` and
+  `Z¹ L`/`B¹ L` for the dual cycles/boundaries (scope `ToricChain`), and the same
+  `Z₁`/`B₁`/`H₁` for `rscCycles`/`rscBoundaries`/`rscH1` (scope `RotatedSurfaceChain`);
+  `C.logicalX ℓ`/`C.logicalZ ℓ` are the names goals print for `(C.logicalOps ℓ).xOp`/`.zOp`.
 - `NQubitPauliGroupElement.toMatrix`, `.mulOp`, `.phasePower`, `.operators`
 - `NQubitPauliGroupElement.Anticommute`, `.anticommutesAt`
 - `NQubitPauliGroupElement.commutes_iff_even_anticommutes` — main parity-based

--- a/Playground.lean
+++ b/Playground.lean
@@ -26,6 +26,12 @@ open Quantum.StabilizerGroup
 -- proved distance. (It is the repo's first non-CSS code.)
 #check FiveQubit_5_1_3.stabilizerCodeWithDistance
 
+-- The same object through the scoped `[[n, k, d]]` type notation: `Code[[5, 1, 3]]` is
+-- `StabilizerCodeWithDistance 5 1 3` (and `Code[[5, 1]]` is `StabilizerCode 5 1`). The
+-- `open Quantum.StabilizerGroup` above activates it.
+#check (FiveQubit_5_1_3.stabilizerCodeWithDistance : Code[[5, 1, 3]])
+#check (Steane7.stabilizerCode : Code[[7, 1]])
+
 -- The parametric toric code, for every `L ≥ 2`. (It lives under
 -- `Quantum.Stabilizer.Lattice`, not the `Quantum.StabilizerGroup` opened above.)
 #check @Quantum.Stabilizer.Lattice.toricHomologicalCode

--- a/QEC/Foundations/Basic.lean
+++ b/QEC/Foundations/Basic.lean
@@ -28,7 +28,8 @@ as a subtype.
 - **`NQubitBasis n`**: function type `Fin n → QubitBasis` for generic n-qubit systems
   (used with stabilizer / Pauli formalism).
 
-Standard kets **`ket0`**, **`ket1`** and basis vectors are defined here; `Gates.lean`
+Standard kets **`ket0`**, **`ket1`** and basis vectors are defined here, with the scoped
+Dirac notation `|0⟩`, `|01⟩`, `|0101⟩`, … (see the end of the file); `Gates.lean`
 builds unitary matrices on these spaces.
 -/
 
@@ -366,20 +367,75 @@ noncomputable def ket111 : ThreeQubitState :=
 /-!
 ## Dirac ket notation
 
-Scoped notation for the standard kets above, so proofs and statements can be written
-the way they are on paper: `|0⟩`, `|+⟩`, `|01⟩`, …
+Scoped notation for the computational-basis kets, so proofs and statements can be written
+the way they are on paper: `|0⟩`, `|+⟩`, `|01⟩`, `|0101⟩`, …
 
-Bring them into scope with `open scoped Quantum` (or `open Quantum`). They are
-`scoped` deliberately: the tokens begin with `|`, so an unqualified `open` would make
-`{x |0 ≤ x}`-style set-builders (no space after the bar) fail to parse in that file.
-Writing `{x | 0 ≤ x}` with the usual space is unaffected.
+`|b⟩` for a bitstring `b` of length `n ≥ 1` is the standard basis state of the
+corresponding `n`-qubit state type, i.e. exactly the pre-existing term for it:
+
+| length  | elaborates to                   | type              |
+|---------|---------------------------------|-------------------|
+| 1       | `ket0`, `ket1`                  | `Qubit`           |
+| 2       | `ket00`, …, `ket11`             | `TwoQubitState`   |
+| 3       | `ket000`, …, `ket111`           | `ThreeQubitState` |
+| `n ≥ 4` | `nQubitKet n ![b₀, …, bₙ₋₁]`    | `NQubitState n`   |
+
+The tuple-indexed state types stop at three qubits, so from four qubits on the only
+`n`-qubit state type is `NQubitState n`. `|+⟩` and `|-⟩` are the Hadamard-basis kets
+`ketPlus` and `ketMinus`.
+
+**Parsing.** The bitstring lexes as a single numeral token (`0101` is one `num`
+literal), and the macro reads that token's *source text* — `"0101"`, leading zeros
+included, where the literal's numeric value would lose them — accepting only the digits
+`0` and `1`. No new token is introduced: `|` and `⟩` are the ordinary bar and
+right-angle tokens, and the whole form is `atomic`, so `|x|` (absolute value) and
+`{x | p x}` (set-builder) parse exactly as before.
+
+Bring the notation into scope with `open scoped Quantum` (or `open Quantum`). It is
+`scoped` deliberately, like the rest of this file's notation, so that files which never
+mention kets do not get a term-level parser on the bar token. Each ket displays back as
+`|…⟩` in goals while the scope is open (`set_option pp.notation false` recovers the
+names).
 -/
 
-/-- Computational basis ket `|0⟩`, i.e. `ket0`. -/
-scoped notation "|0⟩" => ket0
+section KetNotation
 
-/-- Computational basis ket `|1⟩`, i.e. `ket1`. -/
-scoped notation "|1⟩" => ket1
+open Lean
+
+/-- `|b⟩` for a bitstring `b` (e.g. `|0⟩`, `|01⟩`, `|0101⟩`): the computational basis
+state of the `n`-qubit state type, `n` the length of `b` — `ket0`/`ket1` for one qubit,
+`ket00`…`ket11` for two, `ket000`…`ket111` for three, and `nQubitKet n ![b₀, …, bₙ₋₁]`
+from four qubits on. Scoped: `open scoped Quantum`. -/
+scoped syntax:max (name := ketLit) atomic("|" noWs num noWs "⟩") : term
+
+/-- The bit `0`/`1` as a numeral term (for the `![…]` of an `n ≥ 4` ket). -/
+private def bitLit (c : Char) : Term :=
+  ⟨(Syntax.mkNumLit (if c == '1' then "1" else "0")).raw⟩
+
+macro_rules
+  | `(|$b:num⟩) => do
+    let some s := b.raw.isLit? numLitKind
+      | Macro.throwErrorAt b "expected a bitstring of 0s and 1s"
+    unless s.all fun c => c == '0' || c == '1' do
+      Macro.throwErrorAt b s!"invalid ket bitstring '{s}': expected the digits 0 and 1 only"
+    match s with
+    | "0" => `(ket0)
+    | "1" => `(ket1)
+    | "00" => `(ket00)
+    | "01" => `(ket01)
+    | "10" => `(ket10)
+    | "11" => `(ket11)
+    | "000" => `(ket000)
+    | "001" => `(ket001)
+    | "010" => `(ket010)
+    | "011" => `(ket011)
+    | "100" => `(ket100)
+    | "101" => `(ket101)
+    | "110" => `(ket110)
+    | "111" => `(ket111)
+    | _ =>
+      let bits : Syntax.TSepArray `term "," := .ofElems (s.toList.toArray.map bitLit)
+      `(nQubitKet $(quote s.length) ![$bits,*])
 
 /-- Hadamard-basis ket `|+⟩ = (|0⟩ + |1⟩)/√2`, i.e. `ketPlus`. -/
 scoped notation "|+⟩" => ketPlus
@@ -387,16 +443,143 @@ scoped notation "|+⟩" => ketPlus
 /-- Hadamard-basis ket `|−⟩ = (|0⟩ − |1⟩)/√2`, i.e. `ketMinus`. -/
 scoped notation "|-⟩" => ketMinus
 
-/-- Two-qubit computational basis ket `|00⟩`, i.e. `ket00`. -/
-scoped notation "|00⟩" => ket00
+/-! ### Display
 
-/-- Two-qubit computational basis ket `|01⟩`, i.e. `ket01`. -/
-scoped notation "|01⟩" => ket01
+The named kets display back as `|…⟩` (one unexpander each), and an `n ≥ 4` ket
+`nQubitKet n ![b₀, …, bₙ₋₁]` with literal `n` and literal bits displays as
+`|b₀…bₙ₋₁⟩`. All of these are scoped with the notation. -/
 
-/-- Two-qubit computational basis ket `|10⟩`, i.e. `ket10`. -/
-scoped notation "|10⟩" => ket10
+/-- `ket0` displays as `|0⟩`. -/
+@[scoped app_unexpander Quantum.ket0] def unexpandKet0 : PrettyPrinter.Unexpander
+  | `($_:ident) => `(|0⟩)
+  | _ => throw ()
 
-/-- Two-qubit computational basis ket `|11⟩`, i.e. `ket11`. -/
-scoped notation "|11⟩" => ket11
+/-- `ket1` displays as `|1⟩`. -/
+@[scoped app_unexpander Quantum.ket1] def unexpandKet1 : PrettyPrinter.Unexpander
+  | `($_:ident) => `(|1⟩)
+  | _ => throw ()
+
+/-- `ket00` displays as `|00⟩`. -/
+@[scoped app_unexpander Quantum.ket00] def unexpandKet00 : PrettyPrinter.Unexpander
+  | `($_:ident) => `(|00⟩)
+  | _ => throw ()
+
+/-- `ket01` displays as `|01⟩`. -/
+@[scoped app_unexpander Quantum.ket01] def unexpandKet01 : PrettyPrinter.Unexpander
+  | `($_:ident) => `(|01⟩)
+  | _ => throw ()
+
+/-- `ket10` displays as `|10⟩`. -/
+@[scoped app_unexpander Quantum.ket10] def unexpandKet10 : PrettyPrinter.Unexpander
+  | `($_:ident) => `(|10⟩)
+  | _ => throw ()
+
+/-- `ket11` displays as `|11⟩`. -/
+@[scoped app_unexpander Quantum.ket11] def unexpandKet11 : PrettyPrinter.Unexpander
+  | `($_:ident) => `(|11⟩)
+  | _ => throw ()
+
+/-- `ket000` displays as `|000⟩`. -/
+@[scoped app_unexpander Quantum.ket000] def unexpandKet000 : PrettyPrinter.Unexpander
+  | `($_:ident) => `(|000⟩)
+  | _ => throw ()
+
+/-- `ket001` displays as `|001⟩`. -/
+@[scoped app_unexpander Quantum.ket001] def unexpandKet001 : PrettyPrinter.Unexpander
+  | `($_:ident) => `(|001⟩)
+  | _ => throw ()
+
+/-- `ket010` displays as `|010⟩`. -/
+@[scoped app_unexpander Quantum.ket010] def unexpandKet010 : PrettyPrinter.Unexpander
+  | `($_:ident) => `(|010⟩)
+  | _ => throw ()
+
+/-- `ket011` displays as `|011⟩`. -/
+@[scoped app_unexpander Quantum.ket011] def unexpandKet011 : PrettyPrinter.Unexpander
+  | `($_:ident) => `(|011⟩)
+  | _ => throw ()
+
+/-- `ket100` displays as `|100⟩`. -/
+@[scoped app_unexpander Quantum.ket100] def unexpandKet100 : PrettyPrinter.Unexpander
+  | `($_:ident) => `(|100⟩)
+  | _ => throw ()
+
+/-- `ket101` displays as `|101⟩`. -/
+@[scoped app_unexpander Quantum.ket101] def unexpandKet101 : PrettyPrinter.Unexpander
+  | `($_:ident) => `(|101⟩)
+  | _ => throw ()
+
+/-- `ket110` displays as `|110⟩`. -/
+@[scoped app_unexpander Quantum.ket110] def unexpandKet110 : PrettyPrinter.Unexpander
+  | `($_:ident) => `(|110⟩)
+  | _ => throw ()
+
+/-- `ket111` displays as `|111⟩`. -/
+@[scoped app_unexpander Quantum.ket111] def unexpandKet111 : PrettyPrinter.Unexpander
+  | `($_:ident) => `(|111⟩)
+  | _ => throw ()
+
+/-- A literal natural: a raw `Nat` literal or `OfNat.ofNat` of one. -/
+private def natLit? (e : Expr) : Option Nat :=
+  match e with
+  | .lit (.natVal k) => some k
+  | _ =>
+    if e.isAppOfArity ``OfNat.ofNat 3 then
+      match e.getArg! 1 with
+      | .lit (.natVal k) => some k
+      | _ => none
+    else none
+
+/-- The literal bits of a `![b₀, …, bₙ₋₁]` vector (a `Matrix.vecCons` chain ending in
+`Matrix.vecEmpty`), each a literal `0` or `1`; `none` on any other shape. -/
+private partial def vecBits? (e : Expr) (acc : Array Nat := #[]) : Option (Array Nat) :=
+  if e.isAppOfArity ``Matrix.vecCons 4 then do
+    let b ← natLit? (e.getArg! 2)
+    guard (b == 0 || b == 1)
+    vecBits? (e.getArg! 3) (acc.push b)
+  else if e.isAppOfArity ``Matrix.vecEmpty 1 then
+    some acc
+  else none
+
+open PrettyPrinter Delaborator SubExpr in
+/-- Delaborate `nQubitKet n ![b₀, …, bₙ₋₁]` with literal `n ≥ 4` and literal bits back to
+`|b₀…bₙ₋₁⟩`. Stays silent on any other shape, and on `n ≤ 3` (where `|…⟩` denotes the
+tuple-indexed kets, so displaying it would not round-trip). -/
+@[scoped app_delab Quantum.nQubitKet] def delabNQubitKet : Delab :=
+  whenPPOption getPPNotation <| whenNotPPOption getPPExplicit do
+    let e ← getExpr
+    unless e.isAppOfArity ``Quantum.nQubitKet 2 do failure
+    let some n := natLit? (e.getArg! 0) | failure
+    let some bits := vecBits? (e.getArg! 1) | failure
+    unless bits.size == n && 4 ≤ n do failure
+    let s := String.ofList (bits.toList.map fun b => if b == 1 then '1' else '0')
+    `(|$(Syntax.mkNumLit s)⟩)
+
+end KetNotation
+
+/-!
+### Round-trip tests
+
+Each ket literal elaborates to exactly the pre-existing term.
+-/
+
+section KetRoundTrip
+
+example : |0⟩ = ket0 := rfl
+example : |1⟩ = ket1 := rfl
+example : |00⟩ = ket00 := rfl
+example : |01⟩ = ket01 := rfl
+example : |10⟩ = ket10 := rfl
+example : |11⟩ = ket11 := rfl
+example : |000⟩ = ket000 := rfl
+example : |101⟩ = ket101 := rfl
+example : |111⟩ = ket111 := rfl
+example : |0101⟩ = nQubitKet 4 ![0, 1, 0, 1] := rfl
+example : |1000000⟩ = nQubitKet 7 ![1, 0, 0, 0, 0, 0, 0] := rfl
+example : (|0110⟩ : NQubitState 4).val = basisVec ![0, 1, 1, 0] := rfl
+example : |+⟩ = ketPlus := rfl
+example : |-⟩ = ketMinus := rfl
+
+end KetRoundTrip
 
 end Quantum

--- a/QEC/Foundations/GateConjugation.lean
+++ b/QEC/Foundations/GateConjugation.lean
@@ -26,19 +26,19 @@ conjugation by the transversal gate matrix star U * P * U).
 -/
 
 /-- H Z H† = X (Hadamard conjugates Z to X). -/
-lemma H_conj_Z : H.val * Zmat * star H.val = Xmat := by
+lemma H_conj_Z : H ⊳ Zmat = Xmat := by
   matrix_expand[Hmat, Zmat, Xmat]
 
 /-- H X H† = Z (Hadamard conjugates X to Z). -/
-lemma H_conj_X : H.val * Xmat * star H.val = Zmat := by
+lemma H_conj_X : H ⊳ Xmat = Zmat := by
   matrix_expand[Hmat, Xmat, Zmat]
 
 /-- H† Z H = X. Used when rewriting conjugation by the adjoint transversal gate. -/
-lemma H_adj_Z_H : star H.val * Zmat * H.val = Xmat := by
+lemma H_adj_Z_H : H.valᴴ * Zmat * H.val = Xmat := by
   matrix_expand[Hmat, Xmat, Zmat]
 
 /-- H† X H = Z. Used when rewriting conjugation by the adjoint transversal gate. -/
-lemma H_adj_X_H : star H.val * Xmat * H.val = Zmat := by
+lemma H_adj_X_H : H.valᴴ * Xmat * H.val = Zmat := by
   matrix_expand[Hmat, Xmat, Zmat]
 
 /-! ### Phase gate S
@@ -48,23 +48,23 @@ So S Z S† = Z and S X S† = Y.
 -/
 
 /-- S Z S† = Z (S commutes with Z). -/
-lemma S_conj_Z : S.val * Zmat * star S.val = Zmat := by
+lemma S_conj_Z : S ⊳ Zmat = Zmat := by
   matrix_expand[Smat, Zmat]
 
 /-- S X S† = Y (S conjugates X to Y). -/
-lemma S_conj_X : S.val * Xmat * star S.val = Ymat := by
+lemma S_conj_X : S ⊳ Xmat = Ymat := by
   matrix_expand[Smat, Xmat, Ymat]
 
 /-- S† Z S = Z. Used when rewriting conjugation by the adjoint transversal gate. -/
-lemma S_adj_Z_S : star S.val * Zmat * S.val = Zmat := by
+lemma S_adj_Z_S : S.valᴴ * Zmat * S.val = Zmat := by
   matrix_expand[Smat, Zmat]
 
 /-- S† X S = -Y. Used when rewriting conjugation by the adjoint transversal gate. -/
-lemma S_adj_X_S : star S.val * Xmat * S.val = -Ymat := by
+lemma S_adj_X_S : S.valᴴ * Xmat * S.val = -Ymat := by
   matrix_expand[Smat, Xmat, Ymat]
 
 /-- `inv_S` conjugates Z to itself: `inv_S Z inv_S† = Z`. -/
-lemma inv_S_conj_Z : inv_S.val * Zmat * star inv_S.val = Zmat := by
+lemma inv_S_conj_Z : inv_S ⊳ Zmat = Zmat := by
   calc
     inv_S.val * Zmat * star inv_S.val = star S.val * Zmat * S.val := by
       simp [inv_S_val]
@@ -84,8 +84,7 @@ lemma inv_S_conj_Y : inv_S.val * Ymat * star inv_S.val = Xmat := by
 
 /-- `inv_S` conjugates identity to identity. -/
 lemma inv_S_conj_I :
-    inv_S.val * (1 : Matrix QubitBasis QubitBasis ℂ) * star inv_S.val =
-      (1 : Matrix QubitBasis QubitBasis ℂ) := by
+    inv_S ⊳ (1 : Matrix QubitBasis QubitBasis ℂ) = (1 : Matrix QubitBasis QubitBasis ℂ) := by
   have hU : inv_S.val * star inv_S.val = (1 : Matrix QubitBasis QubitBasis ℂ) := by
     exact Matrix.mem_unitaryGroup_iff.1 inv_S.2
   calc
@@ -96,28 +95,28 @@ lemma inv_S_conj_I :
 /-! ### CNOT (control = first qubit, target = second) -/
 
 /-- CNOT† (X ⊗ I) CNOT = X ⊗ X. -/
-lemma CNOT_adj_X_q1_CNOT : star CNOT.val * X_q1_2.val * CNOT.val = XX_2.val := by
+lemma CNOT_adj_X_q1_CNOT : CNOT.valᴴ * X_q1_2.val * CNOT.val = XX_2.val := by
   rw [CNOT, controllize_val, coe_X, X_q1_2, XX_2, tensorGate_val X 1, tensorGate_val X X]
   ext ⟨c₁, t₁⟩ ⟨c₂, t₂⟩
   fin_cases c₁ <;> fin_cases t₁ <;> fin_cases c₂ <;> fin_cases t₂ <;>
     simp [Matrix.mul_apply, Fintype.sum_prod_type, Xmat]
 
 /-- CNOT† (I ⊗ X) CNOT = I ⊗ X. -/
-lemma CNOT_adj_X_q2_CNOT : star CNOT.val * X_q2_2.val * CNOT.val = X_q2_2.val := by
+lemma CNOT_adj_X_q2_CNOT : CNOT.valᴴ * X_q2_2.val * CNOT.val = X_q2_2.val := by
   rw [CNOT, controllize_val, coe_X, X_q2_2, tensorGate_val 1 X]
   ext ⟨c₁, t₁⟩ ⟨c₂, t₂⟩
   fin_cases c₁ <;> fin_cases t₁ <;> fin_cases c₂ <;> fin_cases t₂ <;>
     simp [Matrix.mul_apply, Fintype.sum_prod_type, Xmat]
 
 /-- CNOT† (Z ⊗ I) CNOT = Z ⊗ I. -/
-lemma CNOT_adj_Z_q1_CNOT : star CNOT.val * Z_q1_2.val * CNOT.val = Z_q1_2.val := by
+lemma CNOT_adj_Z_q1_CNOT : CNOT.valᴴ * Z_q1_2.val * CNOT.val = Z_q1_2.val := by
   rw [CNOT, controllize_val, coe_X, Z_q1_2, tensorGate_val Z 1]
   ext ⟨c₁, t₁⟩ ⟨c₂, t₂⟩
   fin_cases c₁ <;> fin_cases t₁ <;> fin_cases c₂ <;> fin_cases t₂ <;>
     simp [Matrix.mul_apply, Fintype.sum_prod_type, Zmat, Xmat]
 
 /-- CNOT† (I ⊗ Z) CNOT = Z ⊗ Z. -/
-lemma CNOT_adj_Z_q2_CNOT : star CNOT.val * Z_q2_2.val * CNOT.val = ZZ_2.val := by
+lemma CNOT_adj_Z_q2_CNOT : CNOT.valᴴ * Z_q2_2.val * CNOT.val = ZZ_2.val := by
   rw [CNOT, controllize_val, coe_X, Z_q2_2, ZZ_2, tensorGate_val 1 Z, tensorGate_val Z Z]
   ext ⟨c₁, t₁⟩ ⟨c₂, t₂⟩
   fin_cases c₁ <;> fin_cases t₁ <;> fin_cases c₂ <;> fin_cases t₂ <;>

--- a/QEC/Foundations/GateConjugation.lean
+++ b/QEC/Foundations/GateConjugation.lean
@@ -26,19 +26,19 @@ conjugation by the transversal gate matrix star U * P * U).
 -/
 
 /-- H Z H† = X (Hadamard conjugates Z to X). -/
-lemma H_conj_Z : H ⊳ Zmat = Xmat := by
+lemma H_conj_Z : H.val * Zmat * star H.val = Xmat := by
   matrix_expand[Hmat, Zmat, Xmat]
 
 /-- H X H† = Z (Hadamard conjugates X to Z). -/
-lemma H_conj_X : H ⊳ Xmat = Zmat := by
+lemma H_conj_X : H.val * Xmat * star H.val = Zmat := by
   matrix_expand[Hmat, Xmat, Zmat]
 
 /-- H† Z H = X. Used when rewriting conjugation by the adjoint transversal gate. -/
-lemma H_adj_Z_H : H.valᴴ * Zmat * H.val = Xmat := by
+lemma H_adj_Z_H : star H.val * Zmat * H.val = Xmat := by
   matrix_expand[Hmat, Xmat, Zmat]
 
 /-- H† X H = Z. Used when rewriting conjugation by the adjoint transversal gate. -/
-lemma H_adj_X_H : H.valᴴ * Xmat * H.val = Zmat := by
+lemma H_adj_X_H : star H.val * Xmat * H.val = Zmat := by
   matrix_expand[Hmat, Xmat, Zmat]
 
 /-! ### Phase gate S
@@ -48,23 +48,23 @@ So S Z S† = Z and S X S† = Y.
 -/
 
 /-- S Z S† = Z (S commutes with Z). -/
-lemma S_conj_Z : S ⊳ Zmat = Zmat := by
+lemma S_conj_Z : S.val * Zmat * star S.val = Zmat := by
   matrix_expand[Smat, Zmat]
 
 /-- S X S† = Y (S conjugates X to Y). -/
-lemma S_conj_X : S ⊳ Xmat = Ymat := by
+lemma S_conj_X : S.val * Xmat * star S.val = Ymat := by
   matrix_expand[Smat, Xmat, Ymat]
 
 /-- S† Z S = Z. Used when rewriting conjugation by the adjoint transversal gate. -/
-lemma S_adj_Z_S : S.valᴴ * Zmat * S.val = Zmat := by
+lemma S_adj_Z_S : star S.val * Zmat * S.val = Zmat := by
   matrix_expand[Smat, Zmat]
 
 /-- S† X S = -Y. Used when rewriting conjugation by the adjoint transversal gate. -/
-lemma S_adj_X_S : S.valᴴ * Xmat * S.val = -Ymat := by
+lemma S_adj_X_S : star S.val * Xmat * S.val = -Ymat := by
   matrix_expand[Smat, Xmat, Ymat]
 
 /-- `inv_S` conjugates Z to itself: `inv_S Z inv_S† = Z`. -/
-lemma inv_S_conj_Z : inv_S ⊳ Zmat = Zmat := by
+lemma inv_S_conj_Z : inv_S.val * Zmat * star inv_S.val = Zmat := by
   calc
     inv_S.val * Zmat * star inv_S.val = star S.val * Zmat * S.val := by
       simp [inv_S_val]
@@ -84,7 +84,8 @@ lemma inv_S_conj_Y : inv_S.val * Ymat * star inv_S.val = Xmat := by
 
 /-- `inv_S` conjugates identity to identity. -/
 lemma inv_S_conj_I :
-    inv_S ⊳ (1 : Matrix QubitBasis QubitBasis ℂ) = (1 : Matrix QubitBasis QubitBasis ℂ) := by
+    inv_S.val * (1 : Matrix QubitBasis QubitBasis ℂ) * star inv_S.val =
+      (1 : Matrix QubitBasis QubitBasis ℂ) := by
   have hU : inv_S.val * star inv_S.val = (1 : Matrix QubitBasis QubitBasis ℂ) := by
     exact Matrix.mem_unitaryGroup_iff.1 inv_S.2
   calc
@@ -95,28 +96,28 @@ lemma inv_S_conj_I :
 /-! ### CNOT (control = first qubit, target = second) -/
 
 /-- CNOT† (X ⊗ I) CNOT = X ⊗ X. -/
-lemma CNOT_adj_X_q1_CNOT : CNOT.valᴴ * X_q1_2.val * CNOT.val = XX_2.val := by
+lemma CNOT_adj_X_q1_CNOT : star CNOT.val * X_q1_2.val * CNOT.val = XX_2.val := by
   rw [CNOT, controllize_val, coe_X, X_q1_2, XX_2, tensorGate_val X 1, tensorGate_val X X]
   ext ⟨c₁, t₁⟩ ⟨c₂, t₂⟩
   fin_cases c₁ <;> fin_cases t₁ <;> fin_cases c₂ <;> fin_cases t₂ <;>
     simp [Matrix.mul_apply, Fintype.sum_prod_type, Xmat]
 
 /-- CNOT† (I ⊗ X) CNOT = I ⊗ X. -/
-lemma CNOT_adj_X_q2_CNOT : CNOT.valᴴ * X_q2_2.val * CNOT.val = X_q2_2.val := by
+lemma CNOT_adj_X_q2_CNOT : star CNOT.val * X_q2_2.val * CNOT.val = X_q2_2.val := by
   rw [CNOT, controllize_val, coe_X, X_q2_2, tensorGate_val 1 X]
   ext ⟨c₁, t₁⟩ ⟨c₂, t₂⟩
   fin_cases c₁ <;> fin_cases t₁ <;> fin_cases c₂ <;> fin_cases t₂ <;>
     simp [Matrix.mul_apply, Fintype.sum_prod_type, Xmat]
 
 /-- CNOT† (Z ⊗ I) CNOT = Z ⊗ I. -/
-lemma CNOT_adj_Z_q1_CNOT : CNOT.valᴴ * Z_q1_2.val * CNOT.val = Z_q1_2.val := by
+lemma CNOT_adj_Z_q1_CNOT : star CNOT.val * Z_q1_2.val * CNOT.val = Z_q1_2.val := by
   rw [CNOT, controllize_val, coe_X, Z_q1_2, tensorGate_val Z 1]
   ext ⟨c₁, t₁⟩ ⟨c₂, t₂⟩
   fin_cases c₁ <;> fin_cases t₁ <;> fin_cases c₂ <;> fin_cases t₂ <;>
     simp [Matrix.mul_apply, Fintype.sum_prod_type, Zmat, Xmat]
 
 /-- CNOT† (I ⊗ Z) CNOT = Z ⊗ Z. -/
-lemma CNOT_adj_Z_q2_CNOT : CNOT.valᴴ * Z_q2_2.val * CNOT.val = ZZ_2.val := by
+lemma CNOT_adj_Z_q2_CNOT : star CNOT.val * Z_q2_2.val * CNOT.val = ZZ_2.val := by
   rw [CNOT, controllize_val, coe_X, Z_q2_2, ZZ_2, tensorGate_val 1 Z, tensorGate_val Z Z]
   ext ⟨c₁, t₁⟩ ⟨c₂, t₂⟩
   fin_cases c₁ <;> fin_cases t₁ <;> fin_cases c₂ <;> fin_cases t₂ <;>

--- a/QEC/Foundations/Gates.lean
+++ b/QEC/Foundations/Gates.lean
@@ -37,11 +37,6 @@ Depends on `Basic.lean` for `QubitBasis`, `NQubitBasis`, and state types.
 abbrev QuantumGate (α : Type*) [DecidableEq α] [Fintype α] :=
   Matrix.unitaryGroup α ℂ
 
-/-- A gate is its matrix: `(U : Matrix α α ℂ)` / `↑U` is `U.val`, so matrix-level
-statements can be written `Uᴴ * M * U` instead of `star U.val * M * U.val`. -/
-instance {α : Type*} [DecidableEq α] [Fintype α] : Coe (QuantumGate α) (Matrix α α ℂ) :=
-  ⟨Subtype.val⟩
-
 /-- Single-qubit gates: 2×2 unitaries in the computational basis. -/
 abbrev OneQubitGate : Type :=
   QuantumGate QubitBasis

--- a/QEC/Foundations/Gates.lean
+++ b/QEC/Foundations/Gates.lean
@@ -37,6 +37,11 @@ Depends on `Basic.lean` for `QubitBasis`, `NQubitBasis`, and state types.
 abbrev QuantumGate (α : Type*) [DecidableEq α] [Fintype α] :=
   Matrix.unitaryGroup α ℂ
 
+/-- A gate is its matrix: `(U : Matrix α α ℂ)` / `↑U` is `U.val`, so matrix-level
+statements can be written `Uᴴ * M * U` instead of `star U.val * M * U.val`. -/
+instance {α : Type*} [DecidableEq α] [Fintype α] : Coe (QuantumGate α) (Matrix α α ℂ) :=
+  ⟨Subtype.val⟩
+
 /-- Single-qubit gates: 2×2 unitaries in the computational basis. -/
 abbrev OneQubitGate : Type :=
   QuantumGate QubitBasis
@@ -108,6 +113,11 @@ noncomputable def conjBy
   {α : Type*} [Fintype α] [DecidableEq α]
   (U : QuantumGate α) (M : Matrix α α ℂ) : Matrix α α ℂ :=
   U.val * M * star U.val
+
+/-- `U ⊳ M` is the conjugation `conjBy U M = U M U†` of a matrix by a gate. Scoped to
+`Quantum` (active throughout the library's namespace). Precedence `70`, like `*`; the
+result is a matrix, so `U ⊳ M = N` needs no parentheses and `(U ⊳ M) i j` does. -/
+scoped notation:70 U:71 " ⊳ " M:71 => conjBy U M
 
 /-- Definitional expansion of `conjBy`. -/
 @[simp] lemma conjBy_def

--- a/QEC/Foundations/Tensor.lean
+++ b/QEC/Foundations/Tensor.lean
@@ -115,31 +115,31 @@ scoped notation ψ:60 " ⊗ₛ " φ:60 => tensorState ψ φ
 
 /-- X on the first of two qubits (X ⊗ I). -/
 noncomputable def X_q1_2 : TwoQubitGate :=
-  tensorGate X 1
+  X ⊗ᵍ 1
 
 /-- X on the second of two qubits (I ⊗ X). -/
 noncomputable def X_q2_2 : TwoQubitGate :=
-  tensorGate 1 X
+  1 ⊗ᵍ X
 
 /-- Z on the first of two qubits (Z ⊗ I). -/
 noncomputable def Z_q1_2 : TwoQubitGate :=
-  tensorGate Z 1
+  Z ⊗ᵍ 1
 
 /-- Z on the second of two qubits (I ⊗ Z). -/
 noncomputable def Z_q2_2 : TwoQubitGate :=
-  tensorGate 1 Z
+  1 ⊗ᵍ Z
 
 /-- X on the first qubit and Z on the second (X ⊗ Z). -/
 noncomputable def X_q1Z_q2_2 : TwoQubitGate :=
-  tensorGate X Z
+  X ⊗ᵍ Z
 
 /-- X on both qubits (X ⊗ X). -/
 noncomputable def XX_2 : TwoQubitGate :=
-  tensorGate X X
+  X ⊗ᵍ X
 
 /-- Z on both qubits (Z ⊗ Z). -/
 noncomputable def ZZ_2 : TwoQubitGate :=
-  tensorGate Z Z
+  Z ⊗ᵍ Z
 
 /-- X ⊗ I: |00⟩ ↦ |10⟩. -/
 @[simp] lemma X_q1_2_on_ket00 : X_q1_2 • |00⟩ = |10⟩ := by
@@ -175,19 +175,19 @@ noncomputable def ZZ_2 : TwoQubitGate :=
 
 /-- X on the first of three qubits (X ⊗ I ⊗ I). -/
 noncomputable def X_q1_3 : ThreeQubitGate :=
-  tensorGate X 1
+  X ⊗ᵍ 1
 
 /-- X on the second of three qubits (I ⊗ X ⊗ I). -/
 noncomputable def X_q2_3 : ThreeQubitGate :=
-  tensorGate 1 (tensorGate X 1)
+  1 ⊗ᵍ X ⊗ᵍ 1
 
 /-- X on the third of three qubits (I ⊗ I ⊗ X). -/
 noncomputable def X_q3_3 : ThreeQubitGate :=
-  tensorGate 1 (tensorGate 1 X)
+  1 ⊗ᵍ 1 ⊗ᵍ X
 
 /-- X on all three qubits (X ⊗ X ⊗ X). -/
 noncomputable def X_q1q2q3_3 : ThreeQubitGate :=
-  tensorGate X (tensorGate X X)
+  X ⊗ᵍ X ⊗ᵍ X
 
 /-- X ⊗ I ⊗ I: |000⟩ ↦ |100⟩. -/
 @[simp] lemma X_q1_3_on_ket000 : X_q1_3 • |000⟩ = |100⟩ := by
@@ -319,7 +319,7 @@ noncomputable def CNOT_q1_q3_3 : ThreeQubitGate :=
 This is the identity on q1 tensored with CNOT on `(q2, q3)`.
 -/
 noncomputable def CNOT_q2_q3_3 : ThreeQubitGate :=
-  tensorGate (1 : OneQubitGate) CNOT
+  (1 : OneQubitGate) ⊗ᵍ CNOT
 
 /-- CNOT with control q2 and target q3: |000⟩ ↦ |000⟩. -/
 @[simp] lemma CNOT_q2_q3_3_on_ket000 : CNOT_q2_q3_3 • |000⟩ = |000⟩ := by

--- a/QEC/Foundations/Tensor.lean
+++ b/QEC/Foundations/Tensor.lean
@@ -190,78 +190,78 @@ noncomputable def X_q1q2q3_3 : ThreeQubitGate :=
   tensorGate X (tensorGate X X)
 
 /-- X ⊗ I ⊗ I: |000⟩ ↦ |100⟩. -/
-@[simp] lemma X_q1_3_on_ket000 : X_q1_3 • ket000 = ket100 := by
+@[simp] lemma X_q1_3_on_ket000 : X_q1_3 • |000⟩ = |100⟩ := by
   vec_expand_simp [X_q1_3, Matrix.mulVec, Xmat]
 
 /-- X ⊗ I ⊗ I: |001⟩ ↦ |101⟩. -/
-@[simp] lemma X_q1_3_on_ket001 : X_q1_3 • ket001 = ket101 := by
+@[simp] lemma X_q1_3_on_ket001 : X_q1_3 • |001⟩ = |101⟩ := by
   vec_expand_simp [X_q1_3, Matrix.mulVec, Xmat]
 
 /-- X ⊗ I ⊗ I: |010⟩ ↦ |110⟩. -/
-@[simp] lemma X_q1_3_on_ket010 : X_q1_3 • ket010 = ket110 := by
+@[simp] lemma X_q1_3_on_ket010 : X_q1_3 • |010⟩ = |110⟩ := by
   vec_expand_simp [X_q1_3, Matrix.mulVec, Xmat]
 
 /-- X ⊗ I ⊗ I: |011⟩ ↦ |111⟩. -/
-@[simp] lemma X_q1_3_on_ket011 : X_q1_3 • ket011 = ket111 := by
+@[simp] lemma X_q1_3_on_ket011 : X_q1_3 • |011⟩ = |111⟩ := by
   vec_expand_simp [X_q1_3, Matrix.mulVec, Xmat]
 
 /-- X ⊗ I ⊗ I: |100⟩ ↦ |000⟩. -/
-@[simp] lemma X_q1_3_on_ket100 : X_q1_3 • ket100 = ket000 := by
+@[simp] lemma X_q1_3_on_ket100 : X_q1_3 • |100⟩ = |000⟩ := by
   vec_expand_simp [X_q1_3, Matrix.mulVec, Xmat]
 
 /-- X ⊗ I ⊗ I: |101⟩ ↦ |001⟩. -/
-@[simp] lemma X_q1_3_on_ket101 : X_q1_3 • ket101 = ket001 := by
+@[simp] lemma X_q1_3_on_ket101 : X_q1_3 • |101⟩ = |001⟩ := by
   vec_expand_simp [X_q1_3, Matrix.mulVec, Xmat]
 
 /-- X ⊗ I ⊗ I: |110⟩ ↦ |010⟩. -/
-@[simp] lemma X_q1_3_on_ket110 : X_q1_3 • ket110 = ket010 := by
+@[simp] lemma X_q1_3_on_ket110 : X_q1_3 • |110⟩ = |010⟩ := by
   vec_expand_simp [X_q1_3, Matrix.mulVec, Xmat]
 
 /-- X ⊗ I ⊗ I: |111⟩ ↦ |011⟩. -/
-@[simp] lemma X_q1_3_on_ket111 : X_q1_3 • ket111 = ket011 := by
+@[simp] lemma X_q1_3_on_ket111 : X_q1_3 • |111⟩ = |011⟩ := by
   vec_expand_simp [X_q1_3, Matrix.mulVec, Xmat]
 
 /-- X ⊗ X ⊗ X: |000⟩ ↦ |111⟩. -/
-@[simp] lemma X_q1q2q3_on_ket000 : X_q1q2q3_3 • ket000 = ket111 := by
+@[simp] lemma X_q1q2q3_on_ket000 : X_q1q2q3_3 • |000⟩ = |111⟩ := by
   vec_expand_simp[X_q1q2q3_3, Matrix.mulVec, Xmat]
 
 /-- X ⊗ X ⊗ X: |111⟩ ↦ |000⟩. -/
-@[simp] lemma X_q1q2q3_on_ket111 : X_q1q2q3_3 • ket111 = ket000 := by
+@[simp] lemma X_q1q2q3_on_ket111 : X_q1q2q3_3 • |111⟩ = |000⟩ := by
   vec_expand_simp[X_q1q2q3_3, Matrix.mulVec, Xmat]
 
 /-! ### `X_q2_3` (I ⊗ X ⊗ I): flips the second bit -/
 
 
 /-- I ⊗ X ⊗ I: |000⟩ ↦ |010⟩. -/
-@[simp] lemma X_q2_3_on_ket000 : X_q2_3 • ket000 = ket010 := by
+@[simp] lemma X_q2_3_on_ket000 : X_q2_3 • |000⟩ = |010⟩ := by
   vec_expand_simp [X_q2_3, Matrix.mulVec, Xmat]
 
 /-- I ⊗ X ⊗ I: |001⟩ ↦ |011⟩. -/
-@[simp] lemma X_q2_3_on_ket001 : X_q2_3 • ket001 = ket011 := by
+@[simp] lemma X_q2_3_on_ket001 : X_q2_3 • |001⟩ = |011⟩ := by
   vec_expand_simp [X_q2_3, Matrix.mulVec, Xmat]
 
 /-- I ⊗ X ⊗ I: |010⟩ ↦ |000⟩. -/
-@[simp] lemma X_q2_3_on_ket010 : X_q2_3 • ket010 = ket000 := by
+@[simp] lemma X_q2_3_on_ket010 : X_q2_3 • |010⟩ = |000⟩ := by
   vec_expand_simp [X_q2_3, Matrix.mulVec, Xmat]
 
 /-- I ⊗ X ⊗ I: |011⟩ ↦ |001⟩. -/
-@[simp] lemma X_q2_3_on_ket011 : X_q2_3 • ket011 = ket001 := by
+@[simp] lemma X_q2_3_on_ket011 : X_q2_3 • |011⟩ = |001⟩ := by
   vec_expand_simp [X_q2_3, Matrix.mulVec, Xmat]
 
 /-- I ⊗ X ⊗ I: |100⟩ ↦ |110⟩. -/
-@[simp] lemma X_q2_3_on_ket100 : X_q2_3 • ket100 = ket110 := by
+@[simp] lemma X_q2_3_on_ket100 : X_q2_3 • |100⟩ = |110⟩ := by
   vec_expand_simp [X_q2_3, Matrix.mulVec, Xmat]
 
 /-- I ⊗ X ⊗ I: |101⟩ ↦ |111⟩. -/
-@[simp] lemma X_q2_3_on_ket101 : X_q2_3 • ket101 = ket111 := by
+@[simp] lemma X_q2_3_on_ket101 : X_q2_3 • |101⟩ = |111⟩ := by
   vec_expand_simp [X_q2_3, Matrix.mulVec, Xmat]
 
 /-- I ⊗ X ⊗ I: |110⟩ ↦ |100⟩. -/
-@[simp] lemma X_q2_3_on_ket110 : X_q2_3 • ket110 = ket100 := by
+@[simp] lemma X_q2_3_on_ket110 : X_q2_3 • |110⟩ = |100⟩ := by
   vec_expand_simp [X_q2_3, Matrix.mulVec, Xmat]
 
 /-- I ⊗ X ⊗ I: |111⟩ ↦ |101⟩. -/
-@[simp] lemma X_q2_3_on_ket111 : X_q2_3 • ket111 = ket101 := by
+@[simp] lemma X_q2_3_on_ket111 : X_q2_3 • |111⟩ = |101⟩ := by
   vec_expand_simp [X_q2_3, Matrix.mulVec, Xmat]
 
 
@@ -269,35 +269,35 @@ noncomputable def X_q1q2q3_3 : ThreeQubitGate :=
 
 
 /-- I ⊗ I ⊗ X: |000⟩ ↦ |001⟩. -/
-@[simp] lemma X_q3_3_on_ket000 : X_q3_3 • ket000 = ket001 := by
+@[simp] lemma X_q3_3_on_ket000 : X_q3_3 • |000⟩ = |001⟩ := by
   vec_expand_simp [X_q3_3, Matrix.mulVec, Xmat]
 
 /-- I ⊗ I ⊗ X: |001⟩ ↦ |000⟩. -/
-@[simp] lemma X_q3_3_on_ket001 : X_q3_3 • ket001 = ket000 := by
+@[simp] lemma X_q3_3_on_ket001 : X_q3_3 • |001⟩ = |000⟩ := by
   vec_expand_simp [X_q3_3, Matrix.mulVec, Xmat]
 
 /-- I ⊗ I ⊗ X: |010⟩ ↦ |011⟩. -/
-@[simp] lemma X_q3_3_on_ket010 : X_q3_3 • ket010 = ket011 := by
+@[simp] lemma X_q3_3_on_ket010 : X_q3_3 • |010⟩ = |011⟩ := by
   vec_expand_simp [X_q3_3, Matrix.mulVec, Xmat]
 
 /-- I ⊗ I ⊗ X: |011⟩ ↦ |010⟩. -/
-@[simp] lemma X_q3_3_on_ket011 : X_q3_3 • ket011 = ket010 := by
+@[simp] lemma X_q3_3_on_ket011 : X_q3_3 • |011⟩ = |010⟩ := by
   vec_expand_simp [X_q3_3, Matrix.mulVec, Xmat]
 
 /-- I ⊗ I ⊗ X: |100⟩ ↦ |101⟩. -/
-@[simp] lemma X_q3_3_on_ket100 : X_q3_3 • ket100 = ket101 := by
+@[simp] lemma X_q3_3_on_ket100 : X_q3_3 • |100⟩ = |101⟩ := by
   vec_expand_simp [X_q3_3, Matrix.mulVec, Xmat]
 
 /-- I ⊗ I ⊗ X: |101⟩ ↦ |100⟩. -/
-@[simp] lemma X_q3_3_on_ket101 : X_q3_3 • ket101 = ket100 := by
+@[simp] lemma X_q3_3_on_ket101 : X_q3_3 • |101⟩ = |100⟩ := by
   vec_expand_simp [X_q3_3, Matrix.mulVec, Xmat]
 
 /-- I ⊗ I ⊗ X: |110⟩ ↦ |111⟩. -/
-@[simp] lemma X_q3_3_on_ket110 : X_q3_3 • ket110 = ket111 := by
+@[simp] lemma X_q3_3_on_ket110 : X_q3_3 • |110⟩ = |111⟩ := by
   vec_expand_simp [X_q3_3, Matrix.mulVec, Xmat]
 
 /-- I ⊗ I ⊗ X: |111⟩ ↦ |110⟩. -/
-@[simp] lemma X_q3_3_on_ket111 : X_q3_3 • ket111 = ket110 := by
+@[simp] lemma X_q3_3_on_ket111 : X_q3_3 • |111⟩ = |110⟩ := by
   vec_expand_simp [X_q3_3, Matrix.mulVec, Xmat]
 
 /-- CNOT on qubits 1 (control) and 2 (target) of a 3-qubit register.
@@ -322,35 +322,35 @@ noncomputable def CNOT_q2_q3_3 : ThreeQubitGate :=
   tensorGate (1 : OneQubitGate) CNOT
 
 /-- CNOT with control q2 and target q3: |000⟩ ↦ |000⟩. -/
-@[simp] lemma CNOT_q2_q3_3_on_ket000 : CNOT_q2_q3_3 • ket000 = ket000 := by
+@[simp] lemma CNOT_q2_q3_3_on_ket000 : CNOT_q2_q3_3 • |000⟩ = |000⟩ := by
   vec_expand_simp [CNOT_q2_q3_3, Matrix.mulVec, CNOT, controllize, Xmat]
 
 /-- CNOT with control q2 and target q3: |001⟩ ↦ |001⟩. -/
-@[simp] lemma CNOT_q2_q3_3_on_ket001 : CNOT_q2_q3_3 • ket001 = ket001 := by
+@[simp] lemma CNOT_q2_q3_3_on_ket001 : CNOT_q2_q3_3 • |001⟩ = |001⟩ := by
   vec_expand_simp [CNOT_q2_q3_3,  Matrix.mulVec, CNOT, controllize, Xmat]
 
 /-- CNOT with control q2 and target q3: |010⟩ ↦ |011⟩. -/
-@[simp] lemma CNOT_q2_q3_3_on_ket010 : CNOT_q2_q3_3 • ket010 = ket011 := by
+@[simp] lemma CNOT_q2_q3_3_on_ket010 : CNOT_q2_q3_3 • |010⟩ = |011⟩ := by
   vec_expand_simp [CNOT_q2_q3_3,  Matrix.mulVec, CNOT, controllize, Xmat]
 
 /-- CNOT with control q2 and target q3: |011⟩ ↦ |010⟩. -/
-@[simp] lemma CNOT_q2_q3_3_on_ket011 : CNOT_q2_q3_3 • ket011 = ket010 := by
+@[simp] lemma CNOT_q2_q3_3_on_ket011 : CNOT_q2_q3_3 • |011⟩ = |010⟩ := by
   vec_expand_simp [CNOT_q2_q3_3,  Matrix.mulVec, CNOT, controllize, Xmat]
 
 /-- CNOT with control q2 and target q3: |100⟩ ↦ |100⟩. -/
-@[simp] lemma CNOT_q2_q3_3_on_ket100 : CNOT_q2_q3_3 • ket100 = ket100 := by
+@[simp] lemma CNOT_q2_q3_3_on_ket100 : CNOT_q2_q3_3 • |100⟩ = |100⟩ := by
   vec_expand_simp [CNOT_q2_q3_3,  Matrix.mulVec, CNOT, controllize, Xmat]
 
 /-- CNOT with control q2 and target q3: |101⟩ ↦ |101⟩. -/
-@[simp] lemma CNOT_q2_q3_3_on_ket101 : CNOT_q2_q3_3 • ket101 = ket101 := by
+@[simp] lemma CNOT_q2_q3_3_on_ket101 : CNOT_q2_q3_3 • |101⟩ = |101⟩ := by
   vec_expand_simp [CNOT_q2_q3_3,  Matrix.mulVec, CNOT, controllize, Xmat]
 
 /-- CNOT with control q2 and target q3: |110⟩ ↦ |111⟩. -/
-@[simp] lemma CNOT_q2_q3_3_on_ket110 : CNOT_q2_q3_3 • ket110 = ket111 := by
+@[simp] lemma CNOT_q2_q3_3_on_ket110 : CNOT_q2_q3_3 • |110⟩ = |111⟩ := by
   vec_expand_simp [CNOT_q2_q3_3,  Matrix.mulVec, CNOT, controllize, Xmat]
 
 /-- CNOT with control q2 and target q3: |111⟩ ↦ |110⟩. -/
-@[simp] lemma CNOT_q2_q3_3_on_ket111 : CNOT_q2_q3_3 • ket111 = ket110 := by
+@[simp] lemma CNOT_q2_q3_3_on_ket111 : CNOT_q2_q3_3 • |111⟩ = |110⟩ := by
   vec_expand_simp [CNOT_q2_q3_3,  Matrix.mulVec, CNOT, controllize, Xmat]
 
 end Quantum

--- a/QEC/Stabilizer/Codes/BivariateBicycle/Gross/BaseDistance.lean
+++ b/QEC/Stabilizer/Codes/BivariateBicycle/Gross/BaseDistance.lean
@@ -138,7 +138,7 @@ configurations. -/
 
 /-- The augmentation is multiplicative on convolutions. -/
 lemma sum_conv {G : Type} [Fintype G] [AddCommGroup G] (a b : G → ZMod 2) :
-    ∑ g : G, conv a b g = (∑ h : G, a h) * (∑ g : G, b g) := by
+    ∑ g : G, (a ⋆ b) g = (∑ h : G, a h) * (∑ g : G, b g) := by
   simp only [conv_apply]
   rw [Finset.sum_comm]
   rw [Finset.sum_mul]
@@ -158,7 +158,7 @@ lemma cycle_total_parity (u : BaseGroup × Fin 2 → ZMod 2)
       = (∑ h : BaseGroup, baseB h) * (∑ g : BaseGroup, leftHalf u g)
         + (∑ h : BaseGroup, baseA h) * (∑ g : BaseGroup, rightHalf u g) := by
     rw [show (fun g => bbBoundary1Fn baseA baseB u g)
-        = fun g => conv baseB (leftHalf u) g + conv baseA (rightHalf u) g
+        = fun g => (baseB ⋆ leftHalf u) g + (baseA ⋆ rightHalf u) g
       from rfl]
     rw [Finset.sum_add_distrib, sum_conv, sum_conv]
   have hA : (∑ h : BaseGroup, baseA h) = 1 := by decide +kernel

--- a/QEC/Stabilizer/Codes/BivariateBicycle/Gross/CRTFrame.lean
+++ b/QEC/Stabilizer/Codes/BivariateBicycle/Gross/CRTFrame.lean
@@ -349,28 +349,28 @@ chain `z` — by F₂-linearity of `conv baseP ·`, `V`, and `rmul`. -/
 theorem mult_of_basis (psi : BaseGroup → Fin 4) (P : BaseGroup → ZMod 2)
     (Phat : ZMod 2 × ZMod 2 → Fin 4)
     (hbasis : ∀ (p : BaseGroup) (s : ZMod 2 × ZMod 2),
-      V psi s (conv P (Pi.single p 1)) = rmul Phat (fun s' => V psi s' (Pi.single p 1)) s)
+      V psi s (P ⋆ Pi.single p 1) = rmul Phat (fun s' => V psi s' (Pi.single p 1)) s)
     (z : BaseGroup → ZMod 2) (s : ZMod 2 × ZMod 2) :
-    V psi s (conv P z) = rmul Phat (fun s' => V psi s' z) s := by
+    V psi s (P ⋆ z) = rmul Phat (fun s' => V psi s' z) s := by
   have goal_add : ∀ (a b : BaseGroup → ZMod 2),
-      (∀ s, V psi s (conv P a) = rmul Phat (fun s' => V psi s' a) s) →
-      (∀ s, V psi s (conv P b) = rmul Phat (fun s' => V psi s' b) s) →
-      (∀ s, V psi s (conv P (a + b)) = rmul Phat (fun s' => V psi s' (a + b)) s) := by
+      (∀ s, V psi s (P ⋆ a) = rmul Phat (fun s' => V psi s' a) s) →
+      (∀ s, V psi s (P ⋆ b) = rmul Phat (fun s' => V psi s' b) s) →
+      (∀ s, V psi s (P ⋆ (a + b)) = rmul Phat (fun s' => V psi s' (a + b)) s) := by
     intro a b ha hb s
     rw [conv_add_right, V_add]
     rw [show (fun s' => V psi s' (a + b))
         = (fun s' => fadd (V psi s' a) (V psi s' b)) from by funext s'; rw [V_add]]
     rw [rmul_add_right, ha s, hb s]
-  have goal_zero : ∀ s, V psi s (conv P (0 : BaseGroup → ZMod 2))
+  have goal_zero : ∀ s, V psi s (P ⋆ (0 : BaseGroup → ZMod 2))
       = rmul Phat (fun s' => V psi s' (0 : BaseGroup → ZMod 2)) s := by
     intro s
-    have hc0 : conv P (0 : BaseGroup → ZMod 2) = 0 := by funext g; simp [conv_apply]
+    have hc0 : P ⋆ (0 : BaseGroup → ZMod 2) = 0 := by funext g; simp [conv_apply]
     rw [hc0, V_zero,
       show (fun s' => V psi s' (0 : BaseGroup → ZMod 2)) = (fun _ => 0) from by
         funext s'; exact V_zero psi s',
       rmul_zero_right]
   have key : ∀ (S : Finset BaseGroup) (s),
-      V psi s (conv P (ind S)) = rmul Phat (fun s' => V psi s' (ind S)) s := by
+      V psi s (P ⋆ ind S) = rmul Phat (fun s' => V psi s' (ind S)) s := by
     intro S
     induction S using Finset.induction with
     | empty => rw [ind_empty]; exact goal_zero
@@ -386,7 +386,7 @@ For each, a kernel `decide` discharges the 36-`δ_p` basis case (in the sparse
 /-- Sparse form of right-convolution with a point mass:
 `conv P δ_p = P (· - p)` (from `conv_comm` + `conv_single_left`). -/
 theorem conv_single_right (P : BaseGroup → ZMod 2) (p : BaseGroup) :
-    conv P (Pi.single p 1) = fun g => P (g - p) := by
+    P ⋆ Pi.single p 1 = fun g => P (g - p) := by
   rw [conv_comm, conv_single_left]
 
 /-- Reduce the `hbasis` obligation of `mult_of_basis` to its translate form
@@ -398,38 +398,38 @@ theorem basis_of_translate {psi : BaseGroup → Fin 4} {P : BaseGroup → ZMod 2
     (h : ∀ (p : BaseGroup) (s : ZMod 2 × ZMod 2),
       V psi s (fun g => P (g - p)) = rmul Phat (fun s' => V psi s' (Pi.single p 1)) s)
     (p : BaseGroup) (s : ZMod 2 × ZMod 2) :
-    V psi s (conv P (Pi.single p 1)) = rmul Phat (fun s' => V psi s' (Pi.single p 1)) s := by
+    V psi s (P ⋆ Pi.single p 1) = rmul Phat (fun s' => V psi s' (Pi.single p 1)) s := by
   rw [conv_single_right]
   exact h p s
 
 /-- `Â₁`: `V₁(A⋆z) = Â₁·V₁(z)`. -/
 theorem mult_A1 (z : BaseGroup → ZMod 2) (s : ZMod 2 × ZMod 2) :
-    V psi1 s (conv baseA z) = rmul Ahat1 (fun s' => V psi1 s' z) s :=
+    V psi1 s (baseA ⋆ z) = rmul Ahat1 (fun s' => V psi1 s' z) s :=
   mult_of_basis psi1 baseA Ahat1 (basis_of_translate (by decide +kernel)) z s
 
 /-- `Â₃ = Â₁`: `V₃(A⋆z) = Â₁·V₃(z)`. -/
 theorem mult_A3 (z : BaseGroup → ZMod 2) (s : ZMod 2 × ZMod 2) :
-    V psi3 s (conv baseA z) = rmul Ahat1 (fun s' => V psi3 s' z) s :=
+    V psi3 s (baseA ⋆ z) = rmul Ahat1 (fun s' => V psi3 s' z) s :=
   mult_of_basis psi3 baseA Ahat1 (basis_of_translate (by decide +kernel)) z s
 
 /-- `Â₄`: `V₄(A⋆z) = Â₄·V₄(z)`. -/
 theorem mult_A4 (z : BaseGroup → ZMod 2) (s : ZMod 2 × ZMod 2) :
-    V psi4 s (conv baseA z) = rmul Ahat4 (fun s' => V psi4 s' z) s :=
+    V psi4 s (baseA ⋆ z) = rmul Ahat4 (fun s' => V psi4 s' z) s :=
   mult_of_basis psi4 baseA Ahat4 (basis_of_translate (by decide +kernel)) z s
 
 /-- `B̂₂`: `V₂(B⋆z) = B̂₂·V₂(z)`. -/
 theorem mult_B2 (z : BaseGroup → ZMod 2) (s : ZMod 2 × ZMod 2) :
-    V psi2 s (conv baseB z) = rmul Bhat2 (fun s' => V psi2 s' z) s :=
+    V psi2 s (baseB ⋆ z) = rmul Bhat2 (fun s' => V psi2 s' z) s :=
   mult_of_basis psi2 baseB Bhat2 (basis_of_translate (by decide +kernel)) z s
 
 /-- `B̂₃ = B̂₂`: `V₃(B⋆z) = B̂₂·V₃(z)`. -/
 theorem mult_B3 (z : BaseGroup → ZMod 2) (s : ZMod 2 × ZMod 2) :
-    V psi3 s (conv baseB z) = rmul Bhat2 (fun s' => V psi3 s' z) s :=
+    V psi3 s (baseB ⋆ z) = rmul Bhat2 (fun s' => V psi3 s' z) s :=
   mult_of_basis psi3 baseB Bhat2 (basis_of_translate (by decide +kernel)) z s
 
 /-- `B̂₄ = B̂₂`: `V₄(B⋆z) = B̂₂·V₄(z)`. -/
 theorem mult_B4 (z : BaseGroup → ZMod 2) (s : ZMod 2 × ZMod 2) :
-    V psi4 s (conv baseB z) = rmul Bhat2 (fun s' => V psi4 s' z) s :=
+    V psi4 s (baseB ⋆ z) = rmul Bhat2 (fun s' => V psi4 s' z) s :=
   mult_of_basis psi4 baseB Bhat2 (basis_of_translate (by decide +kernel)) z s
 
 end CRTFrame

--- a/QEC/Stabilizer/Codes/BivariateBicycle/Gross/DeckHomotopy.lean
+++ b/QEC/Stabilizer/Codes/BivariateBicycle/Gross/DeckHomotopy.lean
@@ -32,11 +32,11 @@ namespace BB
 
 /-! ## Machine-certified polynomial identities -/
 
-theorem gross_conv_B_B : conv grossB grossB = bSquaredPoly := by
+theorem gross_conv_B_B : grossB ⋆ grossB = bSquaredPoly := by
   decide +kernel
 
 theorem gross_conv_onePlusX2_Bsq :
-    conv onePlusX2 bSquaredPoly = onePlusX6 := by
+    onePlusX2 ⋆ bSquaredPoly = onePlusX6 := by
   decide +kernel
 
 /-! ## `1 + x⁶` acts as `1 + deck shift` -/
@@ -46,7 +46,7 @@ theorem onePlusX6_eq :
   decide +kernel
 
 theorem conv_onePlusX6 (v : GrossGroup → ZMod 2) :
-    conv onePlusX6 v = v + deckShift0 v := by
+    onePlusX6 ⋆ v = v + deckShift0 v := by
   rw [onePlusX6_eq, conv_add_left, conv_single_left, conv_single_left]
   funext g
   simp only [Pi.add_apply, sub_zero, deckShift0_apply]
@@ -56,69 +56,69 @@ theorem conv_onePlusX6 (v : GrossGroup → ZMod 2) :
 
 /-- The homotopy chain `z := (1 + x²) ⋆ B ⋆ v_R`. -/
 def homotopyChain (v : GrossGroup × Fin 2 → ZMod 2) : GrossGroup → ZMod 2 :=
-  conv onePlusX2 (conv grossB (rightHalf v))
+  onePlusX2 ⋆ (grossB ⋆ rightHalf v)
 
 /-- Cycle condition in convolution form: `A⋆v_R = B⋆v_L`. -/
 lemma cycle_conv_eq {v : GrossGroup × Fin 2 → ZMod 2}
     (hv : v ∈ grossComplex.cycles) :
-    conv grossA (rightHalf v) = conv grossB (leftHalf v) := by
+    grossA ⋆ rightHalf v = grossB ⋆ leftHalf v := by
   have h0 : bbBoundary1Fn grossA grossB v = 0 :=
     (HomologicalCode.mem_cycles_iff grossComplex v).mp hv
   funext g
-  have hg : conv grossB (leftHalf v) g + conv grossA (rightHalf v) g = 0 :=
+  have hg : (grossB ⋆ leftHalf v) g + (grossA ⋆ rightHalf v) g = 0 :=
     congrFun h0 g
-  have := (CharTwo.add_eq_zero (a := conv grossB (leftHalf v) g)
-    (b := conv grossA (rightHalf v) g)).mp hg
+  have := (CharTwo.add_eq_zero (a := (grossB ⋆ leftHalf v) g)
+    (b := (grossA ⋆ rightHalf v) g)).mp hg
   exact this.symm
 
 /-- `A ⋆ z = v_L + σ v_L`. -/
 lemma conv_grossA_homotopyChain {v : GrossGroup × Fin 2 → ZMod 2}
     (hv : v ∈ grossComplex.cycles) :
-    conv grossA (homotopyChain v) = leftHalf v + deckShift0 (leftHalf v) := by
+    grossA ⋆ homotopyChain v = leftHalf v + deckShift0 (leftHalf v) := by
   unfold homotopyChain
-  calc conv grossA (conv onePlusX2 (conv grossB (rightHalf v)))
-      = conv (conv grossA onePlusX2) (conv grossB (rightHalf v)) :=
+  calc (grossA ⋆ (onePlusX2 ⋆ (grossB ⋆ rightHalf v)))
+      = (grossA ⋆ onePlusX2) ⋆ (grossB ⋆ rightHalf v) :=
         (conv_assoc _ _ _).symm
-    _ = conv (conv onePlusX2 grossA) (conv grossB (rightHalf v)) := by
+    _ = (onePlusX2 ⋆ grossA) ⋆ (grossB ⋆ rightHalf v) := by
         rw [conv_comm grossA]
-    _ = conv onePlusX2 (conv grossA (conv grossB (rightHalf v))) :=
+    _ = onePlusX2 ⋆ (grossA ⋆ (grossB ⋆ rightHalf v)) :=
         conv_assoc _ _ _
-    _ = conv onePlusX2 (conv (conv grossA grossB) (rightHalf v)) := by
+    _ = onePlusX2 ⋆ ((grossA ⋆ grossB) ⋆ rightHalf v) := by
         rw [conv_assoc]
-    _ = conv onePlusX2 (conv (conv grossB grossA) (rightHalf v)) := by
+    _ = onePlusX2 ⋆ ((grossB ⋆ grossA) ⋆ rightHalf v) := by
         rw [conv_comm grossA grossB]
-    _ = conv onePlusX2 (conv grossB (conv grossA (rightHalf v))) := by
+    _ = onePlusX2 ⋆ (grossB ⋆ (grossA ⋆ rightHalf v)) := by
         rw [conv_assoc]
-    _ = conv onePlusX2 (conv grossB (conv grossB (leftHalf v))) := by
+    _ = onePlusX2 ⋆ (grossB ⋆ (grossB ⋆ leftHalf v)) := by
         rw [cycle_conv_eq hv]
-    _ = conv onePlusX2 (conv (conv grossB grossB) (leftHalf v)) := by
+    _ = onePlusX2 ⋆ ((grossB ⋆ grossB) ⋆ leftHalf v) := by
         rw [conv_assoc]
-    _ = conv onePlusX2 (conv bSquaredPoly (leftHalf v)) := by
+    _ = onePlusX2 ⋆ (bSquaredPoly ⋆ leftHalf v) := by
         rw [gross_conv_B_B]
-    _ = conv (conv onePlusX2 bSquaredPoly) (leftHalf v) :=
+    _ = (onePlusX2 ⋆ bSquaredPoly) ⋆ leftHalf v :=
         (conv_assoc _ _ _).symm
-    _ = conv onePlusX6 (leftHalf v) := by
+    _ = onePlusX6 ⋆ leftHalf v := by
         rw [gross_conv_onePlusX2_Bsq]
     _ = leftHalf v + deckShift0 (leftHalf v) := conv_onePlusX6 _
 
 /-- `B ⋆ z = v_R + σ v_R`. -/
 lemma conv_grossB_homotopyChain (v : GrossGroup × Fin 2 → ZMod 2) :
-    conv grossB (homotopyChain v) = rightHalf v + deckShift0 (rightHalf v) := by
+    grossB ⋆ homotopyChain v = rightHalf v + deckShift0 (rightHalf v) := by
   unfold homotopyChain
-  calc conv grossB (conv onePlusX2 (conv grossB (rightHalf v)))
-      = conv (conv grossB onePlusX2) (conv grossB (rightHalf v)) :=
+  calc (grossB ⋆ (onePlusX2 ⋆ (grossB ⋆ rightHalf v)))
+      = (grossB ⋆ onePlusX2) ⋆ (grossB ⋆ rightHalf v) :=
         (conv_assoc _ _ _).symm
-    _ = conv (conv onePlusX2 grossB) (conv grossB (rightHalf v)) := by
+    _ = (onePlusX2 ⋆ grossB) ⋆ (grossB ⋆ rightHalf v) := by
         rw [conv_comm grossB]
-    _ = conv onePlusX2 (conv grossB (conv grossB (rightHalf v))) :=
+    _ = onePlusX2 ⋆ (grossB ⋆ (grossB ⋆ rightHalf v)) :=
         conv_assoc _ _ _
-    _ = conv onePlusX2 (conv (conv grossB grossB) (rightHalf v)) := by
+    _ = onePlusX2 ⋆ ((grossB ⋆ grossB) ⋆ rightHalf v) := by
         rw [conv_assoc]
-    _ = conv onePlusX2 (conv bSquaredPoly (rightHalf v)) := by
+    _ = onePlusX2 ⋆ (bSquaredPoly ⋆ rightHalf v) := by
         rw [gross_conv_B_B]
-    _ = conv (conv onePlusX2 bSquaredPoly) (rightHalf v) :=
+    _ = (onePlusX2 ⋆ bSquaredPoly) ⋆ rightHalf v :=
         (conv_assoc _ _ _).symm
-    _ = conv onePlusX6 (rightHalf v) := by
+    _ = onePlusX6 ⋆ rightHalf v := by
         rw [gross_conv_onePlusX2_Bsq]
     _ = rightHalf v + deckShift0 (rightHalf v) := conv_onePlusX6 _
 
@@ -129,10 +129,10 @@ theorem bbBoundary2Fn_homotopyChain {v : GrossGroup × Fin 2 → ZMod 2}
   funext p
   obtain ⟨h, j⟩ := p
   fin_cases j
-  · change conv grossA (homotopyChain v) h = (v + deckShift1 v) (h, 0)
+  · change (grossA ⋆ homotopyChain v) h = (v + deckShift1 v) (h, 0)
     rw [conv_grossA_homotopyChain hv]
     rfl
-  · change conv grossB (homotopyChain v) h = (v + deckShift1 v) (h, 1)
+  · change (grossB ⋆ homotopyChain v) h = (v + deckShift1 v) (h, 1)
     rw [conv_grossB_homotopyChain v]
     rfl
 

--- a/QEC/Stabilizer/Codes/BivariateBicycle/Gross/Defs.lean
+++ b/QEC/Stabilizer/Codes/BivariateBicycle/Gross/Defs.lean
@@ -39,36 +39,31 @@ abbrev BaseGroup : Type := ZMod 6 × ZMod 6
 /-! ## Polynomials
 
 Group-algebra elements are `ZMod 2`-valued indicator functions of their
-supports.  Monomial `xᵃyᵇ` ↦ the point `(a, b)`. -/
+supports.  Monomial `xᵃyᵇ` ↦ the point `(a, b)`; `poly[x^3 + y + y^2]`
+(`BBChainComplex.lean`) expands to exactly the
+`fun g => if g = (3, 0) ∨ g = (0, 1) ∨ g = (0, 2) then 1 else 0` indicator. -/
 
 /-- Gross-code `A = x³ + y + y²`. -/
-def grossA : GrossGroup → ZMod 2 := fun g =>
-  if g = (3, 0) ∨ g = (0, 1) ∨ g = (0, 2) then 1 else 0
+def grossA : GrossGroup → ZMod 2 := poly[x^3 + y + y^2]
 
 /-- Gross-code `B = y³ + x + x²`. -/
-def grossB : GrossGroup → ZMod 2 := fun g =>
-  if g = (0, 3) ∨ g = (1, 0) ∨ g = (2, 0) then 1 else 0
+def grossB : GrossGroup → ZMod 2 := poly[y^3 + x + x^2]
 
 /-- Base-code `A = x³ + y + y²` (over `Z₆ × Z₆`). -/
-def baseA : BaseGroup → ZMod 2 := fun g =>
-  if g = (3, 0) ∨ g = (0, 1) ∨ g = (0, 2) then 1 else 0
+def baseA : BaseGroup → ZMod 2 := poly[x^3 + y + y^2]
 
 /-- Base-code `B = y³ + x + x²` (over `Z₆ × Z₆`). -/
-def baseB : BaseGroup → ZMod 2 := fun g =>
-  if g = (0, 3) ∨ g = (1, 0) ∨ g = (2, 0) then 1 else 0
+def baseB : BaseGroup → ZMod 2 := poly[y^3 + x + x^2]
 
 /-- The polynomial `1 + x²` (homotopy-chain prefactor). -/
-def onePlusX2 : GrossGroup → ZMod 2 := fun g =>
-  if g = (0, 0) ∨ g = (2, 0) then 1 else 0
+def onePlusX2 : GrossGroup → ZMod 2 := poly[1 + x^2]
 
 /-- `B ⋆ B = 1 + x² + x⁴` over the gross group (squares kill cross terms in
 char 2, and `y⁶ = 1`). -/
-def bSquaredPoly : GrossGroup → ZMod 2 := fun g =>
-  if g = (0, 0) ∨ g = (2, 0) ∨ g = (4, 0) then 1 else 0
+def bSquaredPoly : GrossGroup → ZMod 2 := poly[1 + x^2 + x^4]
 
 /-- The polynomial `1 + x⁶ = 1 + deck`. -/
-def onePlusX6 : GrossGroup → ZMod 2 := fun g =>
-  if g = (0, 0) ∨ g = (6, 0) then 1 else 0
+def onePlusX6 : GrossGroup → ZMod 2 := poly[1 + x^6]
 
 /-! ## Chain complexes -/
 

--- a/QEC/Stabilizer/Codes/BivariateBicycle/Gross/LightStab.lean
+++ b/QEC/Stabilizer/Codes/BivariateBicycle/Gross/LightStab.lean
@@ -360,19 +360,19 @@ def unitHat : Ring := fun s =>
 
 /-- `V₀(A⋆z) = Â₀·V₀(z)`, `Â₀ = unitHat`. -/
 theorem mult_A0 (z : BaseGroup → ZMod 2) (s : ZMod 2 × ZMod 2) :
-    V psi0 s (conv baseA z) = rmul unitHat (fun s' => V psi0 s' z) s :=
+    V psi0 s (baseA ⋆ z) = rmul unitHat (fun s' => V psi0 s' z) s :=
   mult_of_basis psi0 baseA unitHat (basis_of_translate (by decide +kernel)) z s
 /-- `V₂(A⋆z) = Â₂·V₂(z)`, `Â₂ = unitHat`. -/
 theorem mult_A2 (z : BaseGroup → ZMod 2) (s : ZMod 2 × ZMod 2) :
-    V psi2 s (conv baseA z) = rmul unitHat (fun s' => V psi2 s' z) s :=
+    V psi2 s (baseA ⋆ z) = rmul unitHat (fun s' => V psi2 s' z) s :=
   mult_of_basis psi2 baseA unitHat (basis_of_translate (by decide +kernel)) z s
 /-- `V₀(B⋆z) = B̂₀·V₀(z)`, `B̂₀ = unitHat`. -/
 theorem mult_B0 (z : BaseGroup → ZMod 2) (s : ZMod 2 × ZMod 2) :
-    V psi0 s (conv baseB z) = rmul unitHat (fun s' => V psi0 s' z) s :=
+    V psi0 s (baseB ⋆ z) = rmul unitHat (fun s' => V psi0 s' z) s :=
   mult_of_basis psi0 baseB unitHat (basis_of_translate (by decide +kernel)) z s
 /-- `V₁(B⋆z) = B̂₁·V₁(z)`, `B̂₁ = unitHat`. -/
 theorem mult_B1 (z : BaseGroup → ZMod 2) (s : ZMod 2 × ZMod 2) :
-    V psi1 s (conv baseB z) = rmul unitHat (fun s' => V psi1 s' z) s :=
+    V psi1 s (baseB ⋆ z) = rmul unitHat (fun s' => V psi1 s' z) s :=
   mult_of_basis psi1 baseB unitHat (basis_of_translate (by decide +kernel)) z s
 
 /-! ### Ring facts for the Fourier profile of `B·w` (kernel `decide` over the
@@ -551,9 +551,9 @@ theorem oneBlock_core (b : BaseGroup → ZMod 2)
 
 /-- **The sharp one-block lemma (L4c)**: `w ∈ Ann(A) ∖ ker ∂₂` (`A·w = 0`, `B·w ≠ 0`)
 forces `|B·w| ≥ 16`. -/
-theorem oneBlock_ge16 (w : BaseGroup → ZMod 2) (hA : conv baseA w = 0)
-    (hB : conv baseB w ≠ 0) : 16 ≤ bwt (conv baseB w) := by
-  apply oneBlock_core (conv baseB w)
+theorem oneBlock_ge16 (w : BaseGroup → ZMod 2) (hA : baseA ⋆ w = 0)
+    (hB : baseB ⋆ w ≠ 0) : 16 ≤ bwt (baseB ⋆ w) := by
+  apply oneBlock_core (baseB ⋆ w)
   · intro s
     have hkey : rmul unitHat (fun s' => V psi0 s' w) = (fun _ => 0) := by
       funext s'; rw [← mult_A0 w s', hA]; exact V_zero psi0 s'
@@ -573,7 +573,7 @@ theorem oneBlock_ge16 (w : BaseGroup → ZMod 2) (hA : conv baseA w = 0)
     · right; intro s; rw [mult_B3 w s]; exact h s
   · have hkey1 : rmul Ahat1 (fun s' => V psi1 s' w) = (fun _ => 0) := by
       funext s'; rw [← mult_A1 w s', hA]; exact V_zero psi1 s'
-    have hb1 : (fun s => V psi1 s (conv baseB w)) = rmul unitHat (fun s' => V psi1 s' w) := by
+    have hb1 : (fun s => V psi1 s (baseB ⋆ w)) = rmul unitHat (fun s' => V psi1 s' w) := by
       funext s; exact mult_B1 w s
     rw [hb1]; exact Ahat1_unitHat_ann _ hkey1
   · exact hB
@@ -585,8 +585,8 @@ of `∂₂f` equals a hexagon/D-pair A-block, the residual `w = f − witness �
 has `|B·w| < 16`, so (L4c) `B·w = 0` and `∂₂f = ∂₂(witness)`. -/
 
 /-- L4c contrapositive: `w ∈ Ann(A)` with `|B·w| < 16` forces `B·w = 0`. -/
-theorem oneBlock_contra (w : BaseGroup → ZMod 2) (hA : conv baseA w = 0)
-    (hlt : bwt (conv baseB w) < 16) : conv baseB w = 0 := by
+theorem oneBlock_contra (w : BaseGroup → ZMod 2) (hA : baseA ⋆ w = 0)
+    (hlt : bwt (baseB ⋆ w) < 16) : baseB ⋆ w = 0 := by
   by_contra hne
   exact absurd (oneBlock_ge16 w hA hne) (Nat.not_le.mpr hlt)
 
@@ -603,13 +603,13 @@ theorem bwt_add_le (a b : BaseGroup → ZMod 2) : bwt (a + b) ≤ bwt a + bwt b 
   exact le_trans (Finset.card_le_card hsub) (Finset.card_union_le _ _)
 
 /-- A single hexagon A-block has weight exactly 3. -/
-theorem bwt_baseA_single : ∀ g : BaseGroup, bwt (conv baseA (Pi.single g 1)) = 3 := by
+theorem bwt_baseA_single : ∀ g : BaseGroup, bwt (baseA ⋆ Pi.single g 1) = 3 := by
   have key : ∀ g : BaseGroup, bwt (fun h => baseA (h - g)) = 3 := by decide +kernel
   intro g
   rw [conv_single_right]
   exact key g
 /-- A single hexagon B-block has weight exactly 3. -/
-theorem bwt_baseB_single : ∀ g : BaseGroup, bwt (conv baseB (Pi.single g 1)) = 3 := by
+theorem bwt_baseB_single : ∀ g : BaseGroup, bwt (baseB ⋆ Pi.single g 1) = 3 := by
   have key : ∀ g : BaseGroup, bwt (fun h => baseB (h - g)) = 3 := by decide +kernel
   intro g
   rw [conv_single_right]
@@ -617,13 +617,13 @@ theorem bwt_baseB_single : ∀ g : BaseGroup, bwt (conv baseB (Pi.single g 1)) =
 
 /-- `∂₂` block values (definitional). -/
 theorem bb2_zero (z : BaseGroup → ZMod 2) (h : BaseGroup) :
-    bbBoundary2Fn baseA baseB z (h, 0) = conv baseA z h := rfl
+    bbBoundary2Fn baseA baseB z (h, 0) = (baseA ⋆ z) h := rfl
 theorem bb2_one (z : BaseGroup → ZMod 2) (h : BaseGroup) :
-    bbBoundary2Fn baseA baseB z (h, 1) = conv baseB z h := rfl
+    bbBoundary2Fn baseA baseB z (h, 1) = (baseB ⋆ z) h := rfl
 
 /-- The B-block weight is at most the full boundary weight (`h ↦ (h,1)` injection). -/
 theorem bwt_baseB_le_boundary (f : BaseGroup → ZMod 2) :
-    bwt (conv baseB f) ≤ (Finset.univ.filter (fun j : BaseGroup × Fin 2 =>
+    bwt (baseB ⋆ f) ≤ (Finset.univ.filter (fun j : BaseGroup × Fin 2 =>
       bbBoundary2Fn baseA baseB f j ≠ 0)).card := by
   unfold bwt
   apply Finset.card_le_card_of_injOn (fun h => (h, (1 : Fin 2)))
@@ -636,33 +636,33 @@ theorem bwt_baseB_le_boundary (f : BaseGroup → ZMod 2) :
 /-- **Endgame transfer (hexagon)**: if the A-block of `∂₂f` is `A·δ_g` and `|∂₂f| ≤ 10`,
 then `∂₂f = ∂₂δ_g`. -/
 theorem transfer_hexagon (f : BaseGroup → ZMod 2) (g : BaseGroup)
-    (hA : conv baseA f = conv baseA (Pi.single g 1))
+    (hA : baseA ⋆ f = baseA ⋆ Pi.single g 1)
     (hwt : (Finset.univ.filter (fun j : BaseGroup × Fin 2 =>
       bbBoundary2Fn baseA baseB f j ≠ 0)).card ≤ 10) :
     bbBoundary2Fn baseA baseB f = bbBoundary2Fn baseA baseB (Pi.single g 1) := by
   set δ : BaseGroup → ZMod 2 := Pi.single g 1 with hδ
   have hself : ∀ x : ZMod 2, x + x = 0 := by decide
-  have hAw : conv baseA (f + δ) = 0 := by
+  have hAw : baseA ⋆ (f + δ) = 0 := by
     rw [conv_add_right, hA]; funext h; rw [Pi.add_apply]; exact hself _
-  have hbound : bwt (conv baseB (f + δ)) < 16 := by
+  have hbound : bwt (baseB ⋆ (f + δ)) < 16 := by
     rw [conv_add_right]
-    calc bwt (conv baseB f + conv baseB δ)
-          ≤ bwt (conv baseB f) + bwt (conv baseB δ) := bwt_add_le _ _
+    calc bwt (baseB ⋆ f + baseB ⋆ δ)
+          ≤ bwt (baseB ⋆ f) + bwt (baseB ⋆ δ) := bwt_add_le _ _
       _ ≤ 10 + 3 := by
           gcongr
           · exact le_trans (bwt_baseB_le_boundary f) hwt
           · rw [hδ, bwt_baseB_single g]
       _ < 16 := by norm_num
-  have hBw : conv baseB (f + δ) = 0 := oneBlock_contra _ hAw hbound
-  have hBeq : conv baseB f = conv baseB δ := by
+  have hBw : baseB ⋆ (f + δ) = 0 := oneBlock_contra _ hAw hbound
+  have hBeq : baseB ⋆ f = baseB ⋆ δ := by
     funext h
-    have hpt : conv baseB f h + conv baseB δ h = 0 := by
+    have hpt : (baseB ⋆ f) h + (baseB ⋆ δ) h = 0 := by
       have := congrFun hBw h; rwa [conv_add_right, Pi.add_apply] at this
     have key : ∀ x y : ZMod 2, x + y = 0 → x = y := by decide
     exact key _ _ hpt
   funext ⟨h, j⟩
-  show (if j = 0 then conv baseA f h else conv baseB f h)
-      = (if j = 0 then conv baseA δ h else conv baseB δ h)
+  show (if j = 0 then (baseA ⋆ f) h else (baseB ⋆ f) h)
+      = (if j = 0 then (baseA ⋆ δ) h else (baseB ⋆ δ) h)
   by_cases hj : j = 0
   · rw [if_pos hj, if_pos hj]; exact congrFun hA h
   · rw [if_neg hj, if_neg hj]; exact congrFun hBeq h
@@ -670,7 +670,7 @@ theorem transfer_hexagon (f : BaseGroup → ZMod 2) (g : BaseGroup)
 /-- Block-weight decomposition (≤): the two blocks' weights sum to at most `|∂₂f|`
 (disjoint `h↦(h,0)` / `h↦(h,1)` injections into the boundary support). -/
 theorem bwt_blocks_le_boundary (f : BaseGroup → ZMod 2) :
-    bwt (conv baseA f) + bwt (conv baseB f) ≤
+    bwt (baseA ⋆ f) + bwt (baseB ⋆ f) ≤
     (Finset.univ.filter (fun j : BaseGroup × Fin 2 => bbBoundary2Fn baseA baseB f j ≠ 0)).card := by
   unfold bwt
   have injA : Function.Injective (fun h : BaseGroup => (h, (0 : Fin 2))) :=
@@ -698,7 +698,7 @@ theorem bwt_blocks_le_boundary (f : BaseGroup → ZMod 2) :
 `g + (0,1)` for the two directions `(3,4)`, `(3,5)`, whose second hexagon covers
 `g + (3,0)` — carries value 1 (kernel `decide`, 12 × 36 single-cell checks). -/
 theorem bwt_baseA_dpair_ge1 : ∀ g : BaseGroup, ∀ d ∈ pairDirections,
-    1 ≤ bwt (conv baseA (Pi.single g 1 + Pi.single (g + d) 1)) := by
+    1 ≤ bwt (baseA ⋆ (Pi.single g 1 + Pi.single (g + d) 1)) := by
   have key : ∀ d ∈ pairDirections, ∀ g : BaseGroup,
       ((fun h => baseA (h - g)) + fun h => baseA (h - (g + d)))
         (g + (if d = (3, 4) ∨ d = (3, 5) then (0, 1) else (3, 0))) = 1 := by
@@ -710,11 +710,11 @@ theorem bwt_baseA_dpair_ge1 : ∀ g : BaseGroup, ∀ d ∈ pairDirections,
     ⟨_, Finset.mem_filter.mpr ⟨Finset.mem_univ _, key d hd g⟩⟩
 /-- D-pair B-block has weight ≤ 6 (subadditivity + two weight-3 hexagons). -/
 theorem bwt_baseB_dpair_le6 : ∀ g : BaseGroup, ∀ d ∈ pairDirections,
-    bwt (conv baseB (Pi.single g 1 + Pi.single (g + d) 1)) ≤ 6 := by
+    bwt (baseB ⋆ (Pi.single g 1 + Pi.single (g + d) 1)) ≤ 6 := by
   intro g d _
   rw [conv_add_right]
-  calc bwt (conv baseB (Pi.single g 1) + conv baseB (Pi.single (g + d) 1))
-      ≤ bwt (conv baseB (Pi.single g 1)) + bwt (conv baseB (Pi.single (g + d) 1)) :=
+  calc bwt (baseB ⋆ Pi.single g 1 + baseB ⋆ Pi.single (g + d) 1)
+      ≤ bwt (baseB ⋆ Pi.single g 1) + bwt (baseB ⋆ Pi.single (g + d) 1) :=
         bwt_add_le _ _
     _ = 3 + 3 := by rw [bwt_baseB_single g, bwt_baseB_single (g + d)]
     _ ≤ 6 := by norm_num
@@ -724,36 +724,36 @@ theorem bwt_baseB_dpair_le6 : ∀ g : BaseGroup, ∀ d ∈ pairDirections,
 `10+6` bound only gives `≤16`; the block decomposition tightens `|B·f| ≤ 10−w_A ≤ 9`
 (`w_A = bwt(A·witness) ≥ 1`), so `|B·w| ≤ 15 < 16`. -/
 theorem transfer_dpair (f : BaseGroup → ZMod 2) (g d : BaseGroup) (hd : d ∈ pairDirections)
-    (hA : conv baseA f = conv baseA (Pi.single g 1 + Pi.single (g + d) 1))
+    (hA : baseA ⋆ f = baseA ⋆ (Pi.single g 1 + Pi.single (g + d) 1))
     (hwt : (Finset.univ.filter (fun j : BaseGroup × Fin 2 =>
       bbBoundary2Fn baseA baseB f j ≠ 0)).card ≤ 10) :
     bbBoundary2Fn baseA baseB f
       = bbBoundary2Fn baseA baseB (Pi.single g 1 + Pi.single (g + d) 1) := by
   set wit : BaseGroup → ZMod 2 := Pi.single g 1 + Pi.single (g + d) 1 with hwit
   have hself : ∀ x : ZMod 2, x + x = 0 := by decide
-  have hAw : conv baseA (f + wit) = 0 := by
+  have hAw : baseA ⋆ (f + wit) = 0 := by
     rw [conv_add_right, hA]; funext h; rw [Pi.add_apply]; exact hself _
-  have hbound : bwt (conv baseB (f + wit)) < 16 := by
+  have hbound : bwt (baseB ⋆ (f + wit)) < 16 := by
     rw [conv_add_right]
-    have hBf : bwt (conv baseB f) ≤ 9 := by
+    have hBf : bwt (baseB ⋆ f) ≤ 9 := by
       have hdec := bwt_blocks_le_boundary f
-      have hA1 : 1 ≤ bwt (conv baseA f) := by rw [hA]; exact bwt_baseA_dpair_ge1 g d hd
+      have hA1 : 1 ≤ bwt (baseA ⋆ f) := by rw [hA]; exact bwt_baseA_dpair_ge1 g d hd
       omega
-    have hBwit : bwt (conv baseB wit) ≤ 6 := bwt_baseB_dpair_le6 g d hd
-    calc bwt (conv baseB f + conv baseB wit)
-          ≤ bwt (conv baseB f) + bwt (conv baseB wit) := bwt_add_le _ _
+    have hBwit : bwt (baseB ⋆ wit) ≤ 6 := bwt_baseB_dpair_le6 g d hd
+    calc bwt (baseB ⋆ f + baseB ⋆ wit)
+          ≤ bwt (baseB ⋆ f) + bwt (baseB ⋆ wit) := bwt_add_le _ _
       _ ≤ 9 + 6 := add_le_add hBf hBwit
       _ < 16 := by norm_num
-  have hBw : conv baseB (f + wit) = 0 := oneBlock_contra _ hAw hbound
-  have hBeq : conv baseB f = conv baseB wit := by
+  have hBw : baseB ⋆ (f + wit) = 0 := oneBlock_contra _ hAw hbound
+  have hBeq : baseB ⋆ f = baseB ⋆ wit := by
     funext h
-    have hpt : conv baseB f h + conv baseB wit h = 0 := by
+    have hpt : (baseB ⋆ f) h + (baseB ⋆ wit) h = 0 := by
       have := congrFun hBw h; rwa [conv_add_right, Pi.add_apply] at this
     have key : ∀ x y : ZMod 2, x + y = 0 → x = y := by decide
     exact key _ _ hpt
   funext ⟨h, j⟩
-  show (if j = 0 then conv baseA f h else conv baseB f h)
-      = (if j = 0 then conv baseA wit h else conv baseB wit h)
+  show (if j = 0 then (baseA ⋆ f) h else (baseB ⋆ f) h)
+      = (if j = 0 then (baseA ⋆ wit) h else (baseB ⋆ wit) h)
   by_cases hj : j = 0
   · rw [if_pos hj, if_pos hj]; exact congrFun hA h
   · rw [if_neg hj, if_neg hj]; exact congrFun hBeq h

--- a/QEC/Stabilizer/Codes/BivariateBicycle/Gross/LightStabClassify.lean
+++ b/QEC/Stabilizer/Codes/BivariateBicycle/Gross/LightStabClassify.lean
@@ -305,11 +305,11 @@ packed row-syndrome sweep instead of a per-tuple `gateM` evaluation. -/
 /-- Convolving with a point mass on the right translates:
 `P ⋆ δ_c = P (· - c)` (right-handed sibling of `conv_single_left`). -/
 private theorem conv_single_right (P : BaseGroup → ZMod 2) (c : BaseGroup) :
-    conv P (Pi.single c 1) = fun g => P (g - c) := by
+    P ⋆ Pi.single c 1 = fun g => P (g - c) := by
   rw [conv_comm, conv_single_left]
 
 theorem hexA_correct : ∀ g : Fin 36,
-    hexA.getD g.val 0 = bitmaskOf (conv baseA (Pi.single (cellOf g.val) 1)) := by
+    hexA.getD g.val 0 = bitmaskOf (baseA ⋆ Pi.single (cellOf g.val) 1) := by
   have tab : ∀ g : Fin 36,
       hexA.getD g.val 0 = bitmaskOf (fun x => baseA (x - cellOf g.val)) := by decide
   intro g
@@ -319,7 +319,7 @@ theorem hexA_correct : ∀ g : Fin 36,
 theorem gate_hexA : ∀ g : Fin 36, gateM (hexA.getD g.val 0) = true := by decide
 
 theorem hexB_correct : ∀ g : Fin 36,
-    hexB.getD g.val 0 = bitmaskOf (conv baseB (Pi.single (cellOf g.val) 1)) := by
+    hexB.getD g.val 0 = bitmaskOf (baseB ⋆ Pi.single (cellOf g.val) 1) := by
   have tab : ∀ g : Fin 36,
       hexB.getD g.val 0 = bitmaskOf (fun x => baseB (x - cellOf g.val)) := by decide
   intro g
@@ -343,17 +343,17 @@ theorem xorLift (M : (BaseGroup → ZMod 2) → Nat) (P : Nat → Prop)
   rw [self_eq_ind_filter b]; exact key _
 
 theorem gateM_conv_baseA (z : BaseGroup → ZMod 2) :
-    gateM (bitmaskOf (conv baseA z)) = true := by
-  apply xorLift (fun w => bitmaskOf (conv baseA w)) (fun m => gateM m = true)
-  · show bitmaskOf (conv baseA 0) = 0
-    rw [show conv baseA (0 : BaseGroup → ZMod 2) = 0 from by funext g; simp [conv_apply],
+    gateM (bitmaskOf (baseA ⋆ z)) = true := by
+  apply xorLift (fun w => bitmaskOf (baseA ⋆ w)) (fun m => gateM m = true)
+  · show bitmaskOf (baseA ⋆ 0) = 0
+    rw [show (baseA ⋆ (0 : BaseGroup → ZMod 2)) = 0 from by funext g; simp [conv_apply],
       bitmaskOf_zero]
-  · intro a b; show bitmaskOf (conv baseA (a + b)) = _
+  · intro a b; show bitmaskOf (baseA ⋆ (a + b)) = _
     rw [conv_add_right, bitmaskOf_add]
   · exact gateM_zero
   · intro m n hm hn; exact gateM_xor hm hn
   · intro g
-    show gateM (bitmaskOf (conv baseA (Pi.single g 1))) = true
+    show gateM (bitmaskOf (baseA ⋆ Pi.single g 1)) = true
     have hk : cellOf (idxOf g) = g := cellOf_idxOf g
     have hc := hexA_correct ⟨idxOf g, idxOf_lt g⟩
     rw [hk] at hc
@@ -435,12 +435,12 @@ theorem inBspan_xor {x y : Nat} (hx : inBspan x) (hy : inBspan y) : inBspan (x ^
 
 /-- The coset-defect map: `Φ f = MBA·(Â-block) ⊕ (B̂-block)`, lands in `Bspan`. -/
 def Phi (f : BaseGroup → ZMod 2) : Nat :=
-  applyCols MBAcols (bitmaskOf (conv baseA f)) ^^^ bitmaskOf (conv baseB f)
+  applyCols MBAcols (bitmaskOf (baseA ⋆ f)) ^^^ bitmaskOf (baseB ⋆ f)
 
 theorem Phi_zero : Phi 0 = 0 := by
   unfold Phi
-  rw [show conv baseA (0 : BaseGroup → ZMod 2) = 0 from by funext g; simp [conv_apply],
-      show conv baseB (0 : BaseGroup → ZMod 2) = 0 from by funext g; simp [conv_apply],
+  rw [show (baseA ⋆ (0 : BaseGroup → ZMod 2)) = 0 from by funext g; simp [conv_apply],
+      show (baseB ⋆ (0 : BaseGroup → ZMod 2)) = 0 from by funext g; simp [conv_apply],
       bitmaskOf_zero, applyCols_zero, Nat.xor_zero]
 
 theorem Phi_add (a b : BaseGroup → ZMod 2) : Phi (a + b) = Phi a ^^^ Phi b := by
@@ -487,18 +487,18 @@ theorem foldl_min_le (f : Nat → Nat) :
     · exact ih _ c hct
 
 theorem minBcoset_le_bwt (f : BaseGroup → ZMod 2) :
-    minBcoset (bitmaskOf (conv baseA f)) ≤ bwt (conv baseB f) := by
+    minBcoset (bitmaskOf (baseA ⋆ f)) ≤ bwt (baseB ⋆ f) := by
   obtain ⟨c, hc⟩ := coset_mem f
   simp only [Phi] at hc
-  have hrw : bitmaskOf (conv baseB f)
-      = applyCols MBAcols (bitmaskOf (conv baseA f)) ^^^ bOffset c.val := by
+  have hrw : bitmaskOf (baseB ⋆ f)
+      = applyCols MBAcols (bitmaskOf (baseA ⋆ f)) ^^^ bOffset c.val := by
     rw [hc, ← Nat.xor_assoc, Nat.xor_self, Nat.zero_xor]
-  calc minBcoset (bitmaskOf (conv baseA f))
-      ≤ wtM (applyCols MBAcols (bitmaskOf (conv baseA f)) ^^^ bOffset c.val) := by
+  calc minBcoset (bitmaskOf (baseA ⋆ f))
+      ≤ wtM (applyCols MBAcols (bitmaskOf (baseA ⋆ f)) ^^^ bOffset c.val) := by
         unfold minBcoset
         exact foldl_min_le _ (List.range 64) 99 c.val (List.mem_range.mpr c.isLt)
-    _ = wtM (bitmaskOf (conv baseB f)) := by rw [← hrw]
-    _ = bwt (conv baseB f) := wtM_eq_bwt _
+    _ = wtM (bitmaskOf (baseB ⋆ f)) := by rw [← hrw]
+    _ = bwt (baseB ⋆ f) := wtM_eq_bwt _
 
 
 
@@ -522,10 +522,10 @@ theorem dpairDirList_mem : ∀ k : Fin 12, dpairDirList.getD k.val 0 ∈ pairDir
 /-- A gated A-block recognised as hexagon/D-pair lifts to a function-level witness:
 its `conv baseA` equals that of a single hexagon, or of a D-pair `δ_g + δ_{g+d}`. -/
 theorem isHexDpairA_witness (f : BaseGroup → ZMod 2)
-    (h : isHexDpairA (bitmaskOf (conv baseA f)) = true) :
-    (∃ g : BaseGroup, conv baseA f = conv baseA (Pi.single g 1)) ∨
+    (h : isHexDpairA (bitmaskOf (baseA ⋆ f)) = true) :
+    (∃ g : BaseGroup, baseA ⋆ f = baseA ⋆ Pi.single g 1) ∨
     (∃ g : BaseGroup, ∃ d ∈ pairDirections,
-        conv baseA f = conv baseA (Pi.single g 1 + Pi.single (g + d) 1)) := by
+        baseA ⋆ f = baseA ⋆ (Pi.single g 1 + Pi.single (g + d) 1)) := by
   unfold isHexDpairA at h
   rw [Bool.or_eq_true] at h
   rcases h with hHex | hDp
@@ -1032,27 +1032,27 @@ theorem classifyCoreEven : ∀ q₁ q₂ q₃ : Fin 36,
 weight ≤ 5 whose boundary is light (`bwt A + bwt B ≤ 10`) is a hexagon or D-pair
 A-block. -/
 theorem classify_master (f : BaseGroup → ZMod 2)
-    (horig : conv baseA f (0, 0) = 1)
-    (hwt5 : bwt (conv baseA f) ≤ 5)
-    (hbnd : bwt (conv baseA f) + bwt (conv baseB f) ≤ 10) :
-    (∃ g : BaseGroup, conv baseA f = conv baseA (Pi.single g 1)) ∨
+    (horig : (baseA ⋆ f) (0, 0) = 1)
+    (hwt5 : bwt (baseA ⋆ f) ≤ 5)
+    (hbnd : bwt (baseA ⋆ f) + bwt (baseB ⋆ f) ≤ 10) :
+    (∃ g : BaseGroup, baseA ⋆ f = baseA ⋆ Pi.single g 1) ∨
     (∃ g : BaseGroup, ∃ d ∈ pairDirections,
-        conv baseA f = conv baseA (Pi.single g 1 + Pi.single (g + d) 1)) := by
-  have hgate : gateM (bitmaskOf (conv baseA f)) = true := gateM_conv_baseA f
-  have hge1 : 1 ≤ bwt (conv baseA f) := by
+        baseA ⋆ f = baseA ⋆ (Pi.single g 1 + Pi.single (g + d) 1)) := by
+  have hgate : gateM (bitmaskOf (baseA ⋆ f)) = true := gateM_conv_baseA f
+  have hge1 : 1 ≤ bwt (baseA ⋆ f) := by
     unfold bwt
     exact Finset.card_pos.mpr ⟨(0, 0), Finset.mem_filter.mpr ⟨Finset.mem_univ _, horig⟩⟩
-  have hge3 : 3 ≤ bwt (conv baseA f) := gated_bwt_ge3 (conv baseA f) hgate hge1
-  have hmb : minBcoset (bitmaskOf (conv baseA f)) ≤ bwt (conv baseB f) := minBcoset_le_bwt f
-  have hclass : isHexDpairA (bitmaskOf (conv baseA f)) = true := by
-    rcases Nat.even_or_odd (bwt (conv baseA f)) with heven | hodd
-    · obtain ⟨q1, q2, q3, hq⟩ := exists_supMask4 (conv baseA f) horig hwt5 (by omega) heven
+  have hge3 : 3 ≤ bwt (baseA ⋆ f) := gated_bwt_ge3 (baseA ⋆ f) hgate hge1
+  have hmb : minBcoset (bitmaskOf (baseA ⋆ f)) ≤ bwt (baseB ⋆ f) := minBcoset_le_bwt f
+  have hclass : isHexDpairA (bitmaskOf (baseA ⋆ f)) = true := by
+    rcases Nat.even_or_odd (bwt (baseA ⋆ f)) with heven | hodd
+    · obtain ⟨q1, q2, q3, hq⟩ := exists_supMask4 (baseA ⋆ f) horig hwt5 (by omega) heven
       have hgate' : gateM (supMask [0, q1, q2, q3]) = true := by rw [hq]; exact hgate
       have h3 : 3 ≤ wtM (supMask [0, q1, q2, q3]) := by rw [hq, wtM_eq_bwt]; exact hge3
       rcases classifyCoreEven q1 q2 q3 hgate' h3 with hhd | hbig
       · rw [hq] at hhd; exact hhd
       · exfalso; rw [hq, wtM_eq_bwt] at hbig; omega
-    · obtain ⟨q1, q2, q3, q4, hq⟩ := exists_supMask5 (conv baseA f) horig hwt5 hodd
+    · obtain ⟨q1, q2, q3, q4, hq⟩ := exists_supMask5 (baseA ⋆ f) horig hwt5 hodd
       have hgate' : gateM (supMask [0, q1, q2, q3, q4]) = true := by rw [hq]; exact hgate
       rcases classifyCore q1 q2 q3 q4 hgate' with hhd | hbig
       · rw [hq] at hhd; exact hhd
@@ -1110,48 +1110,48 @@ theorem bwt_translate (c : BaseGroup) (v : BaseGroup → ZMod 2) :
 /-- The A-lighter classification: if the (necessarily nonzero) A-block of a light
 boundary has weight ≤ 5, the boundary is a hexagon or D-pair. -/
 theorem classify_Alighter (f : BaseGroup → ZMod 2)
-    (hAne : conv baseA f ≠ 0)
+    (hAne : baseA ⋆ f ≠ 0)
     (hle10 : (Finset.univ.filter fun j : BaseGroup × Fin 2 =>
       bbBoundary2Fn baseA baseB f j ≠ 0).card ≤ 10)
-    (hAlight : bwt (conv baseA f) ≤ 5) :
+    (hAlight : bwt (baseA ⋆ f) ≤ 5) :
     (∃ g : BaseGroup, bbBoundary2Fn baseA baseB f
         = bbBoundary2Fn baseA baseB (Pi.single g 1)) ∨
     (∃ g : BaseGroup, ∃ d ∈ pairDirections, bbBoundary2Fn baseA baseB f
         = bbBoundary2Fn baseA baseB (Pi.single g 1 + Pi.single (g + d) 1)) := by
-  obtain ⟨c, hc⟩ : ∃ c, conv baseA f c = 1 := by
+  obtain ⟨c, hc⟩ : ∃ c, (baseA ⋆ f) c = 1 := by
     by_contra hcon
     push Not at hcon
     apply hAne
     funext x
     have h := hcon x
-    change conv baseA f x = (0 : ZMod 2)
-    revert h; generalize conv baseA f x = u; revert u; decide
-  have hAf' : conv baseA (translate c f) = translate c (conv baseA f) := conv_translate baseA f c
-  have hBf' : conv baseB (translate c f) = translate c (conv baseB f) := conv_translate baseB f c
-  have horig : conv baseA (translate c f) (0, 0) = 1 := by
+    change (baseA ⋆ f) x = (0 : ZMod 2)
+    revert h; generalize (baseA ⋆ f) x = u; revert u; decide
+  have hAf' : baseA ⋆ translate c f = translate c (baseA ⋆ f) := conv_translate baseA f c
+  have hBf' : baseB ⋆ translate c f = translate c (baseB ⋆ f) := conv_translate baseB f c
+  have horig : (baseA ⋆ translate c f) (0, 0) = 1 := by
     rw [hAf']
-    change conv baseA f ((0 : BaseGroup) + c) = 1
+    change (baseA ⋆ f) ((0 : BaseGroup) + c) = 1
     rw [zero_add]
     exact hc
-  have hAwt' : bwt (conv baseA (translate c f)) ≤ 5 := by rw [hAf', bwt_translate]; exact hAlight
-  have hbnd : bwt (conv baseA (translate c f)) + bwt (conv baseB (translate c f)) ≤ 10 := by
+  have hAwt' : bwt (baseA ⋆ translate c f) ≤ 5 := by rw [hAf', bwt_translate]; exact hAlight
+  have hbnd : bwt (baseA ⋆ translate c f) + bwt (baseB ⋆ translate c f) ≤ 10 := by
     rw [hAf', hBf', bwt_translate, bwt_translate]
     exact le_trans (bwt_blocks_le_boundary f) hle10
   rcases classify_master (translate c f) horig hAwt' hbnd with ⟨g', hg'⟩ | ⟨g', d, hd, hg'⟩
   · left
     refine ⟨g' + c, ?_⟩
     apply transfer_hexagon f (g' + c) ?_ hle10
-    have hh : translate c (conv baseA f) = conv baseA (Pi.single g' 1) := by rw [← hAf']; exact hg'
-    have h2 : conv baseA f = translate (-c) (conv baseA (Pi.single g' 1)) := by
+    have hh : translate c (baseA ⋆ f) = baseA ⋆ Pi.single g' 1 := by rw [← hAf']; exact hg'
+    have h2 : baseA ⋆ f = translate (-c) (baseA ⋆ Pi.single g' 1) := by
       rw [← hh, translate_neg_translate]
     rw [h2, ← conv_translate, translate_single]
   · right
     refine ⟨g' + c, d, hd, ?_⟩
     apply transfer_dpair f (g' + c) d hd ?_ hle10
-    have hh : translate c (conv baseA f)
-        = conv baseA (Pi.single g' 1 + Pi.single (g' + d) 1) := by rw [← hAf']; exact hg'
-    have h2 : conv baseA f
-        = translate (-c) (conv baseA (Pi.single g' 1 + Pi.single (g' + d) 1)) := by
+    have hh : translate c (baseA ⋆ f)
+        = baseA ⋆ (Pi.single g' 1 + Pi.single (g' + d) 1) := by rw [← hAf']; exact hg'
+    have h2 : baseA ⋆ f
+        = translate (-c) (baseA ⋆ (Pi.single g' 1 + Pi.single (g' + d) 1)) := by
       rw [← hh, translate_neg_translate]
     rw [h2, ← conv_translate, translate_add, translate_single, translate_single,
       show (g' + d) + c = (g' + c) + d from by abel]
@@ -1197,45 +1197,45 @@ theorem funLift (M N : (BaseGroup → ZMod 2) → (BaseGroup → ZMod 2))
     | @insert p S hp ih => rw [ind_insert hp, hMadd, hNadd, hbasis p, ih]
   rw [self_eq_ind_filter f]; exact key _
 
-theorem conv_zero_right (P : BaseGroup → ZMod 2) : conv P 0 = 0 := by
+theorem conv_zero_right (P : BaseGroup → ZMod 2) : P ⋆ 0 = 0 := by
   funext g; simp [conv_apply]
 
 theorem swap_basisA : ∀ g x : BaseGroup,
-    conv baseA (swapFn (Pi.single g 1)) x = swapFn (conv baseB (Pi.single g 1)) x := by
+    (baseA ⋆ swapFn (Pi.single g 1)) x = swapFn (baseB ⋆ Pi.single g 1) x := by
   have key : ∀ g x : BaseGroup, baseA (x - swap g) = baseB (swap x - g) := by decide
   intro g x
   rw [swapFn_single, swapFn_apply, conv_single_right, conv_single_right]
   exact key g x
 theorem swap_basisB : ∀ g x : BaseGroup,
-    conv baseB (swapFn (Pi.single g 1)) x = swapFn (conv baseA (Pi.single g 1)) x := by
+    (baseB ⋆ swapFn (Pi.single g 1)) x = swapFn (baseA ⋆ Pi.single g 1) x := by
   have key : ∀ g x : BaseGroup, baseB (x - swap g) = baseA (swap x - g) := by decide
   intro g x
   rw [swapFn_single, swapFn_apply, conv_single_right, conv_single_right]
   exact key g x
 
 theorem swap_convA (f : BaseGroup → ZMod 2) :
-    conv baseA (swapFn f) = swapFn (conv baseB f) := by
-  apply funLift (fun f => conv baseA (swapFn f)) (fun f => swapFn (conv baseB f))
-  · show conv baseA (swapFn 0) = 0
+    baseA ⋆ swapFn f = swapFn (baseB ⋆ f) := by
+  apply funLift (fun f => (baseA ⋆ swapFn f)) (fun f => swapFn (baseB ⋆ f))
+  · show (baseA ⋆ swapFn 0) = 0
     rw [swapFn_zero, conv_zero_right]
-  · show swapFn (conv baseB 0) = 0
+  · show swapFn (baseB ⋆ 0) = 0
     rw [conv_zero_right, swapFn_zero]
-  · intro a b; show conv baseA (swapFn (a + b)) = _
+  · intro a b; show (baseA ⋆ swapFn (a + b)) = _
     rw [swapFn_add, conv_add_right]
-  · intro a b; show swapFn (conv baseB (a + b)) = _
+  · intro a b; show swapFn (baseB ⋆ (a + b)) = _
     rw [conv_add_right, swapFn_add]
   · intro g; funext x; exact swap_basisA g x
 
 theorem swap_convB (f : BaseGroup → ZMod 2) :
-    conv baseB (swapFn f) = swapFn (conv baseA f) := by
-  apply funLift (fun f => conv baseB (swapFn f)) (fun f => swapFn (conv baseA f))
-  · show conv baseB (swapFn 0) = 0
+    baseB ⋆ swapFn f = swapFn (baseA ⋆ f) := by
+  apply funLift (fun f => (baseB ⋆ swapFn f)) (fun f => swapFn (baseA ⋆ f))
+  · show (baseB ⋆ swapFn 0) = 0
     rw [swapFn_zero, conv_zero_right]
-  · show swapFn (conv baseA 0) = 0
+  · show swapFn (baseA ⋆ 0) = 0
     rw [conv_zero_right, swapFn_zero]
-  · intro a b; show conv baseB (swapFn (a + b)) = _
+  · intro a b; show (baseB ⋆ swapFn (a + b)) = _
     rw [swapFn_add, conv_add_right]
-  · intro a b; show swapFn (conv baseA (a + b)) = _
+  · intro a b; show swapFn (baseA ⋆ (a + b)) = _
     rw [conv_add_right, swapFn_add]
   · intro g; funext x; exact swap_basisB g x
 
@@ -1253,10 +1253,10 @@ theorem bwt_swapFn (v : BaseGroup → ZMod 2) : bwt (swapFn v) = bwt v := by
 
 /-- B-side one-block lemma (via the swap): `conv baseB w = 0`, `conv baseA w ≠ 0`
 forces `|conv baseA w| ≥ 16`. -/
-theorem oneBlock_ge16_B (w : BaseGroup → ZMod 2) (hB : conv baseB w = 0)
-    (hA : conv baseA w ≠ 0) : 16 ≤ bwt (conv baseA w) := by
-  have hA' : conv baseA (swapFn w) = 0 := by rw [swap_convA, hB, swapFn_zero]
-  have hB' : conv baseB (swapFn w) ≠ 0 := by
+theorem oneBlock_ge16_B (w : BaseGroup → ZMod 2) (hB : baseB ⋆ w = 0)
+    (hA : baseA ⋆ w ≠ 0) : 16 ≤ bwt (baseA ⋆ w) := by
+  have hA' : baseA ⋆ swapFn w = 0 := by rw [swap_convA, hB, swapFn_zero]
+  have hB' : baseB ⋆ swapFn w ≠ 0 := by
     rw [swap_convB]; intro h; exact hA (swapFn_injective (h.trans swapFn_zero.symm))
   have h16 := oneBlock_ge16 (swapFn w) hA' hB'
   rwa [swap_convB, bwt_swapFn] at h16
@@ -1270,16 +1270,16 @@ theorem boundary_swapFn (f : BaseGroup → ZMod 2) :
     bbBoundary2Fn baseA baseB (swapFn f) = bnSwap (bbBoundary2Fn baseA baseB f) := by
   funext p
   obtain ⟨h, j⟩ := p
-  change (if j = 0 then conv baseA (swapFn f) h else conv baseB (swapFn f) h)
+  change (if j = 0 then (baseA ⋆ swapFn f) h else (baseB ⋆ swapFn f) h)
     = bbBoundary2Fn baseA baseB f (swap h, swapF2 j)
-  have hA : conv baseA (swapFn f) h = conv baseB f (swap h) := by rw [swap_convA, swapFn_apply]
-  have hB : conv baseB (swapFn f) h = conv baseA f (swap h) := by rw [swap_convB, swapFn_apply]
+  have hA : (baseA ⋆ swapFn f) h = (baseB ⋆ f) (swap h) := by rw [swap_convA, swapFn_apply]
+  have hB : (baseB ⋆ swapFn f) h = (baseA ⋆ f) (swap h) := by rw [swap_convB, swapFn_apply]
   rw [hA, hB]
   fin_cases j
-  · change (if (0 : Fin 2) = 0 then conv baseB f (swap h) else conv baseA f (swap h))
+  · change (if (0 : Fin 2) = 0 then (baseB ⋆ f) (swap h) else (baseA ⋆ f) (swap h))
       = bbBoundary2Fn baseA baseB f (swap h, swapF2 0)
     rw [if_pos rfl]; rfl
-  · change (if (1 : Fin 2) = 0 then conv baseB f (swap h) else conv baseA f (swap h))
+  · change (if (1 : Fin 2) = 0 then (baseB ⋆ f) (swap h) else (baseA ⋆ f) (swap h))
       = bbBoundary2Fn baseA baseB f (swap h, swapF2 1)
     rw [if_neg (by decide)]; rfl
 
@@ -1306,17 +1306,17 @@ theorem pairDirections_swap : ∀ d ∈ pairDirections, swap d ∈ pairDirection
 
 /-- The B-lighter classification (transported from the A-side via the swap). -/
 theorem classify_Blighter (f : BaseGroup → ZMod 2)
-    (hBne : conv baseB f ≠ 0)
+    (hBne : baseB ⋆ f ≠ 0)
     (hle10 : (Finset.univ.filter fun j : BaseGroup × Fin 2 =>
       bbBoundary2Fn baseA baseB f j ≠ 0).card ≤ 10)
-    (hBlight : bwt (conv baseB f) ≤ 5) :
+    (hBlight : bwt (baseB ⋆ f) ≤ 5) :
     (∃ g : BaseGroup, bbBoundary2Fn baseA baseB f
         = bbBoundary2Fn baseA baseB (Pi.single g 1)) ∨
     (∃ g : BaseGroup, ∃ d ∈ pairDirections, bbBoundary2Fn baseA baseB f
         = bbBoundary2Fn baseA baseB (Pi.single g 1 + Pi.single (g + d) 1)) := by
-  have hAne' : conv baseA (swapFn f) ≠ 0 := by
+  have hAne' : baseA ⋆ swapFn f ≠ 0 := by
     rw [swap_convA]; intro h; exact hBne (swapFn_injective (h.trans swapFn_zero.symm))
-  have hAlight' : bwt (conv baseA (swapFn f)) ≤ 5 := by rw [swap_convA, bwt_swapFn]; exact hBlight
+  have hAlight' : bwt (baseA ⋆ swapFn f) ≤ 5 := by rw [swap_convA, bwt_swapFn]; exact hBlight
   have hle10' : (Finset.univ.filter fun j : BaseGroup × Fin 2 =>
       bbBoundary2Fn baseA baseB (swapFn f) j ≠ 0).card ≤ 10 := by
     rw [boundary_swapFn, bnSwap_card]; exact hle10
@@ -1348,28 +1348,28 @@ every nonzero base boundary of weight ≤ 11 is a hexagon or a D-pair. -/
 theorem lightStabilizerClassification_holds : LightStabilizerClassification := by
   intro f hne hle11
   have hle10 := boundary_weight_le_ten f hle11
-  have hsum : bwt (conv baseA f) + bwt (conv baseB f) ≤ 10 :=
+  have hsum : bwt (baseA ⋆ f) + bwt (baseB ⋆ f) ≤ 10 :=
     le_trans (bwt_blocks_le_boundary f) hle10
-  have hAne : conv baseA f ≠ 0 := by
+  have hAne : baseA ⋆ f ≠ 0 := by
     intro hA0
-    have hBne0 : conv baseB f ≠ 0 := by
+    have hBne0 : baseB ⋆ f ≠ 0 := by
       intro hB0; apply hne; funext p; obtain ⟨h, j⟩ := p
-      change (if j = 0 then conv baseA f h else conv baseB f h)
+      change (if j = 0 then (baseA ⋆ f) h else (baseB ⋆ f) h)
         = (0 : BaseGroup × Fin 2 → ZMod 2) (h, j)
       by_cases hj : j = 0
       · rw [if_pos hj, hA0]; rfl
       · rw [if_neg hj, hB0]; rfl
     have h16 := oneBlock_ge16 f hA0 hBne0
-    have hble : bwt (conv baseB f) ≤ 10 := le_trans (bwt_baseB_le_boundary f) hle10
+    have hble : bwt (baseB ⋆ f) ≤ 10 := le_trans (bwt_baseB_le_boundary f) hle10
     omega
-  have hBne : conv baseB f ≠ 0 := by
+  have hBne : baseB ⋆ f ≠ 0 := by
     intro hB0
-    have hAne0 : conv baseA f ≠ 0 := hAne
+    have hAne0 : baseA ⋆ f ≠ 0 := hAne
     have h16 := oneBlock_ge16_B f hB0 hAne0
-    have hale : bwt (conv baseA f) ≤ 10 := by
+    have hale : bwt (baseA ⋆ f) ≤ 10 := by
       have := bwt_blocks_le_boundary f; omega
     omega
-  rcases le_total (bwt (conv baseA f)) (bwt (conv baseB f)) with hAB | hBA
+  rcases le_total (bwt (baseA ⋆ f)) (bwt (baseB ⋆ f)) with hAB | hBA
   · exact classify_Alighter f hAne hle10 (by omega)
   · exact classify_Blighter f hBne hle10 (by omega)
 

--- a/QEC/Stabilizer/Codes/BivariateBicycle/Gross/SafeFloor/MImClassify.lean
+++ b/QEC/Stabilizer/Codes/BivariateBicycle/Gross/SafeFloor/MImClassify.lean
@@ -206,12 +206,12 @@ theorem bb2_sparse (f : BaseGroup → ZMod 2) (p : BaseGroup) (j : Fin 2) :
     bbBoundary2Fn baseA baseB f (p, j)
       = if j = 0 then f (p - (3, 0)) + f (p - (0, 1)) + f (p - (0, 2))
         else f (p - (0, 3)) + f (p - (1, 0)) + f (p - (2, 0)) := by
-  change (if j = 0 then conv baseA f p else conv baseB f p) = _
-  have hA : conv baseA f p
+  change (if j = 0 then (baseA ⋆ f) p else (baseB ⋆ f) p) = _
+  have hA : (baseA ⋆ f) p
       = f (p - (3, 0)) + f (p - (0, 1)) + f (p - (0, 2)) :=
     conv_indicator3 ((3, 0) : BaseGroup) (0, 1) (0, 2)
       (by decide) (by decide) (by decide) f p
-  have hB : conv baseB f p
+  have hB : (baseB ⋆ f) p
       = f (p - (0, 3)) + f (p - (1, 0)) + f (p - (2, 0)) :=
     conv_indicator3 ((0, 3) : BaseGroup) (1, 0) (2, 0)
       (by decide) (by decide) (by decide) f p
@@ -676,12 +676,12 @@ coset's per-component data `off_j(ζ) ⊕ P̂_j · V_j f` that the §10 slot fra
 /-- A-block of a coset element: `leftHalf (seamC ζ + ∂₂ f) = leftHalf (seamC ζ) + A⋆f`. -/
 theorem leftHalf_coset (ζ f : BaseGroup → ZMod 2) :
     leftHalf (seamC ζ + bbBoundary2Fn baseA baseB f)
-      = leftHalf (seamC ζ) + conv baseA f := rfl
+      = leftHalf (seamC ζ) + baseA ⋆ f := rfl
 
 /-- B-block of a coset element: `rightHalf (seamC ζ + ∂₂ f) = rightHalf (seamC ζ) + B⋆f`. -/
 theorem rightHalf_coset (ζ f : BaseGroup → ZMod 2) :
     rightHalf (seamC ζ + bbBoundary2Fn baseA baseB f)
-      = rightHalf (seamC ζ) + conv baseB f := rfl
+      = rightHalf (seamC ζ) + baseB ⋆ f := rfl
 
 /-! ## §3 The coset CRT profile: `V_j(coset) = off_j(ζ) ⊕ P̂_j · V_j f`
 

--- a/QEC/Stabilizer/Codes/BivariateBicycle/Gross/SafeSector.lean
+++ b/QEC/Stabilizer/Codes/BivariateBicycle/Gross/SafeSector.lean
@@ -374,7 +374,7 @@ three-point indicator collapses the `Finset.sum` to three translates. -/
 lemma conv_indicator3 {G : Type} [Fintype G] [AddCommGroup G] [DecidableEq G]
     (m₁ m₂ m₃ : G) (h₁₂ : m₁ ≠ m₂) (h₁₃ : m₁ ≠ m₃) (h₂₃ : m₂ ≠ m₃)
     (f : G → ZMod 2) (g : G) :
-    conv (fun h => if h = m₁ ∨ h = m₂ ∨ h = m₃ then 1 else 0) f g
+    ((fun h => if h = m₁ ∨ h = m₂ ∨ h = m₃ then 1 else 0) ⋆ f) g
       = f (g - m₁) + f (g - m₂) + f (g - m₃) := by
   have key : ∀ h : G,
       (if h = m₁ ∨ h = m₂ ∨ h = m₃ then (1 : ZMod 2) else 0) * f (g - h)
@@ -413,14 +413,14 @@ theorem seamC_eq_sparse (ξ : BaseGroup → ZMod 2) : seamC ξ = seamCSparse ξ 
   change liftStab ξ (deckSigma1 (coverSec1 (p, j))) = _
   rw [deckSigma1_apply]
   change bbBoundary2Fn grossA grossB (liftC2 ξ) ((coverSec1 (p, j)).1 + deckS, j) = _
-  change (if j = 0 then conv grossA (liftC2 ξ) (coverSec p + deckS)
-        else conv grossB (liftC2 ξ) (coverSec p + deckS)) = _
-  have hA : conv grossA (liftC2 ξ) (coverSec p + deckS)
+  change (if j = 0 then (grossA ⋆ liftC2 ξ) (coverSec p + deckS)
+        else (grossB ⋆ liftC2 ξ) (coverSec p + deckS)) = _
+  have hA : (grossA ⋆ liftC2 ξ) (coverSec p + deckS)
       = liftC2 ξ (coverSec p + deckS - (3, 0)) + liftC2 ξ (coverSec p + deckS - (0, 1))
         + liftC2 ξ (coverSec p + deckS - (0, 2)) :=
     conv_indicator3 ((3, 0) : GrossGroup) (0, 1) (0, 2)
       (by decide) (by decide) (by decide) (liftC2 ξ) (coverSec p + deckS)
-  have hB : conv grossB (liftC2 ξ) (coverSec p + deckS)
+  have hB : (grossB ⋆ liftC2 ξ) (coverSec p + deckS)
       = liftC2 ξ (coverSec p + deckS - (0, 3)) + liftC2 ξ (coverSec p + deckS - (1, 0))
         + liftC2 ξ (coverSec p + deckS - (2, 0)) :=
     conv_indicator3 ((0, 3) : GrossGroup) (1, 0) (2, 0)

--- a/QEC/Stabilizer/Codes/BivariateBicycle/Gross/StabilizerCode.lean
+++ b/QEC/Stabilizer/Codes/BivariateBicycle/Gross/StabilizerCode.lean
@@ -388,7 +388,7 @@ lemma boundary2_apply_eq_sum_d2term (f : GrossGroup → ZMod 2) (h : GrossGroup)
   rw [hgr]
   by_cases hj : j = 0
   · subst hj
-    change conv grossA f h = ∑ p : GrossGroup, f p * d2term p h 0
+    change (grossA ⋆ f) h = ∑ p : GrossGroup, f p * d2term p h 0
     rw [conv_apply]
     refine (Equiv.sum_comp (Equiv.subLeft h) (fun x => grossA x * f (h - x))).symm.trans ?_
     refine Finset.sum_congr rfl fun p _ => ?_
@@ -396,7 +396,7 @@ lemma boundary2_apply_eq_sum_d2term (f : GrossGroup → ZMod 2) (h : GrossGroup)
     simp [d2term, Equiv.subLeft_apply, hp, mul_comm]
   · have hj1 : j = 1 := by omega
     subst hj1
-    change conv grossB f h = ∑ p : GrossGroup, f p * d2term p h 1
+    change (grossB ⋆ f) h = ∑ p : GrossGroup, f p * d2term p h 1
     rw [conv_apply]
     refine (Equiv.sum_comp (Equiv.subLeft h) (fun x => grossB x * f (h - x))).symm.trans ?_
     refine Finset.sum_congr rfl fun p _ => ?_
@@ -1296,14 +1296,14 @@ private lemma grossB_eq_singles :
       + Pi.single ((2 : ZMod 12), (0 : ZMod 6)) 1 := by decide
 
 private lemma conv_grossB_apply (w : GrossGroup → ZMod 2) (g : GrossGroup) :
-    conv grossB w g
+    (grossB ⋆ w) g
       = w (g - ((0 : ZMod 12), (3 : ZMod 6))) + w (g - ((1 : ZMod 12), (0 : ZMod 6)))
         + w (g - ((2 : ZMod 12), (0 : ZMod 6))) := by
   rw [grossB_eq_singles, conv_add_left, conv_add_left]
   simp only [Pi.add_apply, conv_single_left_apply]
 
 private lemma conv_grossA_apply (w : GrossGroup → ZMod 2) (g : GrossGroup) :
-    conv grossA w g
+    (grossA ⋆ w) g
       = w (g - ((3 : ZMod 12), (0 : ZMod 6))) + w (g - ((0 : ZMod 12), (1 : ZMod 6)))
         + w (g - ((0 : ZMod 12), (2 : ZMod 6))) := by
   rw [grossA_eq_singles, conv_add_left, conv_add_left]

--- a/QEC/Stabilizer/Codes/BivariateBicycle/Gross/Witness.lean
+++ b/QEC/Stabilizer/Codes/BivariateBicycle/Gross/Witness.lean
@@ -33,9 +33,7 @@ open scoped BigOperators
 /-! ## The base cycle `u*` -/
 
 /-- `z* = 1 + y + y² + y⁵ + x³ + x³y⁴` over the base group `Z₆ × Z₆`. -/
-def zStar : BaseGroup → ZMod 2 := fun g =>
-  if g = (0, 0) ∨ g = (0, 1) ∨ g = (0, 2) ∨ g = (0, 5) ∨
-     g = (3, 0) ∨ g = (3, 4) then 1 else 0
+def zStar : BaseGroup → ZMod 2 := poly[1 + y + y^2 + y^5 + x^3 + x^3*y^4]
 
 theorem conv_baseA_zStar : baseA ⋆ zStar = 0 := by
   decide +kernel

--- a/QEC/Stabilizer/Codes/BivariateBicycle/Gross/Witness.lean
+++ b/QEC/Stabilizer/Codes/BivariateBicycle/Gross/Witness.lean
@@ -37,7 +37,7 @@ def zStar : BaseGroup → ZMod 2 := fun g =>
   if g = (0, 0) ∨ g = (0, 1) ∨ g = (0, 2) ∨ g = (0, 5) ∨
      g = (3, 0) ∨ g = (3, 4) then 1 else 0
 
-theorem conv_baseA_zStar : conv baseA zStar = 0 := by
+theorem conv_baseA_zStar : baseA ⋆ zStar = 0 := by
   decide +kernel
 
 /-- The base 1-chain `u*`: `z*` in the right block, zero in the left. -/
@@ -83,8 +83,8 @@ def fluxWitness : GrossGroup × Fin 2 → ZMod 2 := fun p =>
 /-- Raw (computable) form of `dualBoundary fluxWitness = 0`, via the
 transpose formula `bb_dualBoundary_eq`. -/
 theorem fluxWitness_dual_raw :
-    (fun f => conv (reflect grossA) (leftHalf fluxWitness) f
-      + conv (reflect grossB) (rightHalf fluxWitness) f)
+    (fun f => (reflect grossA ⋆ leftHalf fluxWitness) f
+      + (reflect grossB ⋆ rightHalf fluxWitness) f)
       = (0 : GrossGroup → ZMod 2) := by
   decide +kernel
 

--- a/QEC/Stabilizer/Codes/Iceberg/N.lean
+++ b/QEC/Stabilizer/Codes/Iceberg/N.lean
@@ -97,6 +97,7 @@ generalized for k = 2m − 2 logical qubits.
 -/
 
 open NQubitPauliGroupElement
+open scoped Pauli
 
 /-! ## Local convenience -/
 
@@ -380,16 +381,12 @@ For each `i : Fin (2m − 2)`:
 /-- Logical X for logical qubit `i`: X on qubits `i` and `2m − 1`. -/
 def logicalX (m : ℕ) [Fact (2 ≤ m)] (i : Fin (2 * m - 2)) :
     NQubitPauliGroupElement (2 * m) :=
-  ⟨0,
-    ((NQubitPauliOperator.identity (2 * m)).set (logIdx i) PauliOperator.X).set
-      (xAnchor m) PauliOperator.X⟩
+  σ[2 * m | logIdx i ↦ X, xAnchor m ↦ X]
 
 /-- Logical Z for logical qubit `i`: Z on qubits `i` and `2m − 2`. -/
 def logicalZ (m : ℕ) [Fact (2 ≤ m)] (i : Fin (2 * m - 2)) :
     NQubitPauliGroupElement (2 * m) :=
-  ⟨0,
-    ((NQubitPauliOperator.identity (2 * m)).set (logIdx i) PauliOperator.Z).set
-      (zAnchor m) PauliOperator.Z⟩
+  σ[2 * m | logIdx i ↦ Z, zAnchor m ↦ Z]
 
 /-! ## §11 — Logical (anti)commutation -/
 

--- a/QEC/Stabilizer/Codes/Repetition/N.lean
+++ b/QEC/Stabilizer/Codes/Repetition/N.lean
@@ -36,6 +36,7 @@ We show the generated subgroup is a `StabilizerGroup (n+2)`:
 -/
 
 open NQubitPauliGroupElement
+open scoped Pauli
 
 /-!
 ## Generators
@@ -43,9 +44,7 @@ open NQubitPauliGroupElement
 
 /-- The adjacent Z-check `Z_i Z_{i+1}` on `n+2` qubits, indexed by `i : Fin (n+1)`. -/
 def ZPair (n : ℕ) (i : Fin (n + 1)) : NQubitPauliGroupElement (n + 2) :=
-  ⟨0,
-    ((NQubitPauliOperator.identity (n + 2)).set (Fin.castSucc i) PauliOperator.Z)
-      |>.set (Fin.succ i) PauliOperator.Z⟩
+  σ[n + 2 | Fin.castSucc i ↦ Z, Fin.succ i ↦ Z]
 
 def ZGenerators (n : ℕ) : Set (NQubitPauliGroupElement (n + 2)) :=
   Set.range (ZPair n)

--- a/QEC/Stabilizer/Codes/RotatedSurface/BoundaryMaps.lean
+++ b/QEC/Stabilizer/Codes/RotatedSurface/BoundaryMaps.lean
@@ -137,14 +137,38 @@ def rscBoundary1 (L : ℕ) :
     funext zf
     simp only [RingHom.id_apply, Pi.smul_apply, smul_eq_mul, Finset.mul_sum]
 
+/-!
+## Notation
+
+The scoped `RotatedSurfaceChain` notation renders the rotated-surface boundary
+maps as `∂₂ L c`, `∂₁ L c` (and `δ⁰ L s` for the Z-side cut map, declared next to
+it in `H1Dimension.lean`), mirroring the toric `ToricChain` scope. The lattice size
+stays an explicit argument, exactly as for the underlying constants, so the
+conversion is purely notational: `rscBoundary1` is still the declaration name
+for `simp [rscBoundary1]`, `unfold`, and lemma names. Enable with
+`open scoped RotatedSurfaceChain`.
+-/
+
+/-- `∂₂` is the rotated-surface face-boundary map `rscBoundary2 L`.
+Scoped: `open scoped RotatedSurfaceChain`. -/
+scoped[RotatedSurfaceChain] notation "∂₂" =>
+  Quantum.Stabilizer.Lattice.RotatedSurface.rscBoundary2
+
+/-- `∂₁` is the rotated-surface edge-boundary map `rscBoundary1 L`.
+Scoped: `open scoped RotatedSurfaceChain`. -/
+scoped[RotatedSurfaceChain] notation "∂₁" =>
+  Quantum.Stabilizer.Lattice.RotatedSurface.rscBoundary1
+
+open scoped RotatedSurfaceChain
+
 @[simp] theorem rscBoundary2_apply (L : ℕ) (c : XFaceIdx L → ZMod 2)
     (v : VtxIdx L) :
-    rscBoundary2 L c v =
+    ∂₂ L c v =
       ∑ xf : XFaceIdx L, c xf * (if v ∈ xSupport xf then 1 else 0) := rfl
 
 @[simp] theorem rscBoundary1_apply (L : ℕ) (c : VtxIdx L → ZMod 2)
     (zf : ZFaceIdx L) :
-    rscBoundary1 L c zf = ∑ v ∈ zSupport zf, c v := rfl
+    ∂₁ L c zf = ∑ v ∈ zSupport zf, c v := rfl
 
 /-! ## Intersection-cardinality lemmas -/
 
@@ -551,7 +575,7 @@ private lemma inter_card_even {L : ℕ} [Fact (Odd L)]
 
 /-- Chain-complex law: `∂₁ ∘ ∂₂ = 0`. -/
 theorem rscBoundary_comp_zero (L : ℕ) [Fact (Odd L)] :
-    (rscBoundary1 L).comp (rscBoundary2 L) = 0 := by
+    (∂₁ L).comp (∂₂ L) = 0 := by
   ext c zf
   simp only [LinearMap.comp_apply, rscBoundary1_apply, rscBoundary2_apply,
     LinearMap.zero_apply, Pi.zero_apply]
@@ -563,7 +587,7 @@ theorem rscBoundary_comp_zero (L : ℕ) [Fact (Odd L)] :
 /-- Pointwise corollary of `rscBoundary_comp_zero`. -/
 theorem rscBoundary_comp_zero_apply (L : ℕ) [Fact (Odd L)]
     (c : XFaceIdx L → ZMod 2) :
-    rscBoundary1 L (rscBoundary2 L c) = 0 := by
+    ∂₁ L (∂₂ L c) = 0 := by
   have h := congrArg (fun T => T c) (rscBoundary_comp_zero L)
   simpa using h
 

--- a/QEC/Stabilizer/Codes/RotatedSurface/ChainComplex.lean
+++ b/QEC/Stabilizer/Codes/RotatedSurface/ChainComplex.lean
@@ -40,7 +40,8 @@ def rscBoundaries : Submodule (ZMod 2) (VtxIdx L → ZMod 2) :=
   LinearMap.range (∂₂ L)
 
 /-- `Z₁ L` is the rotated-surface 1-cycle submodule `rscCycles L` (`L` explicit, as for
-`∂₁`). Scoped: `open scoped RotatedSurfaceChain`. -/
+`∂₁`). Scoped: `open scoped RotatedSurfaceChain`. The `ToricChain` scope binds the same
+tokens `Z₁`/`B₁`/`H₁` to the toric submodules, so open one of the two scopes per file. -/
 scoped[RotatedSurfaceChain] notation "Z₁" => Quantum.Stabilizer.Lattice.RotatedSurface.rscCycles
 
 /-- `B₁ L` is the rotated-surface 1-boundary submodule `rscBoundaries L`.
@@ -48,7 +49,6 @@ Scoped: `open scoped RotatedSurfaceChain`. -/
 scoped[RotatedSurfaceChain] notation "B₁" =>
   Quantum.Stabilizer.Lattice.RotatedSurface.rscBoundaries
 
-open scoped RotatedSurfaceChain
 
 /-- Every boundary is a cycle (`∂₁ ∘ ∂₂ = 0`). -/
 theorem rscBoundaries_le_rscCycles [Fact (Odd L)] :
@@ -65,7 +65,6 @@ abbrev rscH1 [Fact (Odd L)] : Type :=
 Scoped: `open scoped RotatedSurfaceChain`. -/
 scoped[RotatedSurfaceChain] notation "H₁" => Quantum.Stabilizer.Lattice.RotatedSurface.rscH1
 
-open scoped RotatedSurfaceChain
 
 /-! ## Row-major qubit indexing -/
 

--- a/QEC/Stabilizer/Codes/RotatedSurface/ChainComplex.lean
+++ b/QEC/Stabilizer/Codes/RotatedSurface/ChainComplex.lean
@@ -21,6 +21,7 @@ namespace Lattice
 namespace RotatedSurface
 
 open scoped BigOperators
+open scoped RotatedSurfaceChain
 
 /-! ## Lattice-specific cycles / boundaries / `H₁`
 
@@ -32,11 +33,11 @@ variable (L : ℕ)
 
 /-- 1-cycles: kernel of `∂₁`. -/
 def rscCycles [Fact (Odd L)] : Submodule (ZMod 2) (VtxIdx L → ZMod 2) :=
-  LinearMap.ker (rscBoundary1 L)
+  LinearMap.ker (∂₁ L)
 
 /-- 1-boundaries: range of `∂₂`. -/
 def rscBoundaries : Submodule (ZMod 2) (VtxIdx L → ZMod 2) :=
-  LinearMap.range (rscBoundary2 L)
+  LinearMap.range (∂₂ L)
 
 /-- Every boundary is a cycle (`∂₁ ∘ ∂₂ = 0`). -/
 theorem rscBoundaries_le_rscCycles [Fact (Odd L)] :
@@ -104,8 +105,8 @@ noncomputable def rotatedSurfaceHomologicalCode [Fact (Odd L)] [Fact (3 ≤ L)] 
   fin0 := inferInstance
   fin1 := inferInstance
   fin2 := inferInstance
-  boundary1 := rscBoundary1 L
-  boundary2 := rscBoundary2 L
+  boundary1 := ∂₁ L
+  boundary2 := ∂₂ L
   boundary_comp := rscBoundary_comp_zero L
   numQubits := L * L
   numQubits_eq := by simp [Fintype.card_prod, Fintype.card_fin]
@@ -129,10 +130,10 @@ theorem rotatedSurfaceHomologicalCode_C2 :
     (rotatedSurfaceHomologicalCode L).C2 = XFaceIdx L := rfl
 
 theorem rotatedSurfaceHomologicalCode_boundary1 :
-    (rotatedSurfaceHomologicalCode L).boundary1 = rscBoundary1 L := rfl
+    (rotatedSurfaceHomologicalCode L).boundary1 = ∂₁ L := rfl
 
 theorem rotatedSurfaceHomologicalCode_boundary2 :
-    (rotatedSurfaceHomologicalCode L).boundary2 = rscBoundary2 L := rfl
+    (rotatedSurfaceHomologicalCode L).boundary2 = ∂₂ L := rfl
 
 theorem rotatedSurfaceHomologicalCode_numQubits :
     (rotatedSurfaceHomologicalCode L).numQubits = L * L := rfl

--- a/QEC/Stabilizer/Codes/RotatedSurface/ChainComplex.lean
+++ b/QEC/Stabilizer/Codes/RotatedSurface/ChainComplex.lean
@@ -39,6 +39,17 @@ def rscCycles [Fact (Odd L)] : Submodule (ZMod 2) (VtxIdx L → ZMod 2) :=
 def rscBoundaries : Submodule (ZMod 2) (VtxIdx L → ZMod 2) :=
   LinearMap.range (∂₂ L)
 
+/-- `Z₁ L` is the rotated-surface 1-cycle submodule `rscCycles L` (`L` explicit, as for
+`∂₁`). Scoped: `open scoped RotatedSurfaceChain`. -/
+scoped[RotatedSurfaceChain] notation "Z₁" => Quantum.Stabilizer.Lattice.RotatedSurface.rscCycles
+
+/-- `B₁ L` is the rotated-surface 1-boundary submodule `rscBoundaries L`.
+Scoped: `open scoped RotatedSurfaceChain`. -/
+scoped[RotatedSurfaceChain] notation "B₁" =>
+  Quantum.Stabilizer.Lattice.RotatedSurface.rscBoundaries
+
+open scoped RotatedSurfaceChain
+
 /-- Every boundary is a cycle (`∂₁ ∘ ∂₂ = 0`). -/
 theorem rscBoundaries_le_rscCycles [Fact (Odd L)] :
     rscBoundaries L ≤ rscCycles L := by
@@ -48,7 +59,13 @@ theorem rscBoundaries_le_rscCycles [Fact (Odd L)] :
 
 /-- First homology `H₁ = Z₁ / B₁` for the rotated surface code. -/
 abbrev rscH1 [Fact (Odd L)] : Type :=
-  rscCycles L ⧸ Submodule.comap (rscCycles L).subtype (rscBoundaries L)
+  Z₁ L ⧸ Submodule.comap (Z₁ L).subtype (B₁ L)
+
+/-- `H₁ L` is the rotated-surface first homology `rscH1 L = Z₁ L ⧸ B₁ L`.
+Scoped: `open scoped RotatedSurfaceChain`. -/
+scoped[RotatedSurfaceChain] notation "H₁" => Quantum.Stabilizer.Lattice.RotatedSurface.rscH1
+
+open scoped RotatedSurfaceChain
 
 /-! ## Row-major qubit indexing -/
 
@@ -140,19 +157,19 @@ theorem rotatedSurfaceHomologicalCode_numQubits :
 
 /-- The lattice-specific 1-cycle submodule equals the generic version. -/
 theorem rotatedSurfaceHomologicalCode_cycles_eq :
-    rscCycles L = (rotatedSurfaceHomologicalCode L).cycles := rfl
+    Z₁ L = (rotatedSurfaceHomologicalCode L).cycles := rfl
 
 /-- The lattice-specific 1-boundary submodule equals the generic version. -/
 theorem rotatedSurfaceHomologicalCode_boundaries_eq :
-    rscBoundaries L = (rotatedSurfaceHomologicalCode L).boundaries := rfl
+    B₁ L = (rotatedSurfaceHomologicalCode L).boundaries := rfl
 
 /-- The lattice-specific `H₁` definition agrees with the generic one. -/
 theorem rotatedSurfaceHomologicalCode_H1_eq :
-    rscH1 L = (rotatedSurfaceHomologicalCode L).H1 := rfl
+    H₁ L = (rotatedSurfaceHomologicalCode L).H1 := rfl
 
 /-- `boundaries ≤ cycles` follows from the generic chain-complex law. -/
 theorem rotatedSurfaceHomologicalCode_boundaries_le_cycles :
-    rscBoundaries L ≤ rscCycles L :=
+    B₁ L ≤ Z₁ L :=
   (rotatedSurfaceHomologicalCode L).boundaries_le_cycles
 
 end RotatedSurface

--- a/QEC/Stabilizer/Codes/RotatedSurface/DistanceX.lean
+++ b/QEC/Stabilizer/Codes/RotatedSurface/DistanceX.lean
@@ -257,7 +257,7 @@ theorem rowParity_rscBoundary2
 /-- `rowParity` vanishes on the boundary submodule. -/
 theorem rowParity_eq_zero_of_mem_boundaries
     {c : RotatedSurface.VtxIdx L → ZMod 2}
-    (hc : c ∈ RotatedSurface.rscBoundaries L) (y : Fin L) :
+    (hc : c ∈ B₁ L) (y : Fin L) :
     rowParity L c y = 0 := by
   rcases hc with ⟨f, rfl⟩
   exact rowParity_rscBoundary2 L f y
@@ -272,7 +272,7 @@ the boundary submodule.
 
 /-- `middleColChain` is not a boundary. -/
 theorem middleColChain_not_mem_boundaries :
-    middleColChain L ∉ RotatedSurface.rscBoundaries L := by
+    middleColChain L ∉ B₁ L := by
   intro h
   -- rowParity middleColChain 0 = 1 (§B) ≠ 0 (= rowParity of boundary, §C)
   have h1 : rowParity L (middleColChain L) ⟨0, by have h3 : 3 ≤ L := Fact.out; omega⟩ = 1 :=
@@ -286,8 +286,8 @@ theorem middleColChain_not_mem_boundaries :
 private lemma middleColChain_class_ne_zero :
     (Submodule.Quotient.mk
       (⟨middleColChain L, middleColChain_mem_cycles L⟩ :
-        RotatedSurface.rscCycles L) :
-      RotatedSurface.rscH1 L) ≠ 0 := by
+        Z₁ L) :
+      H₁ L) ≠ 0 := by
   intro h
   -- Submodule.Quotient.mk x = 0 ↔ x ∈ S.  Here S is the comap into cycles.
   rw [Submodule.Quotient.mk_eq_zero] at h
@@ -298,20 +298,20 @@ private lemma middleColChain_class_ne_zero :
 /-- Every cycle is `0` or `middleColChain` modulo boundaries (since `dim H₁ = 1`). -/
 theorem cycle_sub_middleColChain_mem_boundaries
     {c : RotatedSurface.VtxIdx L → ZMod 2}
-    (hc_cycle : c ∈ RotatedSurface.rscCycles L)
-    (hc_nontrivial : c ∉ RotatedSurface.rscBoundaries L) :
-    c - middleColChain L ∈ RotatedSurface.rscBoundaries L := by
-  have h_dim : dim₂ (RotatedSurface.rscH1 L) = 1 :=
+    (hc_cycle : c ∈ Z₁ L)
+    (hc_nontrivial : c ∉ B₁ L) :
+    c - middleColChain L ∈ B₁ L := by
+  have h_dim : dim₂ (H₁ L) = 1 :=
     RotatedSurface.rsc_finrank_H1_eq_one (L := L)
   -- By dim = 1: every element is a scalar multiple of [middleColChain].
   have h_spans :
-      ∀ w : RotatedSurface.rscH1 L,
+      ∀ w : H₁ L,
         ∃ a : ZMod 2, a • (Submodule.Quotient.mk
           (⟨middleColChain L, middleColChain_mem_cycles L⟩ :
-            RotatedSurface.rscCycles L)) = w :=
+            Z₁ L)) = w :=
     (finrank_eq_one_iff_of_nonzero' _ (middleColChain_class_ne_zero L)).mp h_dim
   -- Apply to [c].
-  let cCycle : RotatedSurface.rscCycles L := ⟨c, hc_cycle⟩
+  let cCycle : Z₁ L := ⟨c, hc_cycle⟩
   obtain ⟨a, ha⟩ := h_spans (Submodule.Quotient.mk cCycle)
   -- a is 0 or 1 in ZMod 2.
   have ha_dichot : a = 0 ∨ a = 1 := by
@@ -327,10 +327,10 @@ theorem cycle_sub_middleColChain_mem_boundaries
     exact hc_nontrivial ha
   · -- a = 1: [middleColChain] = [c], so c - middleColChain ∈ boundaries.
     rw [ha1, one_smul] at ha
-    have h_eq : (Submodule.Quotient.mk cCycle : RotatedSurface.rscH1 L) =
+    have h_eq : (Submodule.Quotient.mk cCycle : H₁ L) =
         Submodule.Quotient.mk
           (⟨middleColChain L, middleColChain_mem_cycles L⟩ :
-            RotatedSurface.rscCycles L) := ha.symm
+            Z₁ L) := ha.symm
     rw [Submodule.Quotient.eq] at h_eq
     -- h_eq : cCycle - ⟨middleColChain, _⟩ ∈ Submodule.comap _ boundaries
     -- which unfolds to: c - middleColChain ∈ boundaries
@@ -339,8 +339,8 @@ theorem cycle_sub_middleColChain_mem_boundaries
 /-- For any non-trivial cycle `c`, `rowParity c y = 1` for every row `y`. -/
 theorem rowParity_eq_one_of_nontrivial
     {c : RotatedSurface.VtxIdx L → ZMod 2}
-    (hc_cycle : c ∈ RotatedSurface.rscCycles L)
-    (hc_nontrivial : c ∉ RotatedSurface.rscBoundaries L) (y : Fin L) :
+    (hc_cycle : c ∈ Z₁ L)
+    (hc_nontrivial : c ∉ B₁ L) (y : Fin L) :
     rowParity L c y = 1 := by
   -- c = middleColChain + (c - middleColChain); the second is a boundary.
   have h_diff_boundary :=
@@ -403,8 +403,8 @@ private lemma chainSupport_card_eq_sum_row_card
 /-- For any non-trivial X-cycle `c`, the abstract `chainWeight` is ≥ L. -/
 theorem chainWeight_ge_L_of_nontrivial
     {c : RotatedSurface.VtxIdx L → ZMod 2}
-    (hc_cycle : c ∈ RotatedSurface.rscCycles L)
-    (hc_nontrivial : c ∉ RotatedSurface.rscBoundaries L) :
+    (hc_cycle : c ∈ Z₁ L)
+    (hc_nontrivial : c ∉ B₁ L) :
     L ≤ (RotatedSurface.rotatedSurfaceHomologicalCode L).chainWeight c := by
   -- chainWeight c = (chainSupport c).card; the row decomposition + per-row ≥ 1.
   change L ≤ ((RotatedSurface.rotatedSurfaceHomologicalCode L).chainSupport c).card

--- a/QEC/Stabilizer/Codes/RotatedSurface/DistanceX.lean
+++ b/QEC/Stabilizer/Codes/RotatedSurface/DistanceX.lean
@@ -36,6 +36,7 @@ namespace StabilizerGroup
 namespace RotatedSurfaceCodeN
 
 open scoped BigOperators
+open scoped Homology
 open scoped RotatedSurfaceChain
 open NQubitPauliGroupElement
 open Stabilizer.Lattice
@@ -281,7 +282,7 @@ theorem middleColChain_not_mem_boundaries :
   rw [h1] at h0
   exact (by decide : (1 : ZMod 2) ≠ 0) h0
 
-/-- The class of `middleColChain` in `rscH1 L` is non-zero. -/
+/-- The class of `middleColChain` in `H₁ L` is non-zero. -/
 private lemma middleColChain_class_ne_zero :
     (Submodule.Quotient.mk
       (⟨middleColChain L, middleColChain_mem_cycles L⟩ :
@@ -300,7 +301,7 @@ theorem cycle_sub_middleColChain_mem_boundaries
     (hc_cycle : c ∈ RotatedSurface.rscCycles L)
     (hc_nontrivial : c ∉ RotatedSurface.rscBoundaries L) :
     c - middleColChain L ∈ RotatedSurface.rscBoundaries L := by
-  have h_dim : Module.finrank (ZMod 2) (RotatedSurface.rscH1 L) = 1 :=
+  have h_dim : dim₂ (RotatedSurface.rscH1 L) = 1 :=
     RotatedSurface.rsc_finrank_H1_eq_one (L := L)
   -- By dim = 1: every element is a scalar multiple of [middleColChain].
   have h_spans :

--- a/QEC/Stabilizer/Codes/RotatedSurface/DistanceX.lean
+++ b/QEC/Stabilizer/Codes/RotatedSurface/DistanceX.lean
@@ -36,6 +36,7 @@ namespace StabilizerGroup
 namespace RotatedSurfaceCodeN
 
 open scoped BigOperators
+open scoped RotatedSurfaceChain
 open NQubitPauliGroupElement
 open Stabilizer.Lattice
 
@@ -208,10 +209,10 @@ private lemma rowFilter_xSupport_card_even
 
 /-- `rowParity (rscBoundary2 (Pi.single xf 1)) y = 0`. -/
 private lemma rowParity_boundary2_single (xf : RotatedSurface.XFaceIdx L) (y : Fin L) :
-    rowParity L (RotatedSurface.rscBoundary2 L (Pi.single xf 1)) y = 0 := by
+    rowParity L (∂₂ L (Pi.single xf 1)) y = 0 := by
   classical
   unfold rowParity
-  rw [show (fun x : Fin L => RotatedSurface.rscBoundary2 L (Pi.single xf 1) (x, y)) =
+  rw [show (fun x : Fin L => ∂₂ L (Pi.single xf 1) (x, y)) =
       (fun x : Fin L => if (x, y) ∈ RotatedSurface.xSupport xf then (1 : ZMod 2) else 0) by
     funext x
     exact boundary2_singleFace_apply L xf (x, y)]
@@ -221,7 +222,7 @@ private lemma rowParity_boundary2_single (xf : RotatedSurface.XFaceIdx L) (y : F
 /-- `rowParity (rscBoundary2 f) y = 0` for every X-face chain `f`. -/
 theorem rowParity_rscBoundary2
     (f : RotatedSurface.XFaceIdx L → ZMod 2) (y : Fin L) :
-    rowParity L (RotatedSurface.rscBoundary2 L f) y = 0 := by
+    rowParity L (∂₂ L f) y = 0 := by
   classical
   have hf : f = ∑ xf : RotatedSurface.XFaceIdx L, f xf • (Pi.single xf (1 : ZMod 2)) := by
     funext xf
@@ -232,23 +233,23 @@ theorem rowParity_rscBoundary2
   -- ∑ x, (∑ xf, ∂₂(f xf • δ_xf))(x, y) = ∑ xf, f xf * (∑ x, ∂₂(δ_xf)(x, y)) = 0
   rw [show (fun x : Fin L =>
       (∑ xf : RotatedSurface.XFaceIdx L,
-        RotatedSurface.rscBoundary2 L (f xf • Pi.single xf 1)) (x, y)) =
+        ∂₂ L (f xf • Pi.single xf 1)) (x, y)) =
       (fun x : Fin L =>
         ∑ xf : RotatedSurface.XFaceIdx L,
-          RotatedSurface.rscBoundary2 L (f xf • Pi.single xf 1) (x, y)) by
+          ∂₂ L (f xf • Pi.single xf 1) (x, y)) by
     funext x; rw [Finset.sum_apply]]
   rw [Finset.sum_comm]
   apply Finset.sum_eq_zero
   intro xf _
   have h_smul : ∀ x : Fin L,
-      RotatedSurface.rscBoundary2 L (f xf • Pi.single xf 1) (x, y) =
-        f xf * RotatedSurface.rscBoundary2 L (Pi.single xf 1) (x, y) := fun x => by
+      ∂₂ L (f xf • Pi.single xf 1) (x, y) =
+        f xf * ∂₂ L (Pi.single xf 1) (x, y) := fun x => by
     rw [LinearMap.map_smul]
     simp [Pi.smul_apply, smul_eq_mul]
   rw [Finset.sum_congr rfl (fun x _ => h_smul x)]
   rw [← Finset.mul_sum]
-  rw [show ∑ x : Fin L, RotatedSurface.rscBoundary2 L (Pi.single xf 1) (x, y) =
-      rowParity L (RotatedSurface.rscBoundary2 L (Pi.single xf 1)) y from rfl]
+  rw [show ∑ x : Fin L, ∂₂ L (Pi.single xf 1) (x, y) =
+      rowParity L (∂₂ L (Pi.single xf 1)) y from rfl]
   rw [rowParity_boundary2_single]
   ring
 

--- a/QEC/Stabilizer/Codes/RotatedSurface/DistanceZ.lean
+++ b/QEC/Stabilizer/Codes/RotatedSurface/DistanceZ.lean
@@ -32,6 +32,7 @@ namespace StabilizerGroup
 namespace RotatedSurfaceCodeN
 
 open scoped BigOperators
+open scoped RotatedSurfaceChain
 open NQubitPauliGroupElement
 open Stabilizer.Lattice
 
@@ -194,11 +195,11 @@ private lemma colFilter_zSupport_card_even
 omit [Fact (Odd L)] in
 /-- `colParity (rscZCutMap (Pi.single zf 1)) x = 0`. -/
 private lemma colParity_zCutMap_single (zf : RotatedSurface.ZFaceIdx L) (x : Fin L) :
-    colParity L (RotatedSurface.rscZCutMap L (Pi.single zf 1)) x = 0 := by
+    colParity L (δ⁰ L (Pi.single zf 1)) x = 0 := by
   classical
   unfold colParity
   -- (rscZCutMap (Pi.single zf 1)) v = 1[v ∈ zSupport zf]
-  rw [show (fun y : Fin L => RotatedSurface.rscZCutMap L (Pi.single zf 1) (x, y)) =
+  rw [show (fun y : Fin L => δ⁰ L (Pi.single zf 1) (x, y)) =
       (fun y : Fin L => if (x, y) ∈ RotatedSurface.zSupport zf then (1 : ZMod 2) else 0) by
     funext y
     rw [RotatedSurface.rscZCutMap_apply]
@@ -218,7 +219,7 @@ omit [Fact (Odd L)] in
 /-- `colParity (rscZCutMap s) x = 0` for every Z-face chain `s`. -/
 theorem colParity_rscZCutMap
     (s : RotatedSurface.ZFaceIdx L → ZMod 2) (x : Fin L) :
-    colParity L (RotatedSurface.rscZCutMap L s) x = 0 := by
+    colParity L (δ⁰ L s) x = 0 := by
   classical
   have hs : s = ∑ zf : RotatedSurface.ZFaceIdx L, s zf • (Pi.single zf (1 : ZMod 2)) := by
     funext zf
@@ -228,23 +229,23 @@ theorem colParity_rscZCutMap
   unfold colParity
   rw [show (fun y : Fin L =>
       (∑ zf : RotatedSurface.ZFaceIdx L,
-        RotatedSurface.rscZCutMap L (s zf • Pi.single zf 1)) (x, y)) =
+        δ⁰ L (s zf • Pi.single zf 1)) (x, y)) =
       (fun y : Fin L =>
         ∑ zf : RotatedSurface.ZFaceIdx L,
-          RotatedSurface.rscZCutMap L (s zf • Pi.single zf 1) (x, y)) by
+          δ⁰ L (s zf • Pi.single zf 1) (x, y)) by
     funext y; rw [Finset.sum_apply]]
   rw [Finset.sum_comm]
   apply Finset.sum_eq_zero
   intro zf _
   have h_smul : ∀ y : Fin L,
-      RotatedSurface.rscZCutMap L (s zf • Pi.single zf 1) (x, y) =
-        s zf * RotatedSurface.rscZCutMap L (Pi.single zf 1) (x, y) := fun y => by
+      δ⁰ L (s zf • Pi.single zf 1) (x, y) =
+        s zf * δ⁰ L (Pi.single zf 1) (x, y) := fun y => by
     rw [LinearMap.map_smul]
     simp [Pi.smul_apply, smul_eq_mul]
   rw [Finset.sum_congr rfl (fun y _ => h_smul y)]
   rw [← Finset.mul_sum]
-  rw [show ∑ y : Fin L, RotatedSurface.rscZCutMap L (Pi.single zf 1) (x, y) =
-      colParity L (RotatedSurface.rscZCutMap L (Pi.single zf 1)) x from rfl]
+  rw [show ∑ y : Fin L, δ⁰ L (Pi.single zf 1) (x, y) =
+      colParity L (δ⁰ L (Pi.single zf 1)) x from rfl]
   rw [colParity_zCutMap_single]
   ring
 
@@ -252,7 +253,7 @@ omit [Fact (Odd L)] in
 /-- `colParity` vanishes on the dual-boundaries submodule (range of `rscZCutMap`). -/
 theorem colParity_eq_zero_of_mem_dualBoundaries
     {c : RotatedSurface.VtxIdx L → ZMod 2}
-    (hc : c ∈ LinearMap.range (RotatedSurface.rscZCutMap L)) (x : Fin L) :
+    (hc : c ∈ LinearMap.range (δ⁰ L)) (x : Fin L) :
     colParity L c x = 0 := by
   rcases hc with ⟨s, rfl⟩
   exact colParity_rscZCutMap L s x
@@ -279,7 +280,7 @@ def stabXMatrix : Matrix (RotatedSurface.XFaceIdx L) (RotatedSurface.VtxIdx L) (
 
 omit [Fact (Odd L)] [Fact (3 ≤ L)] in
 lemma rscBoundary2_eq_transpose_mulVecLin :
-    RotatedSurface.rscBoundary2 L = (stabXMatrix L).transpose.mulVecLin := by
+    ∂₂ L = (stabXMatrix L).transpose.mulVecLin := by
   apply LinearMap.ext
   intro c
   funext v
@@ -323,7 +324,7 @@ theorem rsc_rank_dualBoundary :
   have h_eq_rank :
       Module.finrank (ZMod 2)
           (LinearMap.range (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundary) =
-        Module.finrank (ZMod 2) (LinearMap.range (RotatedSurface.rscBoundary2 L)) := by
+        Module.finrank (ZMod 2) (LinearMap.range (∂₂ L)) := by
     rw [dualBoundary_eq_mulVecLin, rscBoundary2_eq_transpose_mulVecLin]
     change Matrix.rank (stabXMatrix L) = Matrix.rank (stabXMatrix L).transpose
     rw [Matrix.rank_transpose]
@@ -353,7 +354,7 @@ omit [Fact (Odd L)] [Fact (3 ≤ L)] in
 /-- Helper: `rscBoundary1 (Pi.single v 1) zf = 1[v ∈ zSupport zf]`. -/
 private lemma rscBoundary1_pi_single
     (v : RotatedSurface.VtxIdx L) (zf : RotatedSurface.ZFaceIdx L) :
-    RotatedSurface.rscBoundary1 L (Pi.single v 1) zf =
+    ∂₁ L (Pi.single v 1) zf =
       (if v ∈ RotatedSurface.zSupport zf then (1 : ZMod 2) else 0) := by
   classical
   rw [RotatedSurface.rscBoundary1_apply]
@@ -371,12 +372,12 @@ private lemma rscBoundary1_pi_single
 /-- Bridge: the abstract `cutMap` equals the lattice-side `rscZCutMap`. -/
 lemma cutMap_eq_rscZCutMap :
     (RotatedSurface.rotatedSurfaceHomologicalCode L).cutMap =
-      RotatedSurface.rscZCutMap L := by
+      δ⁰ L := by
   apply LinearMap.ext
   intro s
   funext v
   change ∑ zf : RotatedSurface.ZFaceIdx L,
-      s zf * RotatedSurface.rscBoundary1 L (Pi.single v 1) zf = _
+      s zf * ∂₁ L (Pi.single v 1) zf = _
   change _ = ∑ zf : RotatedSurface.ZFaceIdx L,
       s zf * (if v ∈ RotatedSurface.zSupport zf then (1 : ZMod 2) else 0)
   apply Finset.sum_congr rfl
@@ -475,7 +476,7 @@ theorem middleRowChain_not_mem_dualBoundaries :
     middleRowChain L ∉
       (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundaries := by
   intro h
-  have h_rsc : middleRowChain L ∈ LinearMap.range (RotatedSurface.rscZCutMap L) := by
+  have h_rsc : middleRowChain L ∈ LinearMap.range (δ⁰ L) := by
     rw [← cutMap_eq_rscZCutMap]
     exact h
   have h1 : colParity L (middleRowChain L)
@@ -550,7 +551,7 @@ theorem colParity_eq_one_of_nontrivial
   rw [colParity_middleRowChain]
   -- dualBoundaries unfolds to range cutMap; convert h_diff_boundary to range rscZCutMap.
   have h_diff_rsc : c - middleRowChain L ∈
-      LinearMap.range (RotatedSurface.rscZCutMap L) := by
+      LinearMap.range (δ⁰ L) := by
     rw [← cutMap_eq_rscZCutMap]
     exact h_diff_boundary
   rw [colParity_eq_zero_of_mem_dualBoundaries L h_diff_rsc x]

--- a/QEC/Stabilizer/Codes/RotatedSurface/DistanceZ.lean
+++ b/QEC/Stabilizer/Codes/RotatedSurface/DistanceZ.lean
@@ -32,6 +32,7 @@ namespace StabilizerGroup
 namespace RotatedSurfaceCodeN
 
 open scoped BigOperators
+open scoped Homology
 open scoped RotatedSurfaceChain
 open NQubitPauliGroupElement
 open Stabilizer.Lattice
@@ -318,13 +319,13 @@ lemma dualBoundary_eq_mulVecLin :
 
 /-- `rank(dualBoundary) = card (XFaceIdx L)`. -/
 theorem rsc_rank_dualBoundary :
-    Module.finrank (ZMod 2)
+    dim₂
         (LinearMap.range (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundary) =
       Fintype.card (RotatedSurface.XFaceIdx L) := by
   have h_eq_rank :
-      Module.finrank (ZMod 2)
+      dim₂
           (LinearMap.range (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundary) =
-        Module.finrank (ZMod 2) (LinearMap.range (∂₂ L)) := by
+        dim₂ (LinearMap.range (∂₂ L)) := by
     rw [dualBoundary_eq_mulVecLin, rscBoundary2_eq_transpose_mulVecLin]
     change Matrix.rank (stabXMatrix L) = Matrix.rank (stabXMatrix L).transpose
     rw [Matrix.rank_transpose]
@@ -333,20 +334,20 @@ theorem rsc_rank_dualBoundary :
 
 /-- `dim dualCycles = L*L − card XFaceIdx`. -/
 theorem rsc_finrank_dualCycles :
-    Module.finrank (ZMod 2)
+    dim₂
         (RotatedSurface.rotatedSurfaceHomologicalCode L).dualCycles =
       L * L - Fintype.card (RotatedSurface.XFaceIdx L) := by
   have hrn := LinearMap.finrank_range_add_finrank_ker
     (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundary
   rw [rsc_rank_dualBoundary] at hrn
   -- dim C₁ = L*L (via Fintype card of VtxIdx).
-  have h_C1 : Module.finrank (ZMod 2)
+  have h_C1 : dim₂
       ((RotatedSurface.rotatedSurfaceHomologicalCode L).C1 → ZMod 2) = L * L := by
     rw [Module.finrank_fintype_fun_eq_card]
     change Fintype.card (RotatedSurface.VtxIdx L) = L * L
     simp [Fintype.card_prod, Fintype.card_fin]
   rw [h_C1] at hrn
-  change Module.finrank (ZMod 2)
+  change dim₂
     (LinearMap.ker (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundary) = _
   omega
 
@@ -387,10 +388,10 @@ lemma cutMap_eq_rscZCutMap :
 
 /-- `dim dualBoundaries = card ZFaceIdx`. -/
 theorem rsc_finrank_dualBoundaries :
-    Module.finrank (ZMod 2)
+    dim₂
         (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundaries =
       Fintype.card (RotatedSurface.ZFaceIdx L) := by
-  change Module.finrank (ZMod 2)
+  change dim₂
     (LinearMap.range (RotatedSurface.rotatedSurfaceHomologicalCode L).cutMap) = _
   rw [cutMap_eq_rscZCutMap]
   exact RotatedSurface.rsc_rank_zCutMap (L := L)
@@ -448,7 +449,7 @@ theorem dualBoundaries_le_dualCycles :
 
 /-- `dim (dualCycles / dualBoundaries) = 1` for the rotated surface code. -/
 theorem rsc_finrank_dualH1_eq_one :
-    Module.finrank (ZMod 2)
+    dim₂
       ((RotatedSurface.rotatedSurfaceHomologicalCode L).dualCycles ⧸
         Submodule.comap
           (RotatedSurface.rotatedSurfaceHomologicalCode L).dualCycles.subtype
@@ -457,10 +458,10 @@ theorem rsc_finrank_dualH1_eq_one :
   have h_quot := Submodule.finrank_quotient_add_finrank (R := ZMod 2)
     (Submodule.comap (RotatedSurface.rotatedSurfaceHomologicalCode L).dualCycles.subtype
       (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundaries)
-  have h_comap : Module.finrank (ZMod 2)
+  have h_comap : dim₂
       (Submodule.comap (RotatedSurface.rotatedSurfaceHomologicalCode L).dualCycles.subtype
         (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundaries) =
-      Module.finrank (ZMod 2)
+      dim₂
         (RotatedSurface.rotatedSurfaceHomologicalCode L).dualBoundaries :=
     (Submodule.comapSubtypeEquivOfLe h_le).finrank_eq
   rw [h_comap, rsc_finrank_dualBoundaries, rsc_finrank_dualCycles] at h_quot

--- a/QEC/Stabilizer/Codes/RotatedSurface/H1Dimension.lean
+++ b/QEC/Stabilizer/Codes/RotatedSurface/H1Dimension.lean
@@ -24,6 +24,7 @@ namespace Lattice
 namespace RotatedSurface
 
 open scoped BigOperators
+open scoped Homology
 open scoped RotatedSurfaceChain
 
 /-! ## Basic ambient facts -/
@@ -129,16 +130,16 @@ end Cardinality
 /-! ## Finrank of chain spaces -/
 
 lemma rsc_finrank_C1 (L : ℕ) :
-    Module.finrank (ZMod 2) (VtxIdx L → ZMod 2) = L * L := by
+    dim₂ (VtxIdx L → ZMod 2) = L * L := by
   rw [Module.finrank_fintype_fun_eq_card]
   simp [VtxIdx, Fintype.card_prod, Fintype.card_fin]
 
 lemma rsc_finrank_C0 (L : ℕ) :
-    Module.finrank (ZMod 2) (ZFaceIdx L → ZMod 2) = Fintype.card (ZFaceIdx L) := by
+    dim₂ (ZFaceIdx L → ZMod 2) = Fintype.card (ZFaceIdx L) := by
   rw [Module.finrank_fintype_fun_eq_card]
 
 lemma rsc_finrank_C2 (L : ℕ) :
-    Module.finrank (ZMod 2) (XFaceIdx L → ZMod 2) = Fintype.card (XFaceIdx L) := by
+    dim₂ (XFaceIdx L → ZMod 2) = Fintype.card (XFaceIdx L) := by
   rw [Module.finrank_fintype_fun_eq_card]
 
 /-! ## Anchor-qubit framework
@@ -579,10 +580,10 @@ theorem rscBoundary2_ker_eq_bot :
 
 /-- `rank(∂₂) = |XFaceIdx L|`. -/
 theorem rsc_rank_boundary2 :
-    Module.finrank (ZMod 2) (LinearMap.range (∂₂ L)) =
+    dim₂ (LinearMap.range (∂₂ L)) =
       Fintype.card (XFaceIdx L) := by
   have hrn := LinearMap.finrank_range_add_finrank_ker (∂₂ L)
-  rw [show Module.finrank (ZMod 2) (LinearMap.ker (∂₂ L)) = 0 from ?_] at hrn
+  rw [show dim₂ (LinearMap.ker (∂₂ L)) = 0 from ?_] at hrn
   · rw [rsc_finrank_C2] at hrn
     omega
   · rw [rscBoundary2_ker_eq_bot]
@@ -653,10 +654,10 @@ theorem rscZCutMap_ker_eq_bot : LinearMap.ker (δ⁰ L) = ⊥ := by
 
 /-- `rank(rscZCutMap) = |ZFaceIdx L|`. -/
 theorem rsc_rank_zCutMap :
-    Module.finrank (ZMod 2) (LinearMap.range (δ⁰ L)) =
+    dim₂ (LinearMap.range (δ⁰ L)) =
       Fintype.card (ZFaceIdx L) := by
   have hrn := LinearMap.finrank_range_add_finrank_ker (δ⁰ L)
-  rw [show Module.finrank (ZMod 2) (LinearMap.ker (δ⁰ L)) = 0 from ?_] at hrn
+  rw [show dim₂ (LinearMap.ker (δ⁰ L)) = 0 from ?_] at hrn
   · rw [rsc_finrank_C0] at hrn
     omega
   · rw [rscZCutMap_ker_eq_bot]
@@ -733,15 +734,15 @@ lemma rscZCutMap_eq_transpose_mulVecLin :
 
 /-- `rank(∂₁) = rank(rscZCutMap)` via matrix transpose-rank. -/
 theorem rsc_rank_boundary1_eq_rank_zCutMap :
-    Module.finrank (ZMod 2) (LinearMap.range (∂₁ L)) =
-      Module.finrank (ZMod 2) (LinearMap.range (δ⁰ L)) := by
+    dim₂ (LinearMap.range (∂₁ L)) =
+      dim₂ (LinearMap.range (δ⁰ L)) := by
   rw [rscBoundary1_eq_mulVecLin, rscZCutMap_eq_transpose_mulVecLin]
   show Matrix.rank (stabZMatrix L) = Matrix.rank (stabZMatrix L).transpose
   rw [Matrix.rank_transpose]
 
 /-- `rank(∂₁) = |ZFaceIdx L|`. -/
 theorem rsc_rank_boundary1 :
-    Module.finrank (ZMod 2) (LinearMap.range (∂₁ L)) =
+    dim₂ (LinearMap.range (∂₁ L)) =
       Fintype.card (ZFaceIdx L) := by
   rw [rsc_rank_boundary1_eq_rank_zCutMap, rsc_rank_zCutMap]
 
@@ -749,7 +750,7 @@ theorem rsc_rank_boundary1 :
 
 /-- `dim(cycles) = L * L − |ZFaceIdx L|`. -/
 theorem rsc_finrank_cycles :
-    Module.finrank (ZMod 2) (rscCycles L) =
+    dim₂ (Z₁ L) =
       L * L - Fintype.card (ZFaceIdx L) := by
   have hrn := LinearMap.finrank_range_add_finrank_ker (∂₁ L)
   rw [rsc_finrank_C1, rsc_rank_boundary1] at hrn
@@ -763,32 +764,32 @@ theorem rsc_finrank_cycles :
     have hLL : 1 ≤ L * L := by nlinarith
     omega
   -- rscCycles = ker rscBoundary1
-  show Module.finrank (ZMod 2) (LinearMap.ker (∂₁ L)) = _
+  show dim₂ (LinearMap.ker (∂₁ L)) = _
   omega
 
 /-- `dim(boundaries) = |XFaceIdx L|`. -/
 theorem rsc_finrank_boundaries :
-    Module.finrank (ZMod 2) (rscBoundaries L) = Fintype.card (XFaceIdx L) := by
-  show Module.finrank (ZMod 2) (LinearMap.range (∂₂ L)) = _
+    dim₂ (B₁ L) = Fintype.card (XFaceIdx L) := by
+  show dim₂ (LinearMap.range (∂₂ L)) = _
   exact rsc_rank_boundary2
 
 /-- `dim(H₁) = 1` for the rotated surface code. -/
 theorem rsc_finrank_H1_eq_one :
-    Module.finrank (ZMod 2) (rscH1 L) = 1 := by
+    dim₂ (H₁ L) = 1 := by
   -- The generic quotient-dimension formula on the HomologicalCode side.
   have hquot := (rotatedSurfaceHomologicalCode L).finrank_H1_eq_cycles_sub_boundaries
   -- Convert from generic cycles/boundaries to lattice-specific via the rfl-bridges.
-  have hC : Module.finrank (ZMod 2) ((rotatedSurfaceHomologicalCode L).cycles) =
+  have hC : dim₂ ((rotatedSurfaceHomologicalCode L).cycles) =
       L * L - Fintype.card (ZFaceIdx L) := by
-    show Module.finrank (ZMod 2) (rscCycles L) = _
+    show dim₂ (Z₁ L) = _
     exact rsc_finrank_cycles
-  have hB : Module.finrank (ZMod 2) ((rotatedSurfaceHomologicalCode L).boundaries) =
+  have hB : dim₂ ((rotatedSurfaceHomologicalCode L).boundaries) =
       Fintype.card (XFaceIdx L) := by
-    show Module.finrank (ZMod 2) (rscBoundaries L) = _
+    show dim₂ (B₁ L) = _
     exact rsc_finrank_boundaries
   rw [hC, hB] at hquot
   -- The two finrank forms (lattice vs generic) agree by defeq.
-  have h_targ : Module.finrank (ZMod 2) (rscH1 L) =
+  have h_targ : dim₂ (H₁ L) =
       @Module.finrank (ZMod 2) (rotatedSurfaceHomologicalCode L).H1 _
         (Submodule.Quotient.addCommGroup
           (rotatedSurfaceHomologicalCode L).boundarySubmoduleInCycles).toAddCommMonoid

--- a/QEC/Stabilizer/Codes/RotatedSurface/H1Dimension.lean
+++ b/QEC/Stabilizer/Codes/RotatedSurface/H1Dimension.lean
@@ -24,6 +24,7 @@ namespace Lattice
 namespace RotatedSurface
 
 open scoped BigOperators
+open scoped RotatedSurfaceChain
 
 /-! ## Basic ambient facts -/
 
@@ -536,7 +537,7 @@ lemma zAnchorIdx_injective : Function.Injective (zAnchorIdx : ZFaceIdx L → ℕ
 Combining the X-anchor properties, the indicator family of X-stabs is
 linearly independent, so the boundary map `∂₂` is injective. -/
 
-theorem rscBoundary2_injective : Function.Injective (rscBoundary2 L) := by
+theorem rscBoundary2_injective : Function.Injective (∂₂ L) := by
   rw [← LinearMap.ker_eq_bot, Submodule.eq_bot_iff]
   intro f hf
   simp only [LinearMap.mem_ker] at hf
@@ -548,7 +549,7 @@ theorem rscBoundary2_injective : Function.Injective (rscBoundary2 L) := by
     S.exists_min_image xAnchorIdx hS_ne
   have hxf_min_ne : f xf_min ≠ 0 := (Finset.mem_filter.mp hxf_min_mem).2
   obtain ⟨v_min, hv_min_supp, hv_min_idx⟩ := xAnchor_mem_xSupport xf_min
-  have hval : (rscBoundary2 L f) v_min = f xf_min := by
+  have hval : (∂₂ L f) v_min = f xf_min := by
     rw [rscBoundary2_apply, Finset.sum_eq_single xf_min]
     · simp [hv_min_supp]
     · intro xf' _ hne'
@@ -566,22 +567,22 @@ theorem rscBoundary2_injective : Function.Injective (rscBoundary2 L) := by
           omega
         simp [hnotin]
     · intro h; exact absurd (Finset.mem_univ xf_min) h
-  have : (rscBoundary2 L f) v_min = 0 := by rw [hf]; rfl
+  have : (∂₂ L f) v_min = 0 := by rw [hf]; rfl
   rw [hval] at this
   exact hxf_min_ne this
 
 /-- The kernel of `rscBoundary2` is `⊥`. -/
 theorem rscBoundary2_ker_eq_bot :
-    LinearMap.ker (rscBoundary2 L) = ⊥ := by
+    LinearMap.ker (∂₂ L) = ⊥ := by
   rw [LinearMap.ker_eq_bot]
   exact rscBoundary2_injective
 
 /-- `rank(∂₂) = |XFaceIdx L|`. -/
 theorem rsc_rank_boundary2 :
-    Module.finrank (ZMod 2) (LinearMap.range (rscBoundary2 L)) =
+    Module.finrank (ZMod 2) (LinearMap.range (∂₂ L)) =
       Fintype.card (XFaceIdx L) := by
-  have hrn := LinearMap.finrank_range_add_finrank_ker (rscBoundary2 L)
-  rw [show Module.finrank (ZMod 2) (LinearMap.ker (rscBoundary2 L)) = 0 from ?_] at hrn
+  have hrn := LinearMap.finrank_range_add_finrank_ker (∂₂ L)
+  rw [show Module.finrank (ZMod 2) (LinearMap.ker (∂₂ L)) = 0 from ?_] at hrn
   · rw [rsc_finrank_C2] at hrn
     omega
   · rw [rscBoundary2_ker_eq_bot]
@@ -604,11 +605,16 @@ def rscZCutMap (L : ℕ) :
     funext v
     simp only [RingHom.id_apply, Pi.smul_apply, smul_eq_mul, Finset.mul_sum, mul_assoc]
 
+/-- `δ⁰` is the rotated-surface Z-side cut map `rscZCutMap L` (the transpose of `∂₁`,
+i.e. the coboundary `C⁰ → C¹`). Scoped: `open scoped RotatedSurfaceChain`. -/
+scoped[RotatedSurfaceChain] notation "δ⁰" =>
+  Quantum.Stabilizer.Lattice.RotatedSurface.rscZCutMap
+
 @[simp] theorem rscZCutMap_apply (L : ℕ) (s : ZFaceIdx L → ZMod 2) (v : VtxIdx L) :
-    rscZCutMap L s v =
+    δ⁰ L s v =
       ∑ zf : ZFaceIdx L, s zf * (if v ∈ zSupport zf then 1 else 0) := rfl
 
-theorem rscZCutMap_injective : Function.Injective (rscZCutMap L) := by
+theorem rscZCutMap_injective : Function.Injective (δ⁰ L) := by
   rw [← LinearMap.ker_eq_bot, Submodule.eq_bot_iff]
   intro s hs
   simp only [LinearMap.mem_ker] at hs
@@ -620,7 +626,7 @@ theorem rscZCutMap_injective : Function.Injective (rscZCutMap L) := by
     S.exists_min_image zAnchorIdx hS_ne
   have hzf_min_ne : s zf_min ≠ 0 := (Finset.mem_filter.mp hzf_min_mem).2
   obtain ⟨v_min, hv_min_supp, hv_min_idx⟩ := zAnchor_mem_zSupport zf_min
-  have hval : (rscZCutMap L s) v_min = s zf_min := by
+  have hval : (δ⁰ L s) v_min = s zf_min := by
     rw [rscZCutMap_apply, Finset.sum_eq_single zf_min]
     · simp [hv_min_supp]
     · intro zf' _ hne'
@@ -638,19 +644,19 @@ theorem rscZCutMap_injective : Function.Injective (rscZCutMap L) := by
           omega
         simp [hnotin]
     · intro h; exact absurd (Finset.mem_univ zf_min) h
-  have : (rscZCutMap L s) v_min = 0 := by rw [hs]; rfl
+  have : (δ⁰ L s) v_min = 0 := by rw [hs]; rfl
   rw [hval] at this
   exact hzf_min_ne this
 
-theorem rscZCutMap_ker_eq_bot : LinearMap.ker (rscZCutMap L) = ⊥ := by
+theorem rscZCutMap_ker_eq_bot : LinearMap.ker (δ⁰ L) = ⊥ := by
   rw [LinearMap.ker_eq_bot]; exact rscZCutMap_injective
 
 /-- `rank(rscZCutMap) = |ZFaceIdx L|`. -/
 theorem rsc_rank_zCutMap :
-    Module.finrank (ZMod 2) (LinearMap.range (rscZCutMap L)) =
+    Module.finrank (ZMod 2) (LinearMap.range (δ⁰ L)) =
       Fintype.card (ZFaceIdx L) := by
-  have hrn := LinearMap.finrank_range_add_finrank_ker (rscZCutMap L)
-  rw [show Module.finrank (ZMod 2) (LinearMap.ker (rscZCutMap L)) = 0 from ?_] at hrn
+  have hrn := LinearMap.finrank_range_add_finrank_ker (δ⁰ L)
+  rw [show Module.finrank (ZMod 2) (LinearMap.ker (δ⁰ L)) = 0 from ?_] at hrn
   · rw [rsc_finrank_C0] at hrn
     omega
   · rw [rscZCutMap_ker_eq_bot]
@@ -663,8 +669,8 @@ maps as mutual transposes, so they share the same rank. -/
 
 theorem rscBoundary1_rscZCutMap_transpose
     (c : VtxIdx L → ZMod 2) (s : ZFaceIdx L → ZMod 2) :
-    ∑ zf : ZFaceIdx L, rscBoundary1 L c zf * s zf =
-      ∑ v : VtxIdx L, c v * rscZCutMap L s v := by
+    ∑ zf : ZFaceIdx L, ∂₁ L c zf * s zf =
+      ∑ v : VtxIdx L, c v * δ⁰ L s v := by
   simp only [rscBoundary1_apply, rscZCutMap_apply]
   -- Helper: ∑ v ∈ zSupport zf, c v * s zf = ∑ v, if v ∈ zSupport zf then c v * s zf else 0.
   have hsplit : ∀ zf : ZFaceIdx L,
@@ -700,7 +706,7 @@ def stabZMatrix (L : ℕ) : Matrix (ZFaceIdx L) (VtxIdx L) (ZMod 2) :=
   fun zf v => if v ∈ zSupport zf then 1 else 0
 
 lemma rscBoundary1_eq_mulVecLin :
-    rscBoundary1 L = (stabZMatrix L).mulVecLin := by
+    ∂₁ L = (stabZMatrix L).mulVecLin := by
   apply LinearMap.ext
   intro c
   funext zf
@@ -715,7 +721,7 @@ lemma rscBoundary1_eq_mulVecLin :
   ext v; simp
 
 lemma rscZCutMap_eq_transpose_mulVecLin :
-    rscZCutMap L = (stabZMatrix L).transpose.mulVecLin := by
+    δ⁰ L = (stabZMatrix L).transpose.mulVecLin := by
   apply LinearMap.ext
   intro s
   funext v
@@ -727,15 +733,15 @@ lemma rscZCutMap_eq_transpose_mulVecLin :
 
 /-- `rank(∂₁) = rank(rscZCutMap)` via matrix transpose-rank. -/
 theorem rsc_rank_boundary1_eq_rank_zCutMap :
-    Module.finrank (ZMod 2) (LinearMap.range (rscBoundary1 L)) =
-      Module.finrank (ZMod 2) (LinearMap.range (rscZCutMap L)) := by
+    Module.finrank (ZMod 2) (LinearMap.range (∂₁ L)) =
+      Module.finrank (ZMod 2) (LinearMap.range (δ⁰ L)) := by
   rw [rscBoundary1_eq_mulVecLin, rscZCutMap_eq_transpose_mulVecLin]
   show Matrix.rank (stabZMatrix L) = Matrix.rank (stabZMatrix L).transpose
   rw [Matrix.rank_transpose]
 
 /-- `rank(∂₁) = |ZFaceIdx L|`. -/
 theorem rsc_rank_boundary1 :
-    Module.finrank (ZMod 2) (LinearMap.range (rscBoundary1 L)) =
+    Module.finrank (ZMod 2) (LinearMap.range (∂₁ L)) =
       Fintype.card (ZFaceIdx L) := by
   rw [rsc_rank_boundary1_eq_rank_zCutMap, rsc_rank_zCutMap]
 
@@ -745,7 +751,7 @@ theorem rsc_rank_boundary1 :
 theorem rsc_finrank_cycles :
     Module.finrank (ZMod 2) (rscCycles L) =
       L * L - Fintype.card (ZFaceIdx L) := by
-  have hrn := LinearMap.finrank_range_add_finrank_ker (rscBoundary1 L)
+  have hrn := LinearMap.finrank_range_add_finrank_ker (∂₁ L)
   rw [rsc_finrank_C1, rsc_rank_boundary1] at hrn
   -- finrank C1 (= L*L) = rank(∂₁) + dim ker = |ZFaceIdx| + dim ker
   -- dim Z₁ = dim ker (rscBoundary1) = L*L - |ZFaceIdx|
@@ -757,13 +763,13 @@ theorem rsc_finrank_cycles :
     have hLL : 1 ≤ L * L := by nlinarith
     omega
   -- rscCycles = ker rscBoundary1
-  show Module.finrank (ZMod 2) (LinearMap.ker (rscBoundary1 L)) = _
+  show Module.finrank (ZMod 2) (LinearMap.ker (∂₁ L)) = _
   omega
 
 /-- `dim(boundaries) = |XFaceIdx L|`. -/
 theorem rsc_finrank_boundaries :
     Module.finrank (ZMod 2) (rscBoundaries L) = Fintype.card (XFaceIdx L) := by
-  show Module.finrank (ZMod 2) (LinearMap.range (rscBoundary2 L)) = _
+  show Module.finrank (ZMod 2) (LinearMap.range (∂₂ L)) = _
   exact rsc_rank_boundary2
 
 /-- `dim(H₁) = 1` for the rotated surface code. -/

--- a/QEC/Stabilizer/Codes/RotatedSurface/StabilizerCode.lean
+++ b/QEC/Stabilizer/Codes/RotatedSurface/StabilizerCode.lean
@@ -35,6 +35,7 @@ namespace StabilizerGroup
 namespace RotatedSurfaceCodeN
 
 open scoped BigOperators
+open scoped RotatedSurfaceChain
 open NQubitPauliGroupElement
 open Stabilizer.Lattice
 -- Open `Lattice` to access `RotatedSurface.*` with one less prefix.
@@ -55,7 +56,7 @@ omit [Fact (Odd L)] [Fact (3 ≤ L)] in
 /-- `rscBoundary1 (Pi.single v 1) zf = 1[v ∈ zSupport zf]`. -/
 private lemma boundary1_pi_single (v : RotatedSurface.VtxIdx L)
     (zf : RotatedSurface.ZFaceIdx L) :
-    RotatedSurface.rscBoundary1 L (Pi.single v 1) zf =
+    ∂₁ L (Pi.single v 1) zf =
       (if v ∈ RotatedSurface.zSupport zf then (1 : ZMod 2) else 0) := by
   classical
   rw [RotatedSurface.rscBoundary1_apply]
@@ -81,7 +82,7 @@ lemma cutMap_singleVtx_apply (zf : RotatedSurface.ZFaceIdx L)
         ((RotatedSurface.rotatedSurfaceHomologicalCode L).singleVtx zf) v =
       ∑ zf' : RotatedSurface.ZFaceIdx L,
         (RotatedSurface.rotatedSurfaceHomologicalCode L).singleVtx zf zf' *
-          RotatedSurface.rscBoundary1 L (Pi.single v 1) zf' from rfl]
+          ∂₁ L (Pi.single v 1) zf' from rfl]
   rw [Finset.sum_eq_single zf]
   · -- (singleVtx zf zf) * (boundary1 (δ_v) zf) = (1 : ZMod 2) * _ = boundary1 (δ_v) zf
     have hone : (RotatedSurface.rotatedSurfaceHomologicalCode L).singleVtx zf zf =
@@ -104,7 +105,7 @@ lemma boundary2_singleFace_apply (xf : RotatedSurface.XFaceIdx L)
         ((RotatedSurface.rotatedSurfaceHomologicalCode L).singleFace xf) v =
       (if v ∈ RotatedSurface.xSupport xf then (1 : ZMod 2) else 0) := by
   classical
-  change RotatedSurface.rscBoundary2 L (Pi.single xf 1) v = _
+  change ∂₂ L (Pi.single xf 1) v = _
   rw [RotatedSurface.rscBoundary2_apply]
   by_cases hv : v ∈ RotatedSurface.xSupport xf
   · rw [if_pos hv, Finset.sum_eq_single xf]
@@ -485,7 +486,7 @@ theorem rowsLinearIndependent_generatorsList :
   -- (We work directly with index splits instead of introducing custom Embeddings.)
   --
   -- Z-half kernel: rscZCutMap (coeffsZ f) = 0.
-  have h_cz_ker : RotatedSurface.rscZCutMap L (coeffsZ L f) = 0 := by
+  have h_cz_ker : δ⁰ L (coeffsZ L f) = 0 := by
     funext v
     rw [Pi.zero_apply]
     -- Get the column equation at natAdd (rscQubitEquiv v).
@@ -594,7 +595,7 @@ theorem rowsLinearIndependent_generatorsList :
   -- For each k < nZ, f k = coeffsZ f (zfAt k) = 0.
   -- For each k ≥ nZ, similar via X-block.
   -- X-half kernel: rscBoundary2 (coeffsX f) = 0.
-  have h_cx_ker : RotatedSurface.rscBoundary2 L (coeffsX L f) = 0 := by
+  have h_cx_ker : ∂₂ L (coeffsX L f) = 0 := by
     funext v
     rw [Pi.zero_apply]
     set q := RotatedSurface.rscQubitEquiv L v with hq_def
@@ -768,7 +769,7 @@ def middleRowChain : RotatedSurface.VtxIdx L → ZMod 2 :=
 theorem middleColChain_mem_cycles :
     middleColChain L ∈ RotatedSurface.rscCycles L := by
   classical
-  change RotatedSurface.rscBoundary1 L (middleColChain L) = 0
+  change ∂₁ L (middleColChain L) = 0
   have h3 : 3 ≤ L := Fact.out
   have hmid_pos : 0 < (L - 1) / 2 := by omega
   have hmid_lt : (L - 1) / 2 < L - 1 := by omega

--- a/QEC/Stabilizer/Codes/Small/FiveQubit_5_1_3.lean
+++ b/QEC/Stabilizer/Codes/Small/FiveQubit_5_1_3.lean
@@ -6,6 +6,7 @@ import QEC.Stabilizer.Framework.Core.Logical.CodeDistance
 import QEC.Stabilizer.Framework.Core.CSS.CSSDistance
 import QEC.Stabilizer.Framework.Core.Logical.LogicalOperators
 import QEC.Stabilizer.Framework.Core.Stabilizer.StabilizerCode
+import QEC.Stabilizer.Framework.Core.CodeNotation
 import QEC.Stabilizer.Foundations.PauliGroup.Commutation
 import QEC.Stabilizer.Foundations.PauliGroup.CommutationTactics
 import QEC.Stabilizer.Foundations.PauliGroup.NQubitOperator
@@ -488,7 +489,7 @@ private def logicalOps5_1_3 : Fin 1 → LogicalQubitOps 5 stabilizerGroup :=
             logicalX_anticommutes_logicalZ⟩
 
 /-- The [[5, 1, 3]] five-qubit perfect code as a `StabilizerCode 5 1`. -/
-noncomputable def stabilizerCode : StabilizerCode 5 1 where
+noncomputable def stabilizerCode : Code[[5, 1]] where
   hk := by decide
   generatorsList := generatorsList
   generators_length := rfl
@@ -750,7 +751,7 @@ theorem code_has_distance_three : HasCodeDistance stabilizerCode 3 := by
       weight_two_anticomm_witness g hg_weight h_cent
 
 /-- The [[5, 1, 3]] perfect code packaged with its distance. -/
-noncomputable def stabilizerCodeWithDistance : StabilizerCodeWithDistance 5 1 3 where
+noncomputable def stabilizerCodeWithDistance : Code[[5, 1, 3]] where
   toStabilizerCode := stabilizerCode
   hasDistance      := code_has_distance_three
 

--- a/QEC/Stabilizer/Codes/Small/Steane7.lean
+++ b/QEC/Stabilizer/Codes/Small/Steane7.lean
@@ -11,6 +11,7 @@ import QEC.Stabilizer.Foundations.BinarySymplectic.CheckMatrix
 import QEC.Stabilizer.Foundations.BinarySymplectic.CheckMatrixDecidable
 import QEC.Stabilizer.Framework.Symplectic.SymplecticSpan
 import QEC.Stabilizer.Framework.Core.Stabilizer.StabilizerCode
+import QEC.Stabilizer.Framework.Core.CodeNotation
 import QEC.Stabilizer.Framework.Symplectic.IndependentEquiv
 import QEC.Stabilizer.Foundations.BinarySymplectic.SymplecticInner
 import QEC.Stabilizer.Foundations.PauliGroup.NQubitOperator
@@ -481,7 +482,7 @@ private def logicalOpsSteane7 : Fin 1 → LogicalQubitOps 7 stabilizerGroup :=
     logicalX_anticommutes_logicalZ⟩
 
 /-- The Steane code as a stabilizer code [[7, 1]]: one logical qubit. -/
-noncomputable def stabilizerCode : StabilizerCode 7 1 where
+noncomputable def stabilizerCode : Code[[7, 1]] where
   hk := by decide
   generatorsList := generatorsList
   generators_length := rfl

--- a/QEC/Stabilizer/Codes/Toric/BoundaryMaps.lean
+++ b/QEC/Stabilizer/Codes/Toric/BoundaryMaps.lean
@@ -62,24 +62,24 @@ scoped[ToricChain] notation "∂₁" => Quantum.Stabilizer.Lattice.toricBoundary
 open scoped ToricChain
 
 @[simp] lemma toricBoundary2_singleFace_apply_h (x y x' y' : Fin L) :
-    ∂₂ (L := L) (singleFace (L := L) (x, y)) (EdgeIdx.h x' y') =
+    ∂₂ (L := L) (singleFace (x, y)) (EdgeIdx.h x' y') =
       (if (x', y') = (x, y) then (1 : ZMod 2) else 0) +
       (if (x', prev L y') = (x, y) then (1 : ZMod 2) else 0) := by
   simp [toricBoundary2, singleFace]
 
 @[simp] lemma toricBoundary2_singleFace_apply_v (x y x' y' : Fin L) :
-    ∂₂ (L := L) (singleFace (L := L) (x, y)) (EdgeIdx.v x' y') =
+    ∂₂ (L := L) (singleFace (x, y)) (EdgeIdx.v x' y') =
       (if (x', y') = (x, y) then (1 : ZMod 2) else 0) +
       (if (prev L x', y') = (x, y) then (1 : ZMod 2) else 0) := by
   simp [toricBoundary2, singleFace]
 
 @[simp] lemma toricBoundary1_singleEdge_apply
     (e : EdgeIdx L) (v : VtxIdx L) :
-    ∂₁ (L := L) (singleEdge (L := L) e) v =
-      singleEdge (L := L) e (EdgeIdx.h v.1 v.2) +
-      singleEdge (L := L) e (EdgeIdx.h (prev L v.1) v.2) +
-      singleEdge (L := L) e (EdgeIdx.v v.1 v.2) +
-      singleEdge (L := L) e (EdgeIdx.v v.1 (prev L v.2)) := by
+    ∂₁ (L := L) (singleEdge e) v =
+      singleEdge e (EdgeIdx.h v.1 v.2) +
+      singleEdge e (EdgeIdx.h (prev L v.1) v.2) +
+      singleEdge e (EdgeIdx.v v.1 v.2) +
+      singleEdge e (EdgeIdx.v v.1 (prev L v.2)) := by
   simp [toricBoundary1]
 
 /-- Chain-complex law for toric boundaries. -/

--- a/QEC/Stabilizer/Codes/Toric/BoundaryMaps.lean
+++ b/QEC/Stabilizer/Codes/Toric/BoundaryMaps.lean
@@ -39,21 +39,43 @@ def toricBoundary1 : C1 L →ₗ[ZMod 2] C0 L where
     ext v
     simp [mul_add, add_assoc]
 
+/-!
+## Notation
+
+The scoped `ToricChain` notation renders the toric boundary maps the way the
+homological narrative writes them: `∂₂ L f`, `∂₁ L c` (and `δ⁰ L s` for the vertex
+cut map, declared next to it in `H1Dimension.lean`). The lattice size stays an
+explicit argument, exactly as for the underlying constants — `∂₁ L`, `∂₁ (L := L)` —
+so the conversion is purely notational: `toricBoundary1` is still the declaration
+name for `simp [toricBoundary1]`, `unfold`, and lemma names. Enable with
+`open scoped ToricChain`.
+-/
+
+/-- `∂₂` is the toric face-boundary map `toricBoundary2 : C2 L →ₗ[ZMod 2] C1 L`,
+with the lattice size explicit: `∂₂ L f`. Scoped: `open scoped ToricChain`. -/
+scoped[ToricChain] notation "∂₂" => Quantum.Stabilizer.Lattice.toricBoundary2
+
+/-- `∂₁` is the toric edge-boundary map `toricBoundary1 : C1 L →ₗ[ZMod 2] C0 L`,
+with the lattice size explicit: `∂₁ L c`. Scoped: `open scoped ToricChain`. -/
+scoped[ToricChain] notation "∂₁" => Quantum.Stabilizer.Lattice.toricBoundary1
+
+open scoped ToricChain
+
 @[simp] lemma toricBoundary2_singleFace_apply_h (x y x' y' : Fin L) :
-    toricBoundary2 (L := L) (singleFace (L := L) (x, y)) (EdgeIdx.h x' y') =
+    ∂₂ (L := L) (singleFace (L := L) (x, y)) (EdgeIdx.h x' y') =
       (if (x', y') = (x, y) then (1 : ZMod 2) else 0) +
       (if (x', prev L y') = (x, y) then (1 : ZMod 2) else 0) := by
   simp [toricBoundary2, singleFace]
 
 @[simp] lemma toricBoundary2_singleFace_apply_v (x y x' y' : Fin L) :
-    toricBoundary2 (L := L) (singleFace (L := L) (x, y)) (EdgeIdx.v x' y') =
+    ∂₂ (L := L) (singleFace (L := L) (x, y)) (EdgeIdx.v x' y') =
       (if (x', y') = (x, y) then (1 : ZMod 2) else 0) +
       (if (prev L x', y') = (x, y) then (1 : ZMod 2) else 0) := by
   simp [toricBoundary2, singleFace]
 
 @[simp] lemma toricBoundary1_singleEdge_apply
     (e : EdgeIdx L) (v : VtxIdx L) :
-    toricBoundary1 (L := L) (singleEdge (L := L) e) v =
+    ∂₁ (L := L) (singleEdge (L := L) e) v =
       singleEdge (L := L) e (EdgeIdx.h v.1 v.2) +
       singleEdge (L := L) e (EdgeIdx.h (prev L v.1) v.2) +
       singleEdge (L := L) e (EdgeIdx.v v.1 v.2) +
@@ -62,7 +84,7 @@ def toricBoundary1 : C1 L →ₗ[ZMod 2] C0 L where
 
 /-- Chain-complex law for toric boundaries. -/
 theorem toricBoundary_comp_zero :
-    (toricBoundary1 (L := L)).comp (toricBoundary2 (L := L)) = 0 := by
+    (∂₁ (L := L)).comp (∂₂ (L := L)) = 0 := by
   ext f v
   simp [LinearMap.comp_apply, toricBoundary1, toricBoundary2,
     add_assoc, add_comm, add_left_comm]
@@ -70,7 +92,7 @@ theorem toricBoundary_comp_zero :
   grind
 /-- Pointwise corollary of `toricBoundary_comp_zero`. -/
 theorem toricBoundary_comp_zero_apply (f : C2 L) :
-    toricBoundary1 (L := L) (toricBoundary2 (L := L) f) = 0 := by
+    ∂₁ (L := L) (∂₂ (L := L) f) = 0 := by
   have h := congrArg (fun T => T f) (toricBoundary_comp_zero (L := L))
   simpa using h
 

--- a/QEC/Stabilizer/Codes/Toric/ChainComplex.lean
+++ b/QEC/Stabilizer/Codes/Toric/ChainComplex.lean
@@ -66,19 +66,19 @@ noncomputable def toricHomologicalCode (L : ℕ) [Fact (0 < L)] :
 
 /-- The toric cycle submodule equals the generic version on `toricHomologicalCode L`. -/
 theorem toricHomologicalCode_cycles_eq (L : ℕ) [Fact (0 < L)] :
-    toricCycles (L := L) = (toricHomologicalCode L).cycles := rfl
+    Z₁ L = (toricHomologicalCode L).cycles := rfl
 
 /-- The toric boundary submodule equals the generic version. -/
 theorem toricHomologicalCode_boundaries_eq (L : ℕ) [Fact (0 < L)] :
-    toricBoundaries (L := L) = (toricHomologicalCode L).boundaries := rfl
+    B₁ L = (toricHomologicalCode L).boundaries := rfl
 
 /-- The toric H₁ definition agrees with the generic version. -/
 theorem toricHomologicalCode_H1_eq (L : ℕ) [Fact (0 < L)] :
-    toricH1 (L := L) = (toricHomologicalCode L).H1 := rfl
+    H₁ L = (toricHomologicalCode L).H1 := rfl
 
 /-- The toric `boundaries ≤ cycles` follows from the generic chain-complex law. -/
 theorem toricHomologicalCode_boundaries_le_cycles (L : ℕ) [Fact (0 < L)] :
-    toricBoundaries (L := L) ≤ toricCycles (L := L) :=
+    B₁ L ≤ Z₁ L :=
   (toricHomologicalCode L).boundaries_le_cycles
 
 /-- The toric `HomologicalCode`'s `numQubits` is definitionally `2 * L * L`. -/

--- a/QEC/Stabilizer/Codes/Toric/ChainComplex.lean
+++ b/QEC/Stabilizer/Codes/Toric/ChainComplex.lean
@@ -27,6 +27,8 @@ namespace Quantum
 namespace Stabilizer
 namespace Lattice
 
+open scoped ToricChain
+
 /-- The toric edge-to-qubit equiv, built from `edgeToQubitIdx` (which is injective
 between equinumerous finite types). Returns an `EdgeIdx L ≃ Fin (toricNumQubits L)`
 so the abstract chain operator and the existing `toricXOperatorOfChain L` end up
@@ -55,8 +57,8 @@ noncomputable def toricHomologicalCode (L : ℕ) [Fact (0 < L)] :
   fin0 := inferInstance
   fin1 := inferInstance
   fin2 := inferInstance
-  boundary1 := toricBoundary1 (L := L)
-  boundary2 := toricBoundary2 (L := L)
+  boundary1 := ∂₁ (L := L)
+  boundary2 := ∂₂ (L := L)
   boundary_comp := toricBoundary_comp_zero (L := L)
   numQubits := Quantum.Stabilizer.Lattice.toricNumQubits L
   numQubits_eq := card_edgeIdx L
@@ -120,7 +122,7 @@ variable (L : ℕ) [Fact (0 < L)]
 `∑ v, ∂₁(δ_e) v * s v = ∑ e', δ_e e' * cutMap s e'` isolates the value
 at edge `e` on both sides. -/
 theorem toricHomologicalCode_cutMap_eq :
-    (toricHomologicalCode L).cutMap = toricVertexCutMap (L := L) := by
+    (toricHomologicalCode L).cutMap = δ⁰ (L := L) := by
   classical
   refine LinearMap.ext fun s => ?_
   funext e
@@ -146,14 +148,14 @@ theorem toricHomologicalCode_cutMap_eq :
   -- The two RHS sums are equal because the LHS sums are equal (both pair `∂₁ δ` with `s`).
   have hRHS :
       ∑ e' : EdgeIdx L, δ e' * (toricHomologicalCode L).cutMap s e'
-      = ∑ e' : EdgeIdx L, δ e' * toricVertexCutMap (L := L) s e' := by
+      = ∑ e' : EdgeIdx L, δ e' * δ⁰ (L := L) s e' := by
     have hLHS_eq :
         ∑ v : VtxIdx L, (toricHomologicalCode L).boundary1 δ v * s v
-        = ∑ v : VtxIdx L, toricBoundary1 (L := L) δ v * s v := rfl
+        = ∑ v : VtxIdx L, ∂₁ (L := L) δ v * s v := rfl
     exact h1.symm.trans (hLHS_eq.trans h2)
   -- Specialize `hpi` to both maps and chain.
   have hL := hpi ((toricHomologicalCode L).cutMap s)
-  have hR := hpi (toricVertexCutMap (L := L) s)
+  have hR := hpi (δ⁰ (L := L) s)
   exact hL.symm.trans (hRHS.trans hR)
 
 /-- The lattice `singleVtx v` is the abstract `singleVtx v`. -/

--- a/QEC/Stabilizer/Codes/Toric/ChainOps.lean
+++ b/QEC/Stabilizer/Codes/Toric/ChainOps.lean
@@ -31,6 +31,7 @@ namespace Stabilizer
 namespace Lattice
 
 open scoped BigOperators
+open scoped ToricChain
 
 -- ---------------------------------------------------------------------------
 -- Z-operator encoding (mirror of `toricXOperatorOfChain`)
@@ -221,7 +222,7 @@ lemma toricZOperatorOfChain_add (L : ℕ) (c c' : C1 L) :
 /-- `toricXOperatorOfChain` maps the boundary of a single face to the corresponding
 face stabilizer. -/
 lemma toricXOperatorOfChain_boundary_singleFace (L : ℕ) [Fact (2 ≤ L)] (x y : Fin L) :
-    toricXOperatorOfChain L (toricBoundary2 (L := L) (singleFace (x, y))) =
+    toricXOperatorOfChain L (∂₂ (L := L) (singleFace (x, y))) =
       StabilizerGroup.ToricCodeN.faceStab L x y := by
   unfold toricXOperatorOfChain StabilizerGroup.ToricCodeN.faceStab
   congr with q
@@ -268,7 +269,7 @@ set_option maxHeartbeats 800000 in
     equals the vertex stabilizer at `(xv, yv)`. -/
 lemma toricZOperatorOfChain_cutMap_singleVtx (L : ℕ) [Fact (2 ≤ L)]
     (xv yv : Fin L) :
-    toricZOperatorOfChain L (toricVertexCutMap (L := L) (singleVtx (xv, yv))) =
+    toricZOperatorOfChain L (δ⁰ (L := L) (singleVtx (xv, yv))) =
       StabilizerGroup.ToricCodeN.vertexStab L xv yv := by
   have hL0 : 0 < L := Nat.lt_of_lt_of_le (by decide : 0 < 2) (Fact.out : 2 ≤ L)
   haveI : Fact (0 < L) := ⟨hL0⟩

--- a/QEC/Stabilizer/Codes/Toric/CodeN.lean
+++ b/QEC/Stabilizer/Codes/Toric/CodeN.lean
@@ -234,14 +234,10 @@ lemma faceStab_is_XType (L : ℕ) [Fact (0 < L)] (x y : Fin L) :
     NQubitPauliGroupElement.IsXTypeElement (faceStab L x y) := by
   refine ⟨rfl, ?_⟩
   let op0 : NQubitPauliOperator (numQubits L) := NQubitPauliOperator.identity (numQubits L)
-  let op1 : NQubitPauliOperator (numQubits L) := P[numQubits L | hEdge L x y ↦ X]
-  let op2 : NQubitPauliOperator (numQubits L) :=
-    P[numQubits L | hEdge L x y ↦ X, hEdge L x (next L y) ↦ X]
-  let op3 : NQubitPauliOperator (numQubits L) :=
-    P[numQubits L | hEdge L x y ↦ X, hEdge L x (next L y) ↦ X, vEdge L x y ↦ X]
-  let op4 : NQubitPauliOperator (numQubits L) :=
-    P[numQubits L | hEdge L x y ↦ X, hEdge L x (next L y) ↦ X, vEdge L x y ↦ X,
-      vEdge L (next L x) y ↦ X]
+  let op1 : NQubitPauliOperator (numQubits L) := op0.set (hEdge L x y) PauliOperator.X
+  let op2 : NQubitPauliOperator (numQubits L) := op1.set (hEdge L x (next L y)) PauliOperator.X
+  let op3 : NQubitPauliOperator (numQubits L) := op2.set (vEdge L x y) PauliOperator.X
+  let op4 : NQubitPauliOperator (numQubits L) := op3.set (vEdge L (next L x) y) PauliOperator.X
   have h0 : NQubitPauliOperator.IsXType op0 := by
     simpa [op0] using (NQubitPauliOperator.IsXType_identity (n := numQubits L))
   have h1 : NQubitPauliOperator.IsXType op1 := by
@@ -259,14 +255,10 @@ lemma vertexStab_is_ZType (L : ℕ) [Fact (0 < L)] (x y : Fin L) :
     NQubitPauliGroupElement.IsZTypeElement (vertexStab L x y) := by
   refine ⟨rfl, ?_⟩
   let op0 : NQubitPauliOperator (numQubits L) := NQubitPauliOperator.identity (numQubits L)
-  let op1 : NQubitPauliOperator (numQubits L) := P[numQubits L | hEdge L x y ↦ Z]
-  let op2 : NQubitPauliOperator (numQubits L) :=
-    P[numQubits L | hEdge L x y ↦ Z, hEdge L (prev L x) y ↦ Z]
-  let op3 : NQubitPauliOperator (numQubits L) :=
-    P[numQubits L | hEdge L x y ↦ Z, hEdge L (prev L x) y ↦ Z, vEdge L x y ↦ Z]
-  let op4 : NQubitPauliOperator (numQubits L) :=
-    P[numQubits L | hEdge L x y ↦ Z, hEdge L (prev L x) y ↦ Z, vEdge L x y ↦ Z,
-      vEdge L x (prev L y) ↦ Z]
+  let op1 : NQubitPauliOperator (numQubits L) := op0.set (hEdge L x y) PauliOperator.Z
+  let op2 : NQubitPauliOperator (numQubits L) := op1.set (hEdge L (prev L x) y) PauliOperator.Z
+  let op3 : NQubitPauliOperator (numQubits L) := op2.set (vEdge L x y) PauliOperator.Z
+  let op4 : NQubitPauliOperator (numQubits L) := op3.set (vEdge L x (prev L y)) PauliOperator.Z
   have h0 : NQubitPauliOperator.IsZType op0 := by
     simpa [op0] using (NQubitPauliOperator.IsZType_identity (n := numQubits L))
   have h1 : NQubitPauliOperator.IsZType op1 := by

--- a/QEC/Stabilizer/Codes/Toric/CodeN.lean
+++ b/QEC/Stabilizer/Codes/Toric/CodeN.lean
@@ -629,15 +629,15 @@ abbrev toricBoundary1 (L : ℕ) [Fact (0 < L)] :=
 
 /-- Alias for toric 1-cycles from the lattice homology layer. -/
 abbrev toricCycles (L : ℕ) [Fact (0 < L)] :=
-  Stabilizer.Lattice.toricCycles (L := L)
+  Stabilizer.Lattice.toricCycles L
 
 /-- Alias for toric 1-boundaries from the lattice homology layer. -/
 abbrev toricBoundaries (L : ℕ) [Fact (0 < L)] :=
-  Stabilizer.Lattice.toricBoundaries (L := L)
+  Stabilizer.Lattice.toricBoundaries L
 
 /-- Alias for toric first homology from the lattice homology layer. -/
 abbrev toricH1 (L : ℕ) [Fact (0 < L)] :=
-  Stabilizer.Lattice.toricH1 (L := L)
+  Stabilizer.Lattice.toricH1 L
 
 end ToricCodeN
 end StabilizerGroup

--- a/QEC/Stabilizer/Codes/Toric/CodeN.lean
+++ b/QEC/Stabilizer/Codes/Toric/CodeN.lean
@@ -36,6 +36,7 @@ both are equivalent via global Hadamard (X ↔ Z on every qubit).
 namespace Quantum
 open scoped BigOperators
 open scoped ToricChain
+open scoped Pauli
 
 namespace StabilizerGroup
 namespace ToricCodeN
@@ -135,17 +136,13 @@ abbrev prev (L : ℕ) [Fact (0 < L)] (i : Fin L) : Fin L := Stabilizer.Lattice.p
 
 /-- Vertex stabilizer at `(x,y)`: Z on the four incident edges. -/
 def vertexStab (L : ℕ) [Fact (0 < L)] (x y : Fin L) : NQubitPauliGroupElement (numQubits L) :=
-  ⟨0, (((NQubitPauliOperator.identity (numQubits L)).set (hEdge L x y) PauliOperator.Z
-    |>.set (hEdge L (prev L x) y) PauliOperator.Z
-    |>.set (vEdge L x y) PauliOperator.Z)
-    |>.set (vEdge L x (prev L y)) PauliOperator.Z)⟩
+  σ[numQubits L | hEdge L x y ↦ Z, hEdge L (prev L x) y ↦ Z,
+    vEdge L x y ↦ Z, vEdge L x (prev L y) ↦ Z]
 
 /-- Face stabilizer at `(x,y)`: X on the four boundary edges. -/
 def faceStab (L : ℕ) [Fact (0 < L)] (x y : Fin L) : NQubitPauliGroupElement (numQubits L) :=
-  ⟨0, (((NQubitPauliOperator.identity (numQubits L)).set (hEdge L x y) PauliOperator.X
-    |>.set (hEdge L x (next L y)) PauliOperator.X
-    |>.set (vEdge L x y) PauliOperator.X)
-    |>.set (vEdge L (next L x) y) PauliOperator.X)⟩
+  σ[numQubits L | hEdge L x y ↦ X, hEdge L x (next L y) ↦ X,
+    vEdge L x y ↦ X, vEdge L (next L x) y ↦ X]
 
 /-- X-type generator family indexed by faces. -/
 def XGenerators (L : ℕ) [Fact (0 < L)] : Set (NQubitPauliGroupElement (numQubits L)) :=
@@ -237,10 +234,14 @@ lemma faceStab_is_XType (L : ℕ) [Fact (0 < L)] (x y : Fin L) :
     NQubitPauliGroupElement.IsXTypeElement (faceStab L x y) := by
   refine ⟨rfl, ?_⟩
   let op0 : NQubitPauliOperator (numQubits L) := NQubitPauliOperator.identity (numQubits L)
-  let op1 : NQubitPauliOperator (numQubits L) := op0.set (hEdge L x y) PauliOperator.X
-  let op2 : NQubitPauliOperator (numQubits L) := op1.set (hEdge L x (next L y)) PauliOperator.X
-  let op3 : NQubitPauliOperator (numQubits L) := op2.set (vEdge L x y) PauliOperator.X
-  let op4 : NQubitPauliOperator (numQubits L) := op3.set (vEdge L (next L x) y) PauliOperator.X
+  let op1 : NQubitPauliOperator (numQubits L) := P[numQubits L | hEdge L x y ↦ X]
+  let op2 : NQubitPauliOperator (numQubits L) :=
+    P[numQubits L | hEdge L x y ↦ X, hEdge L x (next L y) ↦ X]
+  let op3 : NQubitPauliOperator (numQubits L) :=
+    P[numQubits L | hEdge L x y ↦ X, hEdge L x (next L y) ↦ X, vEdge L x y ↦ X]
+  let op4 : NQubitPauliOperator (numQubits L) :=
+    P[numQubits L | hEdge L x y ↦ X, hEdge L x (next L y) ↦ X, vEdge L x y ↦ X,
+      vEdge L (next L x) y ↦ X]
   have h0 : NQubitPauliOperator.IsXType op0 := by
     simpa [op0] using (NQubitPauliOperator.IsXType_identity (n := numQubits L))
   have h1 : NQubitPauliOperator.IsXType op1 := by
@@ -258,10 +259,14 @@ lemma vertexStab_is_ZType (L : ℕ) [Fact (0 < L)] (x y : Fin L) :
     NQubitPauliGroupElement.IsZTypeElement (vertexStab L x y) := by
   refine ⟨rfl, ?_⟩
   let op0 : NQubitPauliOperator (numQubits L) := NQubitPauliOperator.identity (numQubits L)
-  let op1 : NQubitPauliOperator (numQubits L) := op0.set (hEdge L x y) PauliOperator.Z
-  let op2 : NQubitPauliOperator (numQubits L) := op1.set (hEdge L (prev L x) y) PauliOperator.Z
-  let op3 : NQubitPauliOperator (numQubits L) := op2.set (vEdge L x y) PauliOperator.Z
-  let op4 : NQubitPauliOperator (numQubits L) := op3.set (vEdge L x (prev L y)) PauliOperator.Z
+  let op1 : NQubitPauliOperator (numQubits L) := P[numQubits L | hEdge L x y ↦ Z]
+  let op2 : NQubitPauliOperator (numQubits L) :=
+    P[numQubits L | hEdge L x y ↦ Z, hEdge L (prev L x) y ↦ Z]
+  let op3 : NQubitPauliOperator (numQubits L) :=
+    P[numQubits L | hEdge L x y ↦ Z, hEdge L (prev L x) y ↦ Z, vEdge L x y ↦ Z]
+  let op4 : NQubitPauliOperator (numQubits L) :=
+    P[numQubits L | hEdge L x y ↦ Z, hEdge L (prev L x) y ↦ Z, vEdge L x y ↦ Z,
+      vEdge L x (prev L y) ↦ Z]
   have h0 : NQubitPauliOperator.IsZType op0 := by
     simpa [op0] using (NQubitPauliOperator.IsZType_identity (n := numQubits L))
   have h1 : NQubitPauliOperator.IsZType op1 := by

--- a/QEC/Stabilizer/Codes/Toric/CodeN.lean
+++ b/QEC/Stabilizer/Codes/Toric/CodeN.lean
@@ -35,6 +35,7 @@ both are equivalent via global Hadamard (X ↔ Z on every qubit).
 
 namespace Quantum
 open scoped BigOperators
+open scoped ToricChain
 
 namespace StabilizerGroup
 namespace ToricCodeN
@@ -615,11 +616,11 @@ of length `numQubits L - 2`. The full `generatorsList L` here has length
 
 /-- Alias for the toric `∂2` boundary map from the lattice chain-complex layer. -/
 abbrev toricBoundary2 (L : ℕ) [Fact (0 < L)] :=
-  Stabilizer.Lattice.toricBoundary2 (L := L)
+  ∂₂ (L := L)
 
 /-- Alias for the toric `∂1` boundary map from the lattice chain-complex layer. -/
 abbrev toricBoundary1 (L : ℕ) [Fact (0 < L)] :=
-  Stabilizer.Lattice.toricBoundary1 (L := L)
+  ∂₁ (L := L)
 
 /-- Alias for toric 1-cycles from the lattice homology layer. -/
 abbrev toricCycles (L : ℕ) [Fact (0 < L)] :=

--- a/QEC/Stabilizer/Codes/Toric/DistanceX.lean
+++ b/QEC/Stabilizer/Codes/Toric/DistanceX.lean
@@ -40,14 +40,14 @@ def HasToricXDistance (L d : ℕ) [Fact (2 ≤ L)] : Prop :=
 
 /-- Section-8 witness: the canonical horizontal loop is a toric 1-cycle. -/
 theorem horizontalLoopChain_mem_toricCycles (L : ℕ) [Fact (2 ≤ L)] :
-    horizontalLoopChain L ∈ Stabilizer.Lattice.toricCycles (L := L) := by
+    horizontalLoopChain L ∈ Stabilizer.Lattice.toricCycles L := by
   unfold Stabilizer.Lattice.toricCycles;
   unfold Stabilizer.Lattice.toricBoundary1 horizontalLoopChain; simp +decide ;
   ext ⟨ x, y ⟩ ; aesop
 
 /-- Section-8 witness: the canonical horizontal loop is not a toric 1-boundary. -/
 theorem horizontalLoopChain_not_mem_toricBoundaries (L : ℕ) [Fact (2 ≤ L)] :
-    horizontalLoopChain L ∉ Stabilizer.Lattice.toricBoundaries (L := L) := by
+    horizontalLoopChain L ∉ Stabilizer.Lattice.toricBoundaries L := by
   have h_hAt_zero :
       Stabilizer.Lattice.hAt (L := L) (Stabilizer.Lattice.zeroCoord L)
         (horizontalLoopChain L) = 1 := by
@@ -220,8 +220,8 @@ theorem nontrivial_x_logical_weight_ge_L (L : ℕ) [Fact (2 ≤ L)]
         · cases hgX.2 q <;> aesop
     exact this g hgX;
   have h_cycle :
-      c ∈ Stabilizer.Lattice.toricCycles (L := L) ∧
-        c ∉ Stabilizer.Lattice.toricBoundaries (L := L) := by
+      c ∈ Stabilizer.Lattice.toricCycles L ∧
+        c ∉ Stabilizer.Lattice.toricBoundaries L := by
     rw [hc] at hgLogical;
     exact (Stabilizer.Lattice.xNontrivialLogical_iff_cycle_not_boundary L c).mp hgLogical;
   have h_weight : Stabilizer.Lattice.edgeWeight c ≥ L := by
@@ -374,7 +374,7 @@ def verticalLoopXOperator (L : ℕ) [Fact (0 < L)] :
 
 /-- The vertical X-loop chain is a primal cycle. -/
 theorem verticalLoopChain_mem_toricCycles (L : ℕ) [Fact (2 ≤ L)] :
-    verticalLoopChain L ∈ Stabilizer.Lattice.toricCycles (L := L) := by
+    verticalLoopChain L ∈ Stabilizer.Lattice.toricCycles L := by
   haveI : Fact (0 < L) := ⟨lt_of_lt_of_le (by decide : 0 < 2) Fact.out⟩
   unfold Stabilizer.Lattice.toricCycles
   rw [LinearMap.mem_ker]
@@ -389,7 +389,7 @@ theorem verticalLoopChain_mem_toricCycles (L : ℕ) [Fact (2 ≤ L)] :
 
 /-- The vertical X-loop chain is not a primal boundary (its `vAt` invariant is 1). -/
 theorem verticalLoopChain_not_mem_toricBoundaries (L : ℕ) [Fact (2 ≤ L)] :
-    verticalLoopChain L ∉ Stabilizer.Lattice.toricBoundaries (L := L) := by
+    verticalLoopChain L ∉ Stabilizer.Lattice.toricBoundaries L := by
   haveI : Fact (0 < L) := ⟨lt_of_lt_of_le (by decide : 0 < 2) Fact.out⟩
   intro h
   have h_vAt : Stabilizer.Lattice.vAt (L := L) (Stabilizer.Lattice.zeroCoord L)

--- a/QEC/Stabilizer/Codes/Toric/DistanceX.lean
+++ b/QEC/Stabilizer/Codes/Toric/DistanceX.lean
@@ -61,12 +61,12 @@ theorem horizontalLoopChain_not_mem_toricBoundaries (L : ℕ) [Fact (2 ≤ L)] :
 
 /-- Section-8 witness: canonical horizontal loop chain has edge-weight `L`. -/
 theorem horizontalLoopChain_edgeWeight_eq_L (L : ℕ) [Fact (2 ≤ L)] :
-    Stabilizer.Lattice.edgeWeight (L := L) (horizontalLoopChain L) = L := by
+    Stabilizer.Lattice.edgeWeight (horizontalLoopChain L) = L := by
   let z0 : Fin L := Stabilizer.Lattice.zeroCoord L
   let horizAtZero : Finset (Stabilizer.Lattice.EdgeIdx L) :=
     (Finset.univ.image (fun x : Fin L => Stabilizer.Lattice.EdgeIdx.h x z0))
   have hsupport :
-      Stabilizer.Lattice.edgeSupport (L := L) (horizontalLoopChain L) = horizAtZero := by
+      Stabilizer.Lattice.edgeSupport (horizontalLoopChain L) = horizAtZero := by
     ext e
     constructor
     · intro he
@@ -104,8 +104,8 @@ theorem horizontalLoopChain_edgeWeight_eq_L (L : ℕ) [Fact (2 ≤ L)] :
             exact hinj hab)
       _ = L := by simp
   calc
-    Stabilizer.Lattice.edgeWeight (L := L) (horizontalLoopChain L)
-        = (Stabilizer.Lattice.edgeSupport (L := L) (horizontalLoopChain L)).card := rfl
+    Stabilizer.Lattice.edgeWeight (horizontalLoopChain L)
+        = (Stabilizer.Lattice.edgeSupport (horizontalLoopChain L)).card := rfl
     _ = horizAtZero.card := by rw [hsupport]
     _ = L := hcard
 
@@ -224,7 +224,7 @@ theorem nontrivial_x_logical_weight_ge_L (L : ℕ) [Fact (2 ≤ L)]
         c ∉ Stabilizer.Lattice.toricBoundaries (L := L) := by
     rw [hc] at hgLogical;
     exact (Stabilizer.Lattice.xNontrivialLogical_iff_cycle_not_boundary L c).mp hgLogical;
-  have h_weight : Stabilizer.Lattice.edgeWeight (L := L) c ≥ L := by
+  have h_weight : Stabilizer.Lattice.edgeWeight c ≥ L := by
     have h_weight :
         Stabilizer.Lattice.hWrap (L := L) ⟨c, h_cycle.left⟩ ≠ 0 ∨
           Stabilizer.Lattice.vWrap (L := L) ⟨c, h_cycle.left⟩ ≠ 0 := by
@@ -408,13 +408,13 @@ theorem verticalLoopChain_not_mem_toricBoundaries (L : ℕ) [Fact (2 ≤ L)] :
 
 /-- The vertical X-loop chain has edge weight `L`. -/
 theorem verticalLoopChain_edgeWeight_eq_L (L : ℕ) [Fact (2 ≤ L)] :
-    Stabilizer.Lattice.edgeWeight (L := L) (verticalLoopChain L) = L := by
+    Stabilizer.Lattice.edgeWeight (verticalLoopChain L) = L := by
   haveI : Fact (0 < L) := ⟨lt_of_lt_of_le (by decide : 0 < 2) Fact.out⟩
   let z0 : Fin L := Stabilizer.Lattice.zeroCoord L
   let vertCol : Finset (Stabilizer.Lattice.EdgeIdx L) :=
     (Finset.univ.image (fun y : Fin L => Stabilizer.Lattice.EdgeIdx.v z0 y))
   have hsupport :
-      Stabilizer.Lattice.edgeSupport (L := L) (verticalLoopChain L) = vertCol := by
+      Stabilizer.Lattice.edgeSupport (verticalLoopChain L) = vertCol := by
     ext e
     constructor
     · intro he
@@ -446,8 +446,8 @@ theorem verticalLoopChain_edgeWeight_eq_L (L : ℕ) [Fact (2 ≤ L)] :
             (by intro a b hab; exact hinj hab)
       _ = L := by simp
   calc
-    Stabilizer.Lattice.edgeWeight (L := L) (verticalLoopChain L)
-        = (Stabilizer.Lattice.edgeSupport (L := L) (verticalLoopChain L)).card := rfl
+    Stabilizer.Lattice.edgeWeight (verticalLoopChain L)
+        = (Stabilizer.Lattice.edgeSupport (verticalLoopChain L)).card := rfl
     _ = vertCol.card := by rw [hsupport]
     _ = L := hcard
 

--- a/QEC/Stabilizer/Codes/Toric/DistanceZ.lean
+++ b/QEC/Stabilizer/Codes/Toric/DistanceZ.lean
@@ -97,14 +97,14 @@ theorem verticalVRowChain_not_mem_toricDualBoundaries (L : ℕ) [Fact (2 ≤ L)]
 
 /-- The vertical V-row chain has edge-weight `L`. -/
 theorem verticalVRowChain_edgeWeight_eq_L (L : ℕ) [Fact (2 ≤ L)] :
-    Stabilizer.Lattice.edgeWeight (L := L) (verticalVRowChain L) = L := by
+    Stabilizer.Lattice.edgeWeight (verticalVRowChain L) = L := by
   have hL0 : 0 < L := Nat.lt_of_lt_of_le (by decide : 0 < 2) (Fact.out : 2 ≤ L)
   haveI : Fact (0 < L) := ⟨hL0⟩
   let z0 : Fin L := Stabilizer.Lattice.zeroCoord L
   let vertAtZero : Finset (Stabilizer.Lattice.EdgeIdx L) :=
     (Finset.univ.image (fun x : Fin L => Stabilizer.Lattice.EdgeIdx.v x z0))
   have hsupport :
-      Stabilizer.Lattice.edgeSupport (L := L) (verticalVRowChain L) = vertAtZero := by
+      Stabilizer.Lattice.edgeSupport (verticalVRowChain L) = vertAtZero := by
     ext e
     constructor
     · intro he
@@ -142,8 +142,8 @@ theorem verticalVRowChain_edgeWeight_eq_L (L : ℕ) [Fact (2 ≤ L)] :
             exact hinj hab)
       _ = L := by simp
   calc
-    Stabilizer.Lattice.edgeWeight (L := L) (verticalVRowChain L)
-        = (Stabilizer.Lattice.edgeSupport (L := L) (verticalVRowChain L)).card := rfl
+    Stabilizer.Lattice.edgeWeight (verticalVRowChain L)
+        = (Stabilizer.Lattice.edgeSupport (verticalVRowChain L)).card := rfl
     _ = vertAtZero.card := by rw [hsupport]
     _ = L := hcard
 
@@ -274,7 +274,7 @@ theorem nontrivial_z_logical_weight_ge_L (L : ℕ) [Fact (2 ≤ L)]
         c ∉ Stabilizer.Lattice.toricDualBoundaries (L := L) := by
     rw [hc] at hgLogical
     exact (Stabilizer.Lattice.zNontrivialLogical_iff_dualCycle_not_dualBoundary L c).mp hgLogical
-  have h_weight : Stabilizer.Lattice.edgeWeight (L := L) c ≥ L := by
+  have h_weight : Stabilizer.Lattice.edgeWeight c ≥ L := by
     have h_invariant_nonzero :
         Stabilizer.Lattice.hRowAt (L := L) (Stabilizer.Lattice.zeroCoord L) c ≠ 0 ∨
           Stabilizer.Lattice.vColAt (L := L) (Stabilizer.Lattice.zeroCoord L) c ≠ 0 := by
@@ -467,13 +467,13 @@ theorem horizontalHRowChain_not_mem_toricDualBoundaries (L : ℕ) [Fact (2 ≤ L
 
 /-- The horizontal Z-row chain has edge weight `L`. -/
 theorem horizontalHRowChain_edgeWeight_eq_L (L : ℕ) [Fact (2 ≤ L)] :
-    Stabilizer.Lattice.edgeWeight (L := L) (horizontalHRowChain L) = L := by
+    Stabilizer.Lattice.edgeWeight (horizontalHRowChain L) = L := by
   haveI : Fact (0 < L) := ⟨lt_of_lt_of_le (by decide : 0 < 2) Fact.out⟩
   let z0 : Fin L := Stabilizer.Lattice.zeroCoord L
   let horizCol : Finset (Stabilizer.Lattice.EdgeIdx L) :=
     (Finset.univ.image (fun y : Fin L => Stabilizer.Lattice.EdgeIdx.h z0 y))
   have hsupport :
-      Stabilizer.Lattice.edgeSupport (L := L) (horizontalHRowChain L) = horizCol := by
+      Stabilizer.Lattice.edgeSupport (horizontalHRowChain L) = horizCol := by
     ext e
     constructor
     · intro he
@@ -505,8 +505,8 @@ theorem horizontalHRowChain_edgeWeight_eq_L (L : ℕ) [Fact (2 ≤ L)] :
             (by intro a b hab; exact hinj hab)
       _ = L := by simp
   calc
-    Stabilizer.Lattice.edgeWeight (L := L) (horizontalHRowChain L)
-        = (Stabilizer.Lattice.edgeSupport (L := L) (horizontalHRowChain L)).card := rfl
+    Stabilizer.Lattice.edgeWeight (horizontalHRowChain L)
+        = (Stabilizer.Lattice.edgeSupport (horizontalHRowChain L)).card := rfl
     _ = horizCol.card := by rw [hsupport]
     _ = L := hcard
 

--- a/QEC/Stabilizer/Codes/Toric/DistanceZ.lean
+++ b/QEC/Stabilizer/Codes/Toric/DistanceZ.lean
@@ -60,7 +60,7 @@ def verticalVRowZOperator (L : ℕ) [Fact (0 < L)] :
 
 /-- The vertical V-row chain is a dual cycle (commutes with all face stabs). -/
 theorem verticalVRowChain_mem_toricDualCycles (L : ℕ) [Fact (2 ≤ L)] :
-    verticalVRowChain L ∈ Stabilizer.Lattice.toricDualCycles (L := L) := by
+    verticalVRowChain L ∈ Stabilizer.Lattice.toricDualCycles L := by
   have hL0 : 0 < L := Nat.lt_of_lt_of_le (by decide : 0 < 2) (Fact.out : 2 ≤ L)
   haveI : Fact (0 < L) := ⟨hL0⟩
   unfold Stabilizer.Lattice.toricDualCycles
@@ -76,14 +76,14 @@ theorem verticalVRowChain_mem_toricDualCycles (L : ℕ) [Fact (2 ≤ L)] :
 
 /-- The vertical V-row chain is not a dual boundary. -/
 theorem verticalVRowChain_not_mem_toricDualBoundaries (L : ℕ) [Fact (2 ≤ L)] :
-    verticalVRowChain L ∉ Stabilizer.Lattice.toricDualBoundaries (L := L) := by
+    verticalVRowChain L ∉ Stabilizer.Lattice.toricDualBoundaries L := by
   have hL0 : 0 < L := Nat.lt_of_lt_of_le (by decide : 0 < 2) (Fact.out : 2 ≤ L)
   haveI : Fact (0 < L) := ⟨hL0⟩
   intro h
   have h_vColAt : Stabilizer.Lattice.vColAt (L := L) (Stabilizer.Lattice.zeroCoord L)
       (verticalVRowChain L) = 0 :=
     Stabilizer.Lattice.vColAt_dualBoundary_zero L
-      (⟨verticalVRowChain L, h⟩ : Stabilizer.Lattice.toricDualBoundaries (L := L))
+      (⟨verticalVRowChain L, h⟩ : Stabilizer.Lattice.toricDualBoundaries L)
   have h_compute : Stabilizer.Lattice.vColAt (L := L) (Stabilizer.Lattice.zeroCoord L)
       (verticalVRowChain L) = 1 := by
     unfold Stabilizer.Lattice.vColAt verticalVRowChain
@@ -270,8 +270,8 @@ theorem nontrivial_z_logical_weight_ge_L (L : ℕ) [Fact (2 ≤ L)]
         all_goals (try cases hgZ.2 q <;> aesop)
     exact this g hgZ
   have h_dualCycle :
-      c ∈ Stabilizer.Lattice.toricDualCycles (L := L) ∧
-        c ∉ Stabilizer.Lattice.toricDualBoundaries (L := L) := by
+      c ∈ Stabilizer.Lattice.toricDualCycles L ∧
+        c ∉ Stabilizer.Lattice.toricDualBoundaries L := by
     rw [hc] at hgLogical
     exact (Stabilizer.Lattice.zNontrivialLogical_iff_dualCycle_not_dualBoundary L c).mp hgLogical
   have h_weight : Stabilizer.Lattice.edgeWeight c ≥ L := by
@@ -432,7 +432,7 @@ def horizontalHRowZOperator (L : ℕ) [Fact (0 < L)] :
 
 /-- The horizontal Z-row chain is a dual cycle. -/
 theorem horizontalHRowChain_mem_toricDualCycles (L : ℕ) [Fact (2 ≤ L)] :
-    horizontalHRowChain L ∈ Stabilizer.Lattice.toricDualCycles (L := L) := by
+    horizontalHRowChain L ∈ Stabilizer.Lattice.toricDualCycles L := by
   haveI : Fact (0 < L) := ⟨lt_of_lt_of_le (by decide : 0 < 2) Fact.out⟩
   unfold Stabilizer.Lattice.toricDualCycles
   rw [LinearMap.mem_ker]
@@ -447,7 +447,7 @@ theorem horizontalHRowChain_mem_toricDualCycles (L : ℕ) [Fact (2 ≤ L)] :
 
 /-- The horizontal Z-row chain is not a dual boundary (its `hRowAt` invariant is 1). -/
 theorem horizontalHRowChain_not_mem_toricDualBoundaries (L : ℕ) [Fact (2 ≤ L)] :
-    horizontalHRowChain L ∉ Stabilizer.Lattice.toricDualBoundaries (L := L) := by
+    horizontalHRowChain L ∉ Stabilizer.Lattice.toricDualBoundaries L := by
   haveI : Fact (0 < L) := ⟨lt_of_lt_of_le (by decide : 0 < 2) Fact.out⟩
   intro h
   have h_hRowAt : Stabilizer.Lattice.hRowAt (L := L) (Stabilizer.Lattice.zeroCoord L)

--- a/QEC/Stabilizer/Codes/Toric/DualWrappingInvariants.lean
+++ b/QEC/Stabilizer/Codes/Toric/DualWrappingInvariants.lean
@@ -7,6 +7,7 @@ namespace Stabilizer
 namespace Lattice
 
 open scoped BigOperators
+open scoped ToricChain
 
 /-!
 # Dual wrapping invariants for the toric code (Z-type)
@@ -282,20 +283,20 @@ theorem toric_finrank_dualCycles :
   simp_all +decide ;
   have h_dual_boundary_range :
       Module.finrank (ZMod 2) (LinearMap.range (toricDualBoundary L)) =
-        Module.finrank (ZMod 2) (LinearMap.range (toricBoundary2 (L := L))) := by
+        Module.finrank (ZMod 2) (LinearMap.range (∂₂ (L := L))) := by
     have h_dual_boundary :
         LinearMap.rank (toricDualBoundary L) =
-          LinearMap.rank (toricBoundary2 (L := L)) := by
+          LinearMap.rank (∂₂ (L := L)) := by
       have h_dual_boundary :
           (toricDualBoundary L).toMatrix' =
-            (toricBoundary2 (L := L)).toMatrix'.transpose := by
+            (∂₂ (L := L)).toMatrix'.transpose := by
         ext ⟨x, y⟩ e; simp [LinearMap.toMatrix', toricDualBoundary, toricBoundary2];
         cases e <;> simp +decide [ Pi.single_apply ];
         · grind;
         · grind +splitImp
       have h_dual_boundary :
           Matrix.rank (toricDualBoundary L).toMatrix' =
-            Matrix.rank (toricBoundary2 (L := L)).toMatrix' := by
+            Matrix.rank (∂₂ (L := L)).toMatrix' := by
         rw [ h_dual_boundary, Matrix.rank_transpose ];
       convert h_dual_boundary using 1;
       simp +decide [ Matrix.rank, LinearMap.rank ];
@@ -314,10 +315,10 @@ theorem toric_finrank_dualBoundaries :
     Module.finrank (ZMod 2) (toricDualBoundaries (L := L)) = L * L - 1 := by
   -- By definition of `toricDualBoundaries`, we know that it is the range of the vertex cut map.
   have h_dualBoundaries_range :
-      toricDualBoundaries L = LinearMap.range (toricVertexCutMap (L := L)) := by
+      toricDualBoundaries L = LinearMap.range (δ⁰ (L := L)) := by
     exact rfl;
   rw [ h_dualBoundaries_range ];
-  have := LinearMap.finrank_range_add_finrank_ker ( toricVertexCutMap ( L := L ) );
+  have := LinearMap.finrank_range_add_finrank_ker ( δ⁰ ( L := L ) );
   rw [ show Module.finrank ( ZMod 2 ) ( C0 L ) = L * L from ?_ ] at this;
   · refine eq_tsub_of_add_eq ?_;
     convert this;

--- a/QEC/Stabilizer/Codes/Toric/DualWrappingInvariants.lean
+++ b/QEC/Stabilizer/Codes/Toric/DualWrappingInvariants.lean
@@ -7,6 +7,7 @@ namespace Stabilizer
 namespace Lattice
 
 open scoped BigOperators
+open scoped Homology
 open scoped ToricChain
 
 /-!
@@ -70,7 +71,7 @@ theorem vColAt_linear (x0 : Fin L) :
 /-
 `hRowAt` is independent of the chosen row on dual cycles.
 -/
-theorem hRowAt_independent_on_dualCycles (c : toricDualCycles (L := L)) (y0 y1 : Fin L) :
+theorem hRowAt_independent_on_dualCycles (c : Z¹ L) (y0 y1 : Fin L) :
     hRowAt (L := L) y0 c.1 = hRowAt (L := L) y1 c.1 := by
   -- By definition of `toricDualCycles`, we know that `toricDualBoundary L c = 0`.
   have h_dual_boundary_zero : toricDualBoundary L c.1 = 0 := by
@@ -111,7 +112,7 @@ theorem hRowAt_independent_on_dualCycles (c : toricDualCycles (L := L)) (y0 y1 :
 /-
 `vColAt` is independent of the chosen column on dual cycles.
 -/
-theorem vColAt_independent_on_dualCycles (c : toricDualCycles (L := L)) (x0 x1 : Fin L) :
+theorem vColAt_independent_on_dualCycles (c : Z¹ L) (x0 x1 : Fin L) :
     vColAt (L := L) x0 c.1 = vColAt (L := L) x1 c.1 := by
   have hvColAt_linear : ∀ x : Fin L,
       vColAt (L := L) x c.1 + vColAt (L := L) (next L x) c.1 = 0 := by
@@ -161,7 +162,7 @@ theorem vColAt_independent_on_dualCycles (c : toricDualCycles (L := L)) (x0 x1 :
 
 Dual boundaries have trivial `hRowAt` invariant.
 -/
-theorem hRowAt_dualBoundary_zero (b : toricDualBoundaries (L := L)) :
+theorem hRowAt_dualBoundary_zero (b : B¹ L) :
     hRowAt (L := L) (zeroCoord L) b.1 = 0 := by
   rcases b with ⟨ b, ⟨ s, rfl ⟩ ⟩;
   unfold hRowAt toricVertexCutMap;
@@ -175,7 +176,7 @@ theorem hRowAt_dualBoundary_zero (b : toricDualBoundaries (L := L)) :
 /-
 Dual boundaries have trivial `vColAt` invariant.
 -/
-theorem vColAt_dualBoundary_zero (b : toricDualBoundaries (L := L)) :
+theorem vColAt_dualBoundary_zero (b : B¹ L) :
     vColAt (L := L) (zeroCoord L) b.1 = 0 := by
   rcases b with ⟨ b, hb ⟩;
   obtain ⟨ s, rfl ⟩ := hb;
@@ -198,18 +199,18 @@ theorem vColAt_dualBoundary_zero (b : toricDualBoundaries (L := L)) :
 
 /-- Dual homology quotient: toricDualCycles / toricDualBoundaries (as submodule in cycles). -/
 noncomputable abbrev toricDualBoundarySubmoduleInCycles :
-    Submodule (ZMod 2) (toricDualCycles (L := L)) :=
-  Submodule.comap (toricDualCycles (L := L)).subtype (toricDualBoundaries (L := L))
+    Submodule (ZMod 2) (Z¹ L) :=
+  Submodule.comap (Z¹ L).subtype (B¹ L)
 
 /-- The dual H¹ quotient type. -/
 abbrev toricDualH1 : Type :=
-  toricDualCycles (L := L) ⧸ toricDualBoundarySubmoduleInCycles (L := L)
+  Z¹ L ⧸ toricDualBoundarySubmoduleInCycles (L := L)
 
 /-- Quotient-level map `(hRowAt, vColAt)` on dual cycles, well-defined modulo dual boundaries. -/
 noncomputable def phiDual : toricDualH1 (L := L) → ZMod 2 × ZMod 2 :=
-  let N : Submodule (ZMod 2) (toricDualCycles (L := L)) :=
-    Submodule.comap (toricDualCycles (L := L)).subtype (toricDualBoundaries (L := L))
-  let phiDualLin : toricDualCycles (L := L) →ₗ[ZMod 2] ZMod 2 × ZMod 2 :=
+  let N : Submodule (ZMod 2) (Z¹ L) :=
+    Submodule.comap (Z¹ L).subtype (B¹ L)
+  let phiDualLin : Z¹ L →ₗ[ZMod 2] ZMod 2 × ZMod 2 :=
     { toFun := fun c => (hRowAt (L := L) (zeroCoord L) c.1, vColAt (L := L) (zeroCoord L) c.1)
       map_add' := fun a b => by
         simp only [Submodule.coe_add]
@@ -227,7 +228,7 @@ noncomputable def phiDual : toricDualH1 (L := L) → ZMod 2 × ZMod 2 :=
     exact Prod.ext hh hv)
 
 /-- `phiDual` agrees with the underlying linear lift on equivalence classes. -/
-theorem phiDual_liftQ_eq (c : toricDualCycles (L := L)) :
+theorem phiDual_liftQ_eq (c : Z¹ L) :
     phiDual (L := L) (Submodule.Quotient.mk c) =
       (hRowAt (L := L) (zeroCoord L) c.1, vColAt (L := L) (zeroCoord L) c.1) := by
   simp only [phiDual, Submodule.liftQ_apply, LinearMap.coe_mk, AddHom.coe_mk]
@@ -244,7 +245,7 @@ theorem phiDual_surjective :
   intro p
   obtain ⟨a, b⟩ := p
   generalize_proofs at *;
-  obtain ⟨c, hc⟩ : ∃ c : toricDualCycles (L := L),
+  obtain ⟨c, hc⟩ : ∃ c : Z¹ L,
       hRowAt (L := L) (zeroCoord L) c.1 = a ∧
         vColAt (L := L) (zeroCoord L) c.1 = b := by
     -- Define the chain $c$ such that it has $a$ horizontal edges and $b$ vertical edges.
@@ -278,12 +279,12 @@ theorem phiDual_surjective :
 Dimension of the dual cycle space.
 -/
 theorem toric_finrank_dualCycles :
-    Module.finrank (ZMod 2) (toricDualCycles (L := L)) = L * L + 1 := by
+    dim₂ (Z¹ L) = L * L + 1 := by
   have := LinearMap.finrank_range_add_finrank_ker ( toricDualBoundary L ) ;
   simp_all +decide ;
   have h_dual_boundary_range :
-      Module.finrank (ZMod 2) (LinearMap.range (toricDualBoundary L)) =
-        Module.finrank (ZMod 2) (LinearMap.range (∂₂ (L := L))) := by
+      dim₂ (LinearMap.range (toricDualBoundary L)) =
+        dim₂ (LinearMap.range (∂₂ (L := L))) := by
     have h_dual_boundary :
         LinearMap.rank (toricDualBoundary L) =
           LinearMap.rank (∂₂ (L := L)) := by
@@ -312,10 +313,10 @@ theorem toric_finrank_dualCycles :
 Dimension of the dual boundary space.
 -/
 theorem toric_finrank_dualBoundaries :
-    Module.finrank (ZMod 2) (toricDualBoundaries (L := L)) = L * L - 1 := by
+    dim₂ (B¹ L) = L * L - 1 := by
   -- By definition of `toricDualBoundaries`, we know that it is the range of the vertex cut map.
   have h_dualBoundaries_range :
-      toricDualBoundaries L = LinearMap.range (δ⁰ (L := L)) := by
+      B¹ L = LinearMap.range (δ⁰ (L := L)) := by
     exact rfl;
   rw [ h_dualBoundaries_range ];
   have := LinearMap.finrank_range_add_finrank_ker ( δ⁰ ( L := L ) );
@@ -327,8 +328,8 @@ theorem toric_finrank_dualBoundaries :
 
 /-- `phiDual` as an explicit linear map (for injectivity via dimension count). -/
 noncomputable def phiDualLinearMap :
-    (toricDualCycles (L := L) ⧸
-      Submodule.comap (toricDualCycles (L := L)).subtype (toricDualBoundaries (L := L))) →ₗ[ZMod 2]
+    (Z¹ L ⧸
+      Submodule.comap (Z¹ L).subtype (B¹ L)) →ₗ[ZMod 2]
     ZMod 2 × ZMod 2 :=
   Submodule.liftQ _ {
     toFun := fun c => (hRowAt (L := L) (zeroCoord L) c.1, vColAt (L := L) (zeroCoord L) c.1)
@@ -342,7 +343,7 @@ noncomputable def phiDualLinearMap :
   } (by
     intro c hc
     simp only [LinearMap.mem_ker]
-    have hc' : c.1 ∈ toricDualBoundaries (L := L) := by
+    have hc' : c.1 ∈ B¹ L := by
       rwa [Submodule.mem_comap] at hc
     have hh := hRowAt_dualBoundary_zero (L := L) ⟨c.1, hc'⟩
     have hv := vColAt_dualBoundary_zero (L := L) ⟨c.1, hc'⟩
@@ -358,10 +359,10 @@ theorem phiDual_eq_phiDualLinearMap (x : toricDualH1 (L := L)) :
 -/
 theorem phiDual_injective :
     Function.Injective (phiDual (L := L)) := by
-  have h_finrank : Module.finrank (ZMod 2) (toricDualH1 (L := L)) = 2 := by
+  have h_finrank : dim₂ (toricDualH1 (L := L)) = 2 := by
     have h_finrank :
-        Module.finrank (ZMod 2) (toricDualCycles (L := L)) -
-          Module.finrank (ZMod 2) (toricDualBoundaries (L := L)) = 2 := by
+        dim₂ (Z¹ L) -
+          dim₂ (B¹ L) = 2 := by
       rw [ toric_finrank_dualCycles, toric_finrank_dualBoundaries ];
       exact Nat.sub_eq_of_eq_add <| by
         linarith [ Nat.sub_add_cancel <|
@@ -378,7 +379,7 @@ theorem phiDual_injective :
     · exact le_of_lt ( Nat.lt_of_sub_eq_succ h_finrank );
   have := @phiDual_surjective L ‹_›;
   have h_finrank :
-      Module.finrank (ZMod 2) (↥(LinearMap.range (phiDualLinearMap (L := L)))) = 2 := by
+      dim₂ (↥(LinearMap.range (phiDualLinearMap (L := L)))) = 2 := by
     rw [ LinearMap.range_eq_top.mpr ] <;> norm_num [ this ];
     convert this using 1;
   have := LinearMap.finrank_range_add_finrank_ker ( phiDualLinearMap ( L := L ) ) ;

--- a/QEC/Stabilizer/Codes/Toric/H1Dimension.lean
+++ b/QEC/Stabilizer/Codes/Toric/H1Dimension.lean
@@ -280,18 +280,18 @@ theorem toric_rank_boundary1 :
   have hcut_rk :
       dim₂ (LinearMap.range (δ⁰ (L := L))) = L * L - 1 := by
     have hcut_rn := LinearMap.finrank_range_add_finrank_ker (δ⁰ (L := L))
-    have hC0 := toric_finrank_C0 (L := L)
-    have hker := toric_finrank_ker_cutMap_eq_one (L := L)
+    have hC0 := toric_finrank_C0 L
+    have hker := toric_finrank_ker_cutMap_eq_one L
     omega
-  have hbridge := toric_rank_boundary1_eq_rank_cutMap (L := L)
+  have hbridge := toric_rank_boundary1_eq_rank_cutMap L
   omega
 
 /-- Target cycle-space dimension formula. -/
 theorem toric_finrank_cycles :
     dim₂ (Z₁ L) = L * L + 1 := by
-  have hrn := toric_rank_nullity_boundary1 (L := L)
-  have hC1 := toric_finrank_C1 (L := L)
-  have hrk := toric_rank_boundary1 (L := L)
+  have hrn := toric_rank_nullity_boundary1 L
+  have hC1 := toric_finrank_C1 L
+  have hrk := toric_rank_boundary1 L
   rw [hC1, hrk] at hrn
   have hEq : dim₂ (Z₁ L) + (L * L - 1) = 2 * L * L := by
     simpa [add_comm, add_left_comm, add_assoc] using hrn.symm
@@ -393,34 +393,34 @@ theorem toric_finrank_ker_boundary2_eq_one :
 /-- Target boundary-space dimension formula. -/
 theorem toric_finrank_boundaries :
     dim₂ (B₁ L) = L * L - 1 := by
-  have hrn := toric_rank_nullity_boundary2 (L := L)
-  have hC2 := toric_finrank_C2 (L := L)
-  have hker := toric_finrank_ker_boundary2_eq_one (L := L)
+  have hrn := toric_rank_nullity_boundary2 L
+  have hC2 := toric_finrank_C2 L
+  have hker := toric_finrank_ker_boundary2_eq_one L
   omega
 
 /-- Quotient-dimension bridge for `H₁ = Z₁ / B₁`. -/
 theorem toric_finrank_H1_eq_cycles_sub_boundaries
     :
     @Module.finrank (ZMod 2) (H₁ L) _
-      (Submodule.Quotient.addCommGroup (toricBoundarySubmoduleInCycles (L := L))).toAddCommMonoid
-      (Submodule.Quotient.module (toricBoundarySubmoduleInCycles (L := L))) =
+      (Submodule.Quotient.addCommGroup (toricBoundarySubmoduleInCycles L)).toAddCommMonoid
+      (Submodule.Quotient.module (toricBoundarySubmoduleInCycles L)) =
       dim₂ (Z₁ L) -
         dim₂ (B₁ L) := by
   have hquot :
       @Module.finrank (ZMod 2) (H₁ L) _
           (Submodule.Quotient.addCommGroup
-            (toricBoundarySubmoduleInCycles (L := L))).toAddCommMonoid
-          (Submodule.Quotient.module (toricBoundarySubmoduleInCycles (L := L))) +
-          dim₂ (toricBoundarySubmoduleInCycles (L := L)) =
+            (toricBoundarySubmoduleInCycles L)).toAddCommMonoid
+          (Submodule.Quotient.module (toricBoundarySubmoduleInCycles L)) +
+          dim₂ (toricBoundarySubmoduleInCycles L) =
         dim₂ (Z₁ L) := by
     simpa [toricH1, toricBoundarySubmoduleInCycles] using
       (Submodule.finrank_quotient_add_finrank (R := ZMod 2)
-        (toricBoundarySubmoduleInCycles (L := L)))
+        (toricBoundarySubmoduleInCycles L))
   have hcomap :
-      dim₂ (toricBoundarySubmoduleInCycles (L := L)) =
+      dim₂ (toricBoundarySubmoduleInCycles L) =
         dim₂ (B₁ L) := by
     simpa [toricBoundarySubmoduleInCycles] using
-      (Submodule.comapSubtypeEquivOfLe (toric_boundaries_le_cycles (L := L))).finrank_eq
+      (Submodule.comapSubtypeEquivOfLe (toric_boundaries_le_cycles L)).finrank_eq
   rw [hcomap] at hquot
   exact Nat.eq_sub_of_add_eq hquot
 
@@ -428,11 +428,11 @@ theorem toric_finrank_H1_eq_cycles_sub_boundaries
 theorem toric_finrank_H1_eq_two
     :
     @Module.finrank (ZMod 2) (H₁ L) _
-      (Submodule.Quotient.addCommGroup (toricBoundarySubmoduleInCycles (L := L))).toAddCommMonoid
-      (Submodule.Quotient.module (toricBoundarySubmoduleInCycles (L := L))) = 2 := by
-  have hH := toric_finrank_H1_eq_cycles_sub_boundaries (L := L)
-  have hC := toric_finrank_cycles (L := L)
-  have hB := toric_finrank_boundaries (L := L)
+      (Submodule.Quotient.addCommGroup (toricBoundarySubmoduleInCycles L)).toAddCommMonoid
+      (Submodule.Quotient.module (toricBoundarySubmoduleInCycles L)) = 2 := by
+  have hH := toric_finrank_H1_eq_cycles_sub_boundaries L
+  have hC := toric_finrank_cycles L
+  have hB := toric_finrank_boundaries L
   rw [hC, hB] at hH
   have hsq : 1 ≤ L * L := by
     have hL : 0 < L := Fact.out

--- a/QEC/Stabilizer/Codes/Toric/H1Dimension.lean
+++ b/QEC/Stabilizer/Codes/Toric/H1Dimension.lean
@@ -7,6 +7,7 @@ namespace Stabilizer
 namespace Lattice
 
 open scoped BigOperators
+open scoped ToricChain
 
 variable (L : ℕ) [Fact (0 < L)]
 
@@ -50,17 +51,17 @@ theorem toric_boundaries_le_cycles :
 theorem toric_rank_nullity_boundary1 :
     Module.finrank (ZMod 2) (C1 L) =
       Module.finrank (ZMod 2) (toricCycles (L := L)) +
-        Module.finrank (ZMod 2) (LinearMap.range (toricBoundary1 (L := L))) := by
+        Module.finrank (ZMod 2) (LinearMap.range (∂₁ (L := L))) := by
   simpa [toricCycles, add_comm, add_left_comm, add_assoc] using
-    (LinearMap.finrank_range_add_finrank_ker (toricBoundary1 (L := L))).symm
+    (LinearMap.finrank_range_add_finrank_ker (∂₁ (L := L))).symm
 
 /-- Rank-nullity specialization for `∂₂`. -/
 theorem toric_rank_nullity_boundary2 :
     Module.finrank (ZMod 2) (C2 L) =
-      Module.finrank (ZMod 2) (LinearMap.ker (toricBoundary2 (L := L))) +
+      Module.finrank (ZMod 2) (LinearMap.ker (∂₂ (L := L))) +
         Module.finrank (ZMod 2) (toricBoundaries (L := L)) := by
   simpa [toricBoundaries, add_comm, add_left_comm, add_assoc] using
-    (LinearMap.finrank_range_add_finrank_ker (toricBoundary2 (L := L))).symm
+    (LinearMap.finrank_range_add_finrank_ker (∂₂ (L := L))).symm
 
 /-- The vertex cut map: sends a 0-chain `s` to the 1-chain whose value at edge `e`
 is the parity-difference of `s` at the two endpoints of `e`. This is the transpose
@@ -82,24 +83,29 @@ noncomputable def toricVertexCutMap : C0 L →ₗ[ZMod 2] C1 L := by
     ext e
     cases e <;> simp [mul_add]
 
+/-- `δ⁰` is the toric vertex cut map `toricVertexCutMap : C0 L →ₗ[ZMod 2] C1 L` (the
+transpose of `∂₁`, i.e. the coboundary `C⁰ → C¹`), with the lattice size explicit:
+`δ⁰ L s`. Scoped: `open scoped ToricChain`. -/
+scoped[ToricChain] notation "δ⁰" => Quantum.Stabilizer.Lattice.toricVertexCutMap
+
 /-
 The pairing ⟨∂₁ c, s⟩ = ⟨c, cutMap s⟩, showing ∂₁ and cutMap are transposes.
 -/
 set_option maxHeartbeats 400000 in
 -- This transpose-expansion proof is algebra-heavy and needs extra heartbeats.
 theorem toricBoundary1_cutMap_transpose (c : C1 L) (s : C0 L) :
-    ∑ v : VtxIdx L, toricBoundary1 (L := L) c v * s v =
-    ∑ e : EdgeIdx L, c e * toricVertexCutMap (L := L) s e := by
+    ∑ v : VtxIdx L, ∂₁ (L := L) c v * s v =
+    ∑ e : EdgeIdx L, c e * δ⁰ (L := L) s e := by
   -- Expand both sides using the definitions.
   have h_expand_lhs :
-      ∑ v : Fin L × Fin L, (toricBoundary1 L c v) * s v =
+      ∑ v : Fin L × Fin L, (∂₁ L c v) * s v =
         ∑ v : Fin L × Fin L,
           (c (EdgeIdx.h v.1 v.2) + c (EdgeIdx.h (prev L v.1) v.2) +
             c (EdgeIdx.v v.1 v.2) + c (EdgeIdx.v v.1 (prev L v.2))) * s v := by
     rfl
   generalize_proofs at *; (
   have h_expand_rhs :
-      ∑ e : EdgeIdx L, c e * (toricVertexCutMap L s e) =
+      ∑ e : EdgeIdx L, c e * (δ⁰ L s e) =
         ∑ x : Fin L, ∑ y : Fin L,
           (c (EdgeIdx.h x y) * (s (x, y) + s (next L x, y)) +
             c (EdgeIdx.v x y) * (s (x, y) + s (x, next L y))) := by
@@ -153,8 +159,8 @@ theorem toricBoundary1_cutMap_transpose (c : C1 L) (s : C0 L) :
 
 /-- `∂₁` and `toricVertexCutMap` are mutual transposes, so they have equal rank. -/
 theorem toric_rank_boundary1_eq_rank_cutMap :
-    Module.finrank (ZMod 2) (LinearMap.range (toricBoundary1 (L := L))) =
-      Module.finrank (ZMod 2) (LinearMap.range (toricVertexCutMap (L := L))) := by
+    Module.finrank (ZMod 2) (LinearMap.range (∂₁ (L := L))) =
+      Module.finrank (ZMod 2) (LinearMap.range (δ⁰ (L := L))) := by
   rw [ ← LinearMap.finrank_range_dualMap_eq_finrank_range ];
   fapply LinearEquiv.finrank_eq;
   symm;
@@ -194,7 +200,7 @@ theorem toric_rank_boundary1_eq_rank_cutMap :
 
 /-- The kernel of the toric vertex cut map consists exactly of the constant 0-chains. -/
 theorem mem_ker_cutMap_iff (s : C0 L) :
-    s ∈ LinearMap.ker (toricVertexCutMap (L := L)) ↔ ∃ c : ZMod 2, s = fun _ => c := by
+    s ∈ LinearMap.ker (δ⁰ (L := L)) ↔ ∃ c : ZMod 2, s = fun _ => c := by
   constructor
   · intro hs
     have h_const : ∀ x y : Fin L, s (x, y) = s (next L x, y) ∧ s (x, y) = s (x, next L y) := by
@@ -252,7 +258,7 @@ theorem mem_ker_cutMap_iff (s : C0 L) :
 
 /-- The kernel of the toric vertex cut map equals `span{constant 1}`. -/
 theorem ker_toricVertexCutMap_eq_span_one :
-    LinearMap.ker (toricVertexCutMap (L := L)) =
+    LinearMap.ker (δ⁰ (L := L)) =
       Submodule.span (ZMod 2) ({fun _ => 1} : Set (C0 L)) := by
   ext s
   rw [mem_ker_cutMap_iff, Submodule.mem_span_singleton]
@@ -262,16 +268,16 @@ theorem ker_toricVertexCutMap_eq_span_one :
 
 /-- Kernel-dimension result for the cut-map connectivity argument. -/
 theorem toric_finrank_ker_cutMap_eq_one :
-    Module.finrank (ZMod 2) (LinearMap.ker (toricVertexCutMap (L := L))) = 1 := by
+    Module.finrank (ZMod 2) (LinearMap.ker (δ⁰ (L := L))) = 1 := by
   rw [ker_toricVertexCutMap_eq_span_one, finrank_span_singleton]
   exact fun h => by simpa using congr_fun h (⟨0, Fact.out⟩, ⟨0, Fact.out⟩)
 
 /-- Target rank formula for `∂₁`. -/
 theorem toric_rank_boundary1 :
-    Module.finrank (ZMod 2) (LinearMap.range (toricBoundary1 (L := L))) = L * L - 1 := by
+    Module.finrank (ZMod 2) (LinearMap.range (∂₁ (L := L))) = L * L - 1 := by
   have hcut_rk :
-      Module.finrank (ZMod 2) (LinearMap.range (toricVertexCutMap (L := L))) = L * L - 1 := by
-    have hcut_rn := LinearMap.finrank_range_add_finrank_ker (toricVertexCutMap (L := L))
+      Module.finrank (ZMod 2) (LinearMap.range (δ⁰ (L := L))) = L * L - 1 := by
+    have hcut_rn := LinearMap.finrank_range_add_finrank_ker (δ⁰ (L := L))
     have hC0 := toric_finrank_C0 (L := L)
     have hker := toric_finrank_ker_cutMap_eq_one (L := L)
     omega
@@ -304,7 +310,7 @@ theorem toric_finrank_cycles :
 
 /-- The kernel of `∂₂` consists exactly of the constant 2-chains. -/
 theorem mem_ker_boundary2_iff (f : C2 L) :
-    f ∈ LinearMap.ker (toricBoundary2 (L := L)) ↔ ∃ c : ZMod 2, f = fun _ => c := by
+    f ∈ LinearMap.ker (∂₂ (L := L)) ↔ ∃ c : ZMod 2, f = fun _ => c := by
   constructor
   · intro hf
     have h_const : ∀ x y, f (x, next L y) = f (x, y) := by
@@ -368,7 +374,7 @@ theorem mem_ker_boundary2_iff (f : C2 L) :
 
 /-- The kernel of `∂₂` equals `span{constant 1}`. -/
 theorem ker_toricBoundary2_eq_span_one :
-    LinearMap.ker (toricBoundary2 (L := L)) =
+    LinearMap.ker (∂₂ (L := L)) =
       Submodule.span (ZMod 2) ({fun _ => 1} : Set (C2 L)) := by
   ext f
   rw [mem_ker_boundary2_iff, Submodule.mem_span_singleton]
@@ -378,7 +384,7 @@ theorem ker_toricBoundary2_eq_span_one :
 
 /-- Kernel-dimension result for `∂₂`. -/
 theorem toric_finrank_ker_boundary2_eq_one :
-    Module.finrank (ZMod 2) (LinearMap.ker (toricBoundary2 (L := L))) = 1 := by
+    Module.finrank (ZMod 2) (LinearMap.ker (∂₂ (L := L))) = 1 := by
   rw [ker_toricBoundary2_eq_span_one, finrank_span_singleton]
   exact fun h => by simpa using congr_fun h (⟨0, Fact.out⟩, ⟨0, Fact.out⟩)
 

--- a/QEC/Stabilizer/Codes/Toric/H1Dimension.lean
+++ b/QEC/Stabilizer/Codes/Toric/H1Dimension.lean
@@ -1,5 +1,6 @@
 import Mathlib.Tactic
 import QEC.Stabilizer.Codes.Toric.Homology
+import QEC.Stabilizer.Framework.Homological.Code
 
 
 namespace Quantum
@@ -7,59 +8,60 @@ namespace Stabilizer
 namespace Lattice
 
 open scoped BigOperators
+open scoped Homology
 open scoped ToricChain
 
 variable (L : ℕ) [Fact (0 < L)]
 
 /-- The boundary submodule viewed inside the cycle submodule (`B₁` as a submodule of `Z₁`). -/
-abbrev toricBoundarySubmoduleInCycles : Submodule (ZMod 2) (toricCycles (L := L)) :=
-  Submodule.comap (toricCycles (L := L)).subtype (toricBoundaries (L := L))
+abbrev toricBoundarySubmoduleInCycles : Submodule (ZMod 2) (Z₁ L) :=
+  Submodule.comap (Z₁ L).subtype (B₁ L)
 
 /-- Finrank of the toric 0-chain space. -/
 theorem toric_finrank_C0 :
-    Module.finrank (ZMod 2) (C0 L) = L * L := by
+    dim₂ (C0 L) = L * L := by
   let _ := (Fact.out : 0 < L)
   calc
-    Module.finrank (ZMod 2) (C0 L) = Fintype.card (VtxIdx L) := by
+    dim₂ (C0 L) = Fintype.card (VtxIdx L) := by
       exact Module.finrank_fintype_fun_eq_card (R := ZMod 2) (η := VtxIdx L)
     _ = L * L := by simp
 
 /-- Finrank of the toric 1-chain space. -/
 theorem toric_finrank_C1 :
-    Module.finrank (ZMod 2) (C1 L) = 2 * L * L := by
+    dim₂ (C1 L) = 2 * L * L := by
   let _ := (Fact.out : 0 < L)
   calc
-    Module.finrank (ZMod 2) (C1 L) = Fintype.card (EdgeIdx L) := by
+    dim₂ (C1 L) = Fintype.card (EdgeIdx L) := by
       exact Module.finrank_fintype_fun_eq_card (R := ZMod 2) (η := EdgeIdx L)
     _ = 2 * L * L := by simp
 
 /-- Finrank of the toric 2-chain space. -/
 theorem toric_finrank_C2 :
-    Module.finrank (ZMod 2) (C2 L) = L * L := by
+    dim₂ (C2 L) = L * L := by
   let _ := (Fact.out : 0 < L)
   calc
-    Module.finrank (ZMod 2) (C2 L) = Fintype.card (FaceIdx L) := by
+    dim₂ (C2 L) = Fintype.card (FaceIdx L) := by
       exact Module.finrank_fintype_fun_eq_card (R := ZMod 2) (η := FaceIdx L)
     _ = L * L := by simp
 
 /-- `B₁ ≤ Z₁` for the toric chain complex. -/
 theorem toric_boundaries_le_cycles :
-    toricBoundaries (L := L) ≤ toricCycles (L := L) := by
-  simpa using toricBoundaries_le_toricCycles (L := L)
+    B₁ L ≤ Z₁ L := by
+  simpa using toricBoundaries_le_toricCycles L
 
 /-- Rank-nullity specialization for `∂₁`. -/
 theorem toric_rank_nullity_boundary1 :
-    Module.finrank (ZMod 2) (C1 L) =
-      Module.finrank (ZMod 2) (toricCycles (L := L)) +
-        Module.finrank (ZMod 2) (LinearMap.range (∂₁ (L := L))) := by
+    dim₂ (C1 L) =
+      dim₂ (Z₁ L) +
+        dim₂ (LinearMap.range (∂₁ (L := L))) := by
   simpa [toricCycles, add_comm, add_left_comm, add_assoc] using
     (LinearMap.finrank_range_add_finrank_ker (∂₁ (L := L))).symm
 
 /-- Rank-nullity specialization for `∂₂`. -/
 theorem toric_rank_nullity_boundary2 :
-    Module.finrank (ZMod 2) (C2 L) =
-      Module.finrank (ZMod 2) (LinearMap.ker (∂₂ (L := L))) +
-        Module.finrank (ZMod 2) (toricBoundaries (L := L)) := by
+    dim₂ (C2 L) =
+      dim₂ (LinearMap.ker (∂₂ (L := L))) +
+        dim₂ (B₁ L) := by
   simpa [toricBoundaries, add_comm, add_left_comm, add_assoc] using
     (LinearMap.finrank_range_add_finrank_ker (∂₂ (L := L))).symm
 
@@ -159,8 +161,8 @@ theorem toricBoundary1_cutMap_transpose (c : C1 L) (s : C0 L) :
 
 /-- `∂₁` and `toricVertexCutMap` are mutual transposes, so they have equal rank. -/
 theorem toric_rank_boundary1_eq_rank_cutMap :
-    Module.finrank (ZMod 2) (LinearMap.range (∂₁ (L := L))) =
-      Module.finrank (ZMod 2) (LinearMap.range (δ⁰ (L := L))) := by
+    dim₂ (LinearMap.range (∂₁ (L := L))) =
+      dim₂ (LinearMap.range (δ⁰ (L := L))) := by
   rw [ ← LinearMap.finrank_range_dualMap_eq_finrank_range ];
   fapply LinearEquiv.finrank_eq;
   symm;
@@ -268,15 +270,15 @@ theorem ker_toricVertexCutMap_eq_span_one :
 
 /-- Kernel-dimension result for the cut-map connectivity argument. -/
 theorem toric_finrank_ker_cutMap_eq_one :
-    Module.finrank (ZMod 2) (LinearMap.ker (δ⁰ (L := L))) = 1 := by
+    dim₂ (LinearMap.ker (δ⁰ (L := L))) = 1 := by
   rw [ker_toricVertexCutMap_eq_span_one, finrank_span_singleton]
   exact fun h => by simpa using congr_fun h (⟨0, Fact.out⟩, ⟨0, Fact.out⟩)
 
 /-- Target rank formula for `∂₁`. -/
 theorem toric_rank_boundary1 :
-    Module.finrank (ZMod 2) (LinearMap.range (∂₁ (L := L))) = L * L - 1 := by
+    dim₂ (LinearMap.range (∂₁ (L := L))) = L * L - 1 := by
   have hcut_rk :
-      Module.finrank (ZMod 2) (LinearMap.range (δ⁰ (L := L))) = L * L - 1 := by
+      dim₂ (LinearMap.range (δ⁰ (L := L))) = L * L - 1 := by
     have hcut_rn := LinearMap.finrank_range_add_finrank_ker (δ⁰ (L := L))
     have hC0 := toric_finrank_C0 (L := L)
     have hker := toric_finrank_ker_cutMap_eq_one (L := L)
@@ -286,12 +288,12 @@ theorem toric_rank_boundary1 :
 
 /-- Target cycle-space dimension formula. -/
 theorem toric_finrank_cycles :
-    Module.finrank (ZMod 2) (toricCycles (L := L)) = L * L + 1 := by
+    dim₂ (Z₁ L) = L * L + 1 := by
   have hrn := toric_rank_nullity_boundary1 (L := L)
   have hC1 := toric_finrank_C1 (L := L)
   have hrk := toric_rank_boundary1 (L := L)
   rw [hC1, hrk] at hrn
-  have hEq : Module.finrank (ZMod 2) (toricCycles (L := L)) + (L * L - 1) = 2 * L * L := by
+  have hEq : dim₂ (Z₁ L) + (L * L - 1) = 2 * L * L := by
     simpa [add_comm, add_left_comm, add_assoc] using hrn.symm
   have hsq : 1 ≤ L * L := by
     have hL : 0 < L := Fact.out
@@ -303,7 +305,7 @@ theorem toric_finrank_cycles :
       _ = (L * L) + (L * L) := by
         rw [Nat.sub_add_cancel hsq]
       _ = 2 * L * L := by ring
-  have : Module.finrank (ZMod 2) (toricCycles (L := L)) + (L * L - 1) =
+  have : dim₂ (Z₁ L) + (L * L - 1) =
       (L * L + 1) + (L * L - 1) := by
     exact hEq.trans hsplit.symm
   exact Nat.add_right_cancel this
@@ -384,13 +386,13 @@ theorem ker_toricBoundary2_eq_span_one :
 
 /-- Kernel-dimension result for `∂₂`. -/
 theorem toric_finrank_ker_boundary2_eq_one :
-    Module.finrank (ZMod 2) (LinearMap.ker (∂₂ (L := L))) = 1 := by
+    dim₂ (LinearMap.ker (∂₂ (L := L))) = 1 := by
   rw [ker_toricBoundary2_eq_span_one, finrank_span_singleton]
   exact fun h => by simpa using congr_fun h (⟨0, Fact.out⟩, ⟨0, Fact.out⟩)
 
 /-- Target boundary-space dimension formula. -/
 theorem toric_finrank_boundaries :
-    Module.finrank (ZMod 2) (toricBoundaries (L := L)) = L * L - 1 := by
+    dim₂ (B₁ L) = L * L - 1 := by
   have hrn := toric_rank_nullity_boundary2 (L := L)
   have hC2 := toric_finrank_C2 (L := L)
   have hker := toric_finrank_ker_boundary2_eq_one (L := L)
@@ -399,24 +401,24 @@ theorem toric_finrank_boundaries :
 /-- Quotient-dimension bridge for `H₁ = Z₁ / B₁`. -/
 theorem toric_finrank_H1_eq_cycles_sub_boundaries
     :
-    @Module.finrank (ZMod 2) (toricH1 (L := L)) _
+    @Module.finrank (ZMod 2) (H₁ L) _
       (Submodule.Quotient.addCommGroup (toricBoundarySubmoduleInCycles (L := L))).toAddCommMonoid
       (Submodule.Quotient.module (toricBoundarySubmoduleInCycles (L := L))) =
-      Module.finrank (ZMod 2) (toricCycles (L := L)) -
-        Module.finrank (ZMod 2) (toricBoundaries (L := L)) := by
+      dim₂ (Z₁ L) -
+        dim₂ (B₁ L) := by
   have hquot :
-      @Module.finrank (ZMod 2) (toricH1 (L := L)) _
+      @Module.finrank (ZMod 2) (H₁ L) _
           (Submodule.Quotient.addCommGroup
             (toricBoundarySubmoduleInCycles (L := L))).toAddCommMonoid
           (Submodule.Quotient.module (toricBoundarySubmoduleInCycles (L := L))) +
-          Module.finrank (ZMod 2) (toricBoundarySubmoduleInCycles (L := L)) =
-        Module.finrank (ZMod 2) (toricCycles (L := L)) := by
+          dim₂ (toricBoundarySubmoduleInCycles (L := L)) =
+        dim₂ (Z₁ L) := by
     simpa [toricH1, toricBoundarySubmoduleInCycles] using
       (Submodule.finrank_quotient_add_finrank (R := ZMod 2)
         (toricBoundarySubmoduleInCycles (L := L)))
   have hcomap :
-      Module.finrank (ZMod 2) (toricBoundarySubmoduleInCycles (L := L)) =
-        Module.finrank (ZMod 2) (toricBoundaries (L := L)) := by
+      dim₂ (toricBoundarySubmoduleInCycles (L := L)) =
+        dim₂ (B₁ L) := by
     simpa [toricBoundarySubmoduleInCycles] using
       (Submodule.comapSubtypeEquivOfLe (toric_boundaries_le_cycles (L := L))).finrank_eq
   rw [hcomap] at hquot
@@ -425,7 +427,7 @@ theorem toric_finrank_H1_eq_cycles_sub_boundaries
 /-- `dim(H₁) = 2` for the toric chain complex over `ZMod 2`. -/
 theorem toric_finrank_H1_eq_two
     :
-    @Module.finrank (ZMod 2) (toricH1 (L := L)) _
+    @Module.finrank (ZMod 2) (H₁ L) _
       (Submodule.Quotient.addCommGroup (toricBoundarySubmoduleInCycles (L := L))).toAddCommMonoid
       (Submodule.Quotient.module (toricBoundarySubmoduleInCycles (L := L))) = 2 := by
   have hH := toric_finrank_H1_eq_cycles_sub_boundaries (L := L)

--- a/QEC/Stabilizer/Codes/Toric/Homology.lean
+++ b/QEC/Stabilizer/Codes/Toric/Homology.lean
@@ -5,15 +5,17 @@ namespace Quantum
 namespace Stabilizer
 namespace Lattice
 
+open scoped ToricChain
+
 variable (L : ℕ) [Fact (0 < L)]
 
 /-- 1-cycles: kernel of `∂1`. -/
 def toricCycles : Submodule (ZMod 2) (C1 L) :=
-  LinearMap.ker (toricBoundary1 (L := L))
+  LinearMap.ker (∂₁ (L := L))
 
 /-- 1-boundaries: range of `∂2`. -/
 def toricBoundaries : Submodule (ZMod 2) (C1 L) :=
-  LinearMap.range (toricBoundary2 (L := L))
+  LinearMap.range (∂₂ (L := L))
 
 /-- Every boundary is a cycle (`im ∂2 ≤ ker ∂1`). -/
 theorem toricBoundaries_le_toricCycles :

--- a/QEC/Stabilizer/Codes/Toric/Homology.lean
+++ b/QEC/Stabilizer/Codes/Toric/Homology.lean
@@ -17,9 +17,19 @@ def toricCycles : Submodule (ZMod 2) (C1 L) :=
 def toricBoundaries : Submodule (ZMod 2) (C1 L) :=
   LinearMap.range (∂₂ (L := L))
 
+/-- `Z₁ L` is the toric 1-cycle submodule `toricCycles L` (`L` explicit, as for `∂₁`).
+Scoped: `open scoped ToricChain`. -/
+scoped[ToricChain] notation "Z₁" => Quantum.Stabilizer.Lattice.toricCycles
+
+/-- `B₁ L` is the toric 1-boundary submodule `toricBoundaries L`.
+Scoped: `open scoped ToricChain`. -/
+scoped[ToricChain] notation "B₁" => Quantum.Stabilizer.Lattice.toricBoundaries
+
+open scoped ToricChain
+
 /-- Every boundary is a cycle (`im ∂2 ≤ ker ∂1`). -/
 theorem toricBoundaries_le_toricCycles :
-    toricBoundaries (L := L) ≤ toricCycles (L := L) := by
+    B₁ L ≤ Z₁ L := by
   intro c hc
   rcases hc with ⟨f, rfl⟩
   have hcomp := toricBoundary_comp_zero_apply (L := L) f
@@ -27,8 +37,13 @@ theorem toricBoundaries_le_toricCycles :
 
 /-- First homology `H1 = Z1/B1` for the toric chain complex over `ZMod 2`. -/
 abbrev toricH1 : Type :=
-  toricCycles (L := L) ⧸ Submodule.comap (toricCycles (L := L)).subtype
-    (toricBoundaries (L := L))
+  Z₁ L ⧸ Submodule.comap (Z₁ L).subtype (B₁ L)
+
+/-- `H₁ L` is the toric first homology `toricH1 L = Z₁ L ⧸ B₁ L`.
+Scoped: `open scoped ToricChain`. -/
+scoped[ToricChain] notation "H₁" => Quantum.Stabilizer.Lattice.toricH1
+
+open scoped ToricChain
 
 end Lattice
 end Stabilizer

--- a/QEC/Stabilizer/Codes/Toric/Homology.lean
+++ b/QEC/Stabilizer/Codes/Toric/Homology.lean
@@ -18,14 +18,15 @@ def toricBoundaries : Submodule (ZMod 2) (C1 L) :=
   LinearMap.range (∂₂ (L := L))
 
 /-- `Z₁ L` is the toric 1-cycle submodule `toricCycles L` (`L` explicit, as for `∂₁`).
-Scoped: `open scoped ToricChain`. -/
+Scoped: `open scoped ToricChain`. The `RotatedSurfaceChain` scope binds the same tokens
+`Z₁`/`B₁`/`H₁` to the rotated-surface submodules, so open one of the two scopes per file;
+the notation names the lattice constants, not the `ToricCodeN` aliases of them. -/
 scoped[ToricChain] notation "Z₁" => Quantum.Stabilizer.Lattice.toricCycles
 
 /-- `B₁ L` is the toric 1-boundary submodule `toricBoundaries L`.
 Scoped: `open scoped ToricChain`. -/
 scoped[ToricChain] notation "B₁" => Quantum.Stabilizer.Lattice.toricBoundaries
 
-open scoped ToricChain
 
 /-- Every boundary is a cycle (`im ∂2 ≤ ker ∂1`). -/
 theorem toricBoundaries_le_toricCycles :
@@ -43,7 +44,6 @@ abbrev toricH1 : Type :=
 Scoped: `open scoped ToricChain`. -/
 scoped[ToricChain] notation "H₁" => Quantum.Stabilizer.Lattice.toricH1
 
-open scoped ToricChain
 
 end Lattice
 end Stabilizer

--- a/QEC/Stabilizer/Codes/Toric/LogicalCorrespondenceX.lean
+++ b/QEC/Stabilizer/Codes/Toric/LogicalCorrespondenceX.lean
@@ -322,7 +322,7 @@ theorem xCommutesWithZChecks_iff_boundary1_pointwise_zero
 i.e. cycle membership. -/
 theorem boundary1_pointwise_zero_iff_mem_toricCycles
     (L : ℕ) [Fact (2 ≤ L)] (c : C1 L) :
-    (∀ v : VtxIdx L, ∂₁ (L := L) c v = 0) ↔ c ∈ toricCycles (L := L) := by
+    (∀ v : VtxIdx L, ∂₁ (L := L) c v = 0) ↔ c ∈ Z₁ L := by
   constructor
   · intro h
     change ∂₁ (L := L) c = 0
@@ -336,7 +336,7 @@ theorem boundary1_pointwise_zero_iff_mem_toricCycles
 This delegates to the generic `chainXOperator_commutes_ZGenerators_iff_mem_cycles`
 via the toric `HomologicalCode` instance and the lattice/abstract generator-set bridge. -/
 theorem xCommutesWithZChecks_iff_mem_toricCycles (L : ℕ) [Fact (2 ≤ L)] (c : C1 L) :
-    xCommutesWithZChecks L c ↔ c ∈ toricCycles (L := L) := by
+    xCommutesWithZChecks L c ↔ c ∈ Z₁ L := by
   haveI : Fact (0 < L) := ⟨Nat.lt_of_lt_of_le (by decide : 0 < 2) Fact.out⟩
   unfold xCommutesWithZChecks
   rw [← toricHomologicalCode_ZGenerators_eq]
@@ -358,7 +358,7 @@ lemma c2_eq_sum_singleFace (L : ℕ) (f : C2 L) :
 Delegates to `chainXOperator_mem_XClosure_iff_mem_boundaries` on the toric
 `HomologicalCode` instance via the X-generator bridge. -/
 theorem xIsPlaquetteProduct_iff_mem_toricBoundaries (L : ℕ) [Fact (2 ≤ L)] (c : C1 L) :
-    xIsPlaquetteProduct L c ↔ c ∈ toricBoundaries (L := L) := by
+    xIsPlaquetteProduct L c ↔ c ∈ B₁ L := by
   haveI : Fact (0 < L) := ⟨Nat.lt_of_lt_of_le (by decide : 0 < 2) Fact.out⟩
   unfold xIsPlaquetteProduct
   rw [← toricHomologicalCode_XGenerators_eq]
@@ -394,7 +394,7 @@ lemma toricXOperatorOfChain_mem_centralizer_iff_cycle
     (L : ℕ) [Fact (2 ≤ L)] (c : C1 L) :
     toricXOperatorOfChain L c ∈
     StabilizerGroup.centralizer (StabilizerGroup.ToricCodeN.stabilizerGroup L) ↔
-        c ∈ toricCycles (L := L) := by
+        c ∈ Z₁ L := by
   constructor;
   · intro h;
     apply (xCommutesWithZChecks_iff_mem_toricCycles L c).mp;
@@ -535,7 +535,7 @@ lemma stabilizer_same_ops_implies_boundary
     (s : NQubitPauliGroupElement (StabilizerGroup.ToricCodeN.numQubits L))
     (hs : s ∈ (StabilizerGroup.ToricCodeN.stabilizerGroup L).toSubgroup)
     (heq : s.operators = (toricXOperatorOfChain L c).operators) :
-    c ∈ toricBoundaries (L := L) := by
+    c ∈ B₁ L := by
   have hops : ∀ i, s.operators i = PauliOperator.X ∨ s.operators i = PauliOperator.I := by
     intro i; rw [heq]; simp only [toricXOperatorOfChain]
     by_cases h : ∃ e : EdgeIdx L, edgeToQubitIdx L e = i ∧ c e = 1
@@ -558,7 +558,7 @@ shared underlying subgroup of the toric and abstract stabilizer groups. -/
 theorem xNontrivialLogical_iff_cycle_not_boundary (L : ℕ) [Fact (2 ≤ L)] (c : C1 L) :
     StabilizerGroup.IsNontrivialLogicalOperator
         (toricXOperatorOfChain L c) (StabilizerGroup.ToricCodeN.stabilizerGroup L) ↔
-      c ∈ toricCycles (L := L) ∧ c ∉ toricBoundaries (L := L) := by
+      c ∈ Z₁ L ∧ c ∉ B₁ L := by
   haveI : Fact (0 < L) := ⟨Nat.lt_of_lt_of_le (by decide : 0 < 2) Fact.out⟩
   -- The toric and abstract stabilizer groups have the same underlying subgroup
   -- once we translate the lattice generator sets via the §E bridges.

--- a/QEC/Stabilizer/Codes/Toric/LogicalCorrespondenceX.lean
+++ b/QEC/Stabilizer/Codes/Toric/LogicalCorrespondenceX.lean
@@ -11,6 +11,7 @@ namespace Stabilizer
 namespace Lattice
 
 open scoped BigOperators
+open scoped ToricChain
 
 /-- Support membership of `toricXOperatorOfChain` at an indexed edge qubit. -/
 lemma mem_support_toricXOperatorOfChain_edgeToQubitIdx_iff
@@ -282,7 +283,7 @@ theorem evenIncidentOverlap_iff_boundary1_zero_at
         (if c (EdgeIdx.h (StabilizerGroup.ToricCodeN.prev L xv) yv) = 1 then 1 else 0) +
         (if c (EdgeIdx.v xv yv) = 1 then 1 else 0) +
         (if c (EdgeIdx.v xv (StabilizerGroup.ToricCodeN.prev L yv)) = 1 then 1 else 0)) : ℕ)
-      ↔ toricBoundary1 (L := L) c (xv, yv) = 0 := by
+      ↔ ∂₁ (L := L) c (xv, yv) = 0 := by
   simpa [toricBoundary1] using even_indicator_sum4_iff_zmod2_zero
     (c (EdgeIdx.h xv yv))
     (c (EdgeIdx.h (StabilizerGroup.ToricCodeN.prev L xv) yv))
@@ -295,7 +296,7 @@ theorem vertexCheckCommutes_iff_boundary1_zero_at
     (L : ℕ) [Fact (2 ≤ L)] (c : C1 L) (xv yv : Fin L) :
     StabilizerGroup.ToricCodeN.vertexStab L xv yv * toricXOperatorOfChain L c =
       toricXOperatorOfChain L c * StabilizerGroup.ToricCodeN.vertexStab L xv yv
-      ↔ toricBoundary1 (L := L) c (xv, yv) = 0 := by
+      ↔ ∂₁ (L := L) c (xv, yv) = 0 := by
   exact (vertexCheckCommutes_iff_evenIncidentOverlap L c xv yv).trans
     (evenIncidentOverlap_iff_boundary1_zero_at L c xv yv)
 
@@ -303,7 +304,7 @@ theorem vertexCheckCommutes_iff_boundary1_zero_at
 vanishing of the primal boundary map. -/
 theorem xCommutesWithZChecks_iff_boundary1_pointwise_zero
     (L : ℕ) [Fact (2 ≤ L)] (c : C1 L) :
-    xCommutesWithZChecks L c ↔ ∀ v : VtxIdx L, toricBoundary1 (L := L) c v = 0 := by
+    xCommutesWithZChecks L c ↔ ∀ v : VtxIdx L, ∂₁ (L := L) c v = 0 := by
   constructor
   · intro h v
     rcases v with ⟨xv, yv⟩
@@ -321,10 +322,10 @@ theorem xCommutesWithZChecks_iff_boundary1_pointwise_zero
 i.e. cycle membership. -/
 theorem boundary1_pointwise_zero_iff_mem_toricCycles
     (L : ℕ) [Fact (2 ≤ L)] (c : C1 L) :
-    (∀ v : VtxIdx L, toricBoundary1 (L := L) c v = 0) ↔ c ∈ toricCycles (L := L) := by
+    (∀ v : VtxIdx L, ∂₁ (L := L) c v = 0) ↔ c ∈ toricCycles (L := L) := by
   constructor
   · intro h
-    change toricBoundary1 (L := L) c = 0
+    change ∂₁ (L := L) c = 0
     ext v
     exact h v
   · intro h v

--- a/QEC/Stabilizer/Codes/Toric/LogicalCorrespondenceZ.lean
+++ b/QEC/Stabilizer/Codes/Toric/LogicalCorrespondenceZ.lean
@@ -53,9 +53,19 @@ def toricDualCycles (L : ℕ) [Fact (0 < L)] : Submodule (ZMod 2) (C1 L) :=
 noncomputable def toricDualBoundaries (L : ℕ) [Fact (0 < L)] : Submodule (ZMod 2) (C1 L) :=
   LinearMap.range (δ⁰ (L := L))
 
+/-- `Z¹ L` is the toric dual 1-cycle submodule `toricDualCycles L` (kernel of the dual
+boundary). Scoped: `open scoped ToricChain`. -/
+scoped[ToricChain] notation "Z¹" => Quantum.Stabilizer.Lattice.toricDualCycles
+
+/-- `B¹ L` is the toric dual 1-boundary submodule `toricDualBoundaries L` (range of the
+vertex cut map). Scoped: `open scoped ToricChain`. -/
+scoped[ToricChain] notation "B¹" => Quantum.Stabilizer.Lattice.toricDualBoundaries
+
+open scoped ToricChain
+
 /-- Every dual boundary is a dual cycle (∂₂ᵀ ∘ ∂₁ᵀ = 0). -/
 theorem toricDualBoundaries_le_toricDualCycles (L : ℕ) [Fact (0 < L)] :
-    toricDualBoundaries (L := L) ≤ toricDualCycles (L := L) := by
+    B¹ L ≤ Z¹ L := by
   intro c hc
   simp only [toricDualBoundaries, LinearMap.mem_range] at hc
   obtain ⟨s, rfl⟩ := hc
@@ -80,7 +90,7 @@ variable (L : ℕ) [Fact (0 < L)]
 `toricDualBoundaries` (range of `toricVertexCutMap`).  Follows directly from
 `toricHomologicalCode_cutMap_eq`. -/
 theorem toricHomologicalCode_dualBoundaries_eq :
-    (toricHomologicalCode L).dualBoundaries = toricDualBoundaries (L := L) := by
+    (toricHomologicalCode L).dualBoundaries = B¹ L := by
   unfold Homological.HomologicalCode.dualBoundaries toricDualBoundaries
   rw [toricHomologicalCode_cutMap_eq]
   rfl
@@ -234,7 +244,7 @@ theorem toricHomologicalCode_dualBoundary_eq :
 /-- Bridge: the abstract `dualCycles` (kernel of abstract `dualBoundary`) equals
 the lattice `toricDualCycles` (kernel of `toricDualBoundary`). -/
 theorem toricHomologicalCode_dualCycles_eq :
-    (toricHomologicalCode L).dualCycles = toricDualCycles (L := L) := by
+    (toricHomologicalCode L).dualCycles = Z¹ L := by
   unfold Homological.HomologicalCode.dualCycles toricDualCycles
   rw [toricHomologicalCode_dualBoundary_eq]
   rfl
@@ -424,7 +434,7 @@ theorem zCommutesWithXChecks_iff_dualBoundary_pointwise_zero
 theorem dualBoundary_pointwise_zero_iff_mem_toricDualCycles
     (L : ℕ) [Fact (2 ≤ L)] (c : C1 L) :
     (∀ p : FaceIdx L, toricDualBoundary L c p = 0) ↔
-      c ∈ toricDualCycles (L := L) := by
+      c ∈ Z¹ L := by
   constructor
   · intro h
     change toricDualBoundary L c = 0
@@ -437,7 +447,7 @@ theorem dualBoundary_pointwise_zero_iff_mem_toricDualCycles
 Delegates to the generic `chainZOperator_commutes_XGenerators_iff_mem_dualCycles`
 via the X-generator and dual-cycle bridges. -/
 theorem zCommutesWithXChecks_iff_mem_toricDualCycles (L : ℕ) [Fact (2 ≤ L)] (c : C1 L) :
-    zCommutesWithXChecks L c ↔ c ∈ toricDualCycles (L := L) := by
+    zCommutesWithXChecks L c ↔ c ∈ Z¹ L := by
   haveI : Fact (0 < L) := ⟨Nat.lt_of_lt_of_le (by decide : 0 < 2) Fact.out⟩
   unfold zCommutesWithXChecks
   rw [← toricHomologicalCode_XGenerators_eq, ← toricHomologicalCode_dualCycles_eq]
@@ -461,7 +471,7 @@ private lemma c0_eq_sum_singleVtx (L : ℕ) (s : C0 L) :
 Delegates to the generic `chainZOperator_mem_ZClosure_iff_mem_dualBoundaries`
 via the Z-generator and dual-boundary bridges. -/
 theorem zIsStarProduct_iff_mem_toricDualBoundaries (L : ℕ) [Fact (2 ≤ L)] (c : C1 L) :
-    zIsStarProduct L c ↔ c ∈ toricDualBoundaries (L := L) := by
+    zIsStarProduct L c ↔ c ∈ B¹ L := by
   haveI : Fact (0 < L) := ⟨Nat.lt_of_lt_of_le (by decide : 0 < 2) Fact.out⟩
   unfold zIsStarProduct
   rw [← toricHomologicalCode_ZGenerators_eq, ← toricHomologicalCode_dualBoundaries_eq]
@@ -492,7 +502,7 @@ lemma toricZOperatorOfChain_mem_centralizer_iff_dualCycle
     (L : ℕ) [Fact (2 ≤ L)] (c : C1 L) :
     toricZOperatorOfChain L c ∈
       StabilizerGroup.centralizer (StabilizerGroup.ToricCodeN.stabilizerGroup L) ↔
-        c ∈ toricDualCycles (L := L) := by
+        c ∈ Z¹ L := by
   constructor
   · intro h
     apply (zCommutesWithXChecks_iff_mem_toricDualCycles L c).mp
@@ -632,7 +642,7 @@ lemma stabilizer_same_ops_implies_dualBoundary
     (s : NQubitPauliGroupElement (StabilizerGroup.ToricCodeN.numQubits L))
     (hs : s ∈ (StabilizerGroup.ToricCodeN.stabilizerGroup L).toSubgroup)
     (heq : s.operators = (toricZOperatorOfChain L c).operators) :
-    c ∈ toricDualBoundaries (L := L) := by
+    c ∈ B¹ L := by
   have hops : ∀ i, s.operators i = PauliOperator.Z ∨ s.operators i = PauliOperator.I := by
     intro i; rw [heq]; simp only [toricZOperatorOfChain]
     by_cases h : ∃ e : EdgeIdx L, edgeToQubitIdx L e = i ∧ c e = 1
@@ -660,7 +670,7 @@ theorem zNontrivialLogical_iff_dualCycle_not_dualBoundary
     (L : ℕ) [Fact (2 ≤ L)] (c : C1 L) :
     StabilizerGroup.IsNontrivialLogicalOperator
         (toricZOperatorOfChain L c) (StabilizerGroup.ToricCodeN.stabilizerGroup L) ↔
-      c ∈ toricDualCycles (L := L) ∧ c ∉ toricDualBoundaries (L := L) := by
+      c ∈ Z¹ L ∧ c ∉ B¹ L := by
   haveI : Fact (0 < L) := ⟨Nat.lt_of_lt_of_le (by decide : 0 < 2) Fact.out⟩
   -- Translate the lattice `IsNontrivialLogicalOperator` to the abstract one
   -- via the subgroup bridge.

--- a/QEC/Stabilizer/Codes/Toric/LogicalCorrespondenceZ.lean
+++ b/QEC/Stabilizer/Codes/Toric/LogicalCorrespondenceZ.lean
@@ -61,7 +61,6 @@ scoped[ToricChain] notation "Z¹" => Quantum.Stabilizer.Lattice.toricDualCycles
 vertex cut map). Scoped: `open scoped ToricChain`. -/
 scoped[ToricChain] notation "B¹" => Quantum.Stabilizer.Lattice.toricDualBoundaries
 
-open scoped ToricChain
 
 /-- Every dual boundary is a dual cycle (∂₂ᵀ ∘ ∂₁ᵀ = 0). -/
 theorem toricDualBoundaries_le_toricDualCycles (L : ℕ) [Fact (0 < L)] :

--- a/QEC/Stabilizer/Codes/Toric/LogicalCorrespondenceZ.lean
+++ b/QEC/Stabilizer/Codes/Toric/LogicalCorrespondenceZ.lean
@@ -10,6 +10,7 @@ namespace Stabilizer
 namespace Lattice
 
 open scoped BigOperators
+open scoped ToricChain
 
 /-!
 # Z-type logical correspondence for the toric code
@@ -50,7 +51,7 @@ def toricDualCycles (L : ℕ) [Fact (0 < L)] : Submodule (ZMod 2) (C1 L) :=
 
 /-- Dual boundaries: Z-chains that are products of vertex stabilizers. -/
 noncomputable def toricDualBoundaries (L : ℕ) [Fact (0 < L)] : Submodule (ZMod 2) (C1 L) :=
-  LinearMap.range (toricVertexCutMap (L := L))
+  LinearMap.range (δ⁰ (L := L))
 
 /-- Every dual boundary is a dual cycle (∂₂ᵀ ∘ ∂₁ᵀ = 0). -/
 theorem toricDualBoundaries_le_toricDualCycles (L : ℕ) [Fact (0 < L)] :
@@ -102,13 +103,13 @@ theorem toricHomologicalCode_dualBoundary_eq :
   -- Strategy: split EdgeIdx into h and v via `edgeIdxEquivSum`, expand
   -- `toricBoundary2 (Pi.single (x, y) 1)` pointwise, and identify the 4 nonzero terms.
   change ∑ e : EdgeIdx L,
-        c e * toricBoundary2 (L := L) (Pi.single (x, y) (1 : ZMod 2)) e
+        c e * ∂₂ (L := L) (Pi.single (x, y) (1 : ZMod 2)) e
     = c (EdgeIdx.h x y) + c (EdgeIdx.h x (StabilizerGroup.ToricCodeN.next L y))
       + c (EdgeIdx.v x y) + c (EdgeIdx.v (StabilizerGroup.ToricCodeN.next L x) y)
   -- Step 1: rewrite the EdgeIdx-sum as a `Sum`-sum via `edgeIdxEquivSum`.
   rw [← Equiv.sum_comp (edgeIdxEquivSum L).symm
         (fun e : EdgeIdx L =>
-          c e * toricBoundary2 (L := L) (Pi.single (x, y) (1 : ZMod 2)) e),
+          c e * ∂₂ (L := L) (Pi.single (x, y) (1 : ZMod 2)) e),
       Fintype.sum_sum_type]
   -- Step 2: reduce each VtxIdx-sum.
   -- h-edges:
@@ -129,7 +130,7 @@ theorem toricHomologicalCode_dualBoundary_eq :
   have hh :
       ∑ p : VtxIdx L,
           (fun e : EdgeIdx L =>
-              c e * toricBoundary2 (L := L) (Pi.single (x, y) (1 : ZMod 2)) e)
+              c e * ∂₂ (L := L) (Pi.single (x, y) (1 : ZMod 2)) e)
             ((edgeIdxEquivSum L).symm (Sum.inl p))
       = c (EdgeIdx.h x y) + c (EdgeIdx.h x (StabilizerGroup.ToricCodeN.next L y)) := by
     -- Rewrite `(edgeIdxEquivSum L).symm (Sum.inl p) = h p.1 p.2`
@@ -138,7 +139,7 @@ theorem toricHomologicalCode_dualBoundary_eq :
       rintro ⟨_, _⟩; rfl]
     -- Unfold `toricBoundary2 (Pi.single (x, y) 1) (h p.1 p.2)`.
     have heval : ∀ p : VtxIdx L,
-        toricBoundary2 (L := L) (Pi.single (x, y) (1 : ZMod 2)) (EdgeIdx.h p.1 p.2)
+        ∂₂ (L := L) (Pi.single (x, y) (1 : ZMod 2)) (EdgeIdx.h p.1 p.2)
           = (if (p.1, p.2) = (x, y) then (1 : ZMod 2) else 0)
             + (if (p.1, StabilizerGroup.ToricCodeN.prev L p.2) = (x, y)
                 then 1 else 0) := by
@@ -183,14 +184,14 @@ theorem toricHomologicalCode_dualBoundary_eq :
   have hv :
       ∑ p : VtxIdx L,
           (fun e : EdgeIdx L =>
-              c e * toricBoundary2 (L := L) (Pi.single (x, y) (1 : ZMod 2)) e)
+              c e * ∂₂ (L := L) (Pi.single (x, y) (1 : ZMod 2)) e)
             ((edgeIdxEquivSum L).symm (Sum.inr p))
       = c (EdgeIdx.v x y) + c (EdgeIdx.v (StabilizerGroup.ToricCodeN.next L x) y) := by
     simp only [show ∀ p : VtxIdx L,
         (edgeIdxEquivSum L).symm (Sum.inr p) = EdgeIdx.v p.1 p.2 by
       rintro ⟨_, _⟩; rfl]
     have heval : ∀ p : VtxIdx L,
-        toricBoundary2 (L := L) (Pi.single (x, y) (1 : ZMod 2)) (EdgeIdx.v p.1 p.2)
+        ∂₂ (L := L) (Pi.single (x, y) (1 : ZMod 2)) (EdgeIdx.v p.1 p.2)
           = (if (p.1, p.2) = (x, y) then (1 : ZMod 2) else 0)
             + (if (StabilizerGroup.ToricCodeN.prev L p.1, p.2) = (x, y)
                 then 1 else 0) := by

--- a/QEC/Stabilizer/Codes/Toric/StabilizerCode.lean
+++ b/QEC/Stabilizer/Codes/Toric/StabilizerCode.lean
@@ -204,7 +204,7 @@ private lemma vertexStab_listProd_eq_chain (L : ℕ) [Fact (2 ≤ L)]
     (lst.map (fun p => vertexStab L p.1 p.2)).prod =
       Stabilizer.Lattice.toricZOperatorOfChain L
         (δ⁰ (L := L)
-          ((lst.map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum)) := by
+          ((lst.map (fun p => Stabilizer.Lattice.singleVtx p)).sum)) := by
   haveI : Fact (0 < L) := ⟨lt_of_lt_of_le (by decide : 0 < 2) Fact.out⟩
   induction lst with
   | nil =>
@@ -222,7 +222,7 @@ private lemma faceStab_listProd_eq_chain (L : ℕ) [Fact (2 ≤ L)]
     (lst.map (fun p => faceStab L p.1 p.2)).prod =
       Stabilizer.Lattice.toricXOperatorOfChain L
         (∂₂ (L := L)
-          ((lst.map (fun p => Stabilizer.Lattice.singleFace (L := L) p)).sum)) := by
+          ((lst.map (fun p => Stabilizer.Lattice.singleFace p)).sum)) := by
   haveI : Fact (0 < L) := ⟨lt_of_lt_of_le (by decide : 0 < 2) Fact.out⟩
   induction lst with
   | nil =>
@@ -236,7 +236,7 @@ private lemma faceStab_listProd_eq_chain (L : ℕ) [Fact (2 ≤ L)]
 /-- The sum (as 0-chains) of `singleVtx p` over all `p ∈ coords L` is the
 constant-1 chain. -/
 private lemma sum_singleVtx_coords (L : ℕ) [Fact (0 < L)] :
-    ((coords L).map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum =
+    ((coords L).map (fun p => Stabilizer.Lattice.singleVtx p)).sum =
       (fun _ => (1 : ZMod 2)) := by
   have h_nodup : (coords L).Nodup := by
     change ((List.finRange L).product (List.finRange L)).Nodup
@@ -244,14 +244,14 @@ private lemma sum_singleVtx_coords (L : ℕ) [Fact (0 < L)] :
   have h_finset_eq : (coords L).toFinset = (Finset.univ : Finset (Fin L × Fin L)) := by
     ext p
     refine ⟨fun _ => Finset.mem_univ _, fun _ => List.mem_toFinset.mpr (mem_coords L p)⟩
-  rw [show ((coords L).map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum =
-      ∑ p ∈ Finset.univ, Stabilizer.Lattice.singleVtx (L := L) p from ?_]
+  rw [show ((coords L).map (fun p => Stabilizer.Lattice.singleVtx p)).sum =
+      ∑ p ∈ Finset.univ, Stabilizer.Lattice.singleVtx p from ?_]
   · ext v
     rw [Finset.sum_apply]
     rw [Finset.sum_eq_single v]
     · simp [Stabilizer.Lattice.singleVtx]
     · intro b _ hbne
-      have : Stabilizer.Lattice.singleVtx (L := L) b v = 0 :=
+      have : Stabilizer.Lattice.singleVtx b v = 0 :=
         Stabilizer.Lattice.singleVtx_apply_ne hbne.symm
       exact this
     · intro hcontra; exact absurd (Finset.mem_univ v) hcontra
@@ -260,7 +260,7 @@ private lemma sum_singleVtx_coords (L : ℕ) [Fact (0 < L)] :
 
 /-- Symmetric: sum of `singleFace p` over `coords L` is the constant-1 2-chain. -/
 private lemma sum_singleFace_coords (L : ℕ) [Fact (0 < L)] :
-    ((coords L).map (fun p => Stabilizer.Lattice.singleFace (L := L) p)).sum =
+    ((coords L).map (fun p => Stabilizer.Lattice.singleFace p)).sum =
       (fun _ => (1 : ZMod 2)) := by
   have h_nodup : (coords L).Nodup := by
     change ((List.finRange L).product (List.finRange L)).Nodup
@@ -268,8 +268,8 @@ private lemma sum_singleFace_coords (L : ℕ) [Fact (0 < L)] :
   have h_finset_eq : (coords L).toFinset = (Finset.univ : Finset (Fin L × Fin L)) := by
     ext p
     refine ⟨fun _ => Finset.mem_univ _, fun _ => List.mem_toFinset.mpr (mem_coords L p)⟩
-  rw [show ((coords L).map (fun p => Stabilizer.Lattice.singleFace (L := L) p)).sum =
-      ∑ p ∈ Finset.univ, Stabilizer.Lattice.singleFace (L := L) p from ?_]
+  rw [show ((coords L).map (fun p => Stabilizer.Lattice.singleFace p)).sum =
+      ∑ p ∈ Finset.univ, Stabilizer.Lattice.singleFace p from ?_]
   · ext v
     rw [Finset.sum_apply]
     rw [Finset.sum_eq_single v]
@@ -282,9 +282,9 @@ private lemma sum_singleFace_coords (L : ℕ) [Fact (0 < L)] :
 
 /-- Decompose `coords L` sum as `coordsTrimmed L` sum plus origin. -/
 private lemma sum_singleVtx_coords_eq_trimmed_add_origin (L : ℕ) [Fact (0 < L)] :
-    ((coords L).map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum =
-      ((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum
-        + Stabilizer.Lattice.singleVtx (L := L) (originCoord L) := by
+    ((coords L).map (fun p => Stabilizer.Lattice.singleVtx p)).sum =
+      ((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx p)).sum
+        + Stabilizer.Lattice.singleVtx (originCoord L) := by
   have h_nodup : (coords L).Nodup := by
     change ((List.finRange L).product (List.finRange L)).Nodup
     exact List.Nodup.product (List.nodup_finRange L) (List.nodup_finRange L)
@@ -302,11 +302,11 @@ private lemma sum_singleVtx_coords_eq_trimmed_add_origin (L : ℕ) [Fact (0 < L)
       (coords L).toFinset = (Finset.univ : Finset (Fin L × Fin L)) from h_finset_eq) ▸
       Finset.mem_univ p), h⟩⟩
   -- Convert both sides to Finset.sum and apply Finset.sum_erase_eq_sub-style.
-  rw [show ((coords L).map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum =
-      ∑ p ∈ Finset.univ, Stabilizer.Lattice.singleVtx (L := L) p from ?_,
-      show ((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum =
+  rw [show ((coords L).map (fun p => Stabilizer.Lattice.singleVtx p)).sum =
+      ∑ p ∈ Finset.univ, Stabilizer.Lattice.singleVtx p from ?_,
+      show ((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx p)).sum =
       ∑ p ∈ (Finset.univ : Finset (Fin L × Fin L)).erase (originCoord L),
-        Stabilizer.Lattice.singleVtx (L := L) p from ?_]
+        Stabilizer.Lattice.singleVtx p from ?_]
   · rw [Finset.sum_erase_add _ _ (Finset.mem_univ (originCoord L))]
   · rw [show ((Finset.univ : Finset (Fin L × Fin L)).erase (originCoord L)) =
         (coordsTrimmed L).toFinset from h_trim_finset.symm]
@@ -316,9 +316,9 @@ private lemma sum_singleVtx_coords_eq_trimmed_add_origin (L : ℕ) [Fact (0 < L)
 
 /-- Symmetric: decompose `coords L` face sum. -/
 private lemma sum_singleFace_coords_eq_trimmed_add_origin (L : ℕ) [Fact (0 < L)] :
-    ((coords L).map (fun p => Stabilizer.Lattice.singleFace (L := L) p)).sum =
-      ((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleFace (L := L) p)).sum
-        + Stabilizer.Lattice.singleFace (L := L) (originCoord L) := by
+    ((coords L).map (fun p => Stabilizer.Lattice.singleFace p)).sum =
+      ((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleFace p)).sum
+        + Stabilizer.Lattice.singleFace (originCoord L) := by
   have h_nodup : (coords L).Nodup := by
     change ((List.finRange L).product (List.finRange L)).Nodup
     exact List.Nodup.product (List.nodup_finRange L) (List.nodup_finRange L)
@@ -335,11 +335,11 @@ private lemma sum_singleFace_coords_eq_trimmed_add_origin (L : ℕ) [Fact (0 < L
     refine ⟨fun ⟨_, h⟩ => h, fun h => ⟨List.mem_toFinset.mp ((show
       (coords L).toFinset = (Finset.univ : Finset (Fin L × Fin L)) from h_finset_eq) ▸
       Finset.mem_univ p), h⟩⟩
-  rw [show ((coords L).map (fun p => Stabilizer.Lattice.singleFace (L := L) p)).sum =
-      ∑ p ∈ Finset.univ, Stabilizer.Lattice.singleFace (L := L) p from ?_,
-      show ((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleFace (L := L) p)).sum =
+  rw [show ((coords L).map (fun p => Stabilizer.Lattice.singleFace p)).sum =
+      ∑ p ∈ Finset.univ, Stabilizer.Lattice.singleFace p from ?_,
+      show ((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleFace p)).sum =
       ∑ p ∈ (Finset.univ : Finset (Fin L × Fin L)).erase (originCoord L),
-        Stabilizer.Lattice.singleFace (L := L) p from ?_]
+        Stabilizer.Lattice.singleFace p from ?_]
   · rw [Finset.sum_erase_add _ _ (Finset.mem_univ (originCoord L))]
   · rw [show ((Finset.univ : Finset (Fin L × Fin L)).erase (originCoord L)) =
         (coordsTrimmed L).toFinset from h_trim_finset.symm]
@@ -357,14 +357,14 @@ private theorem dropped_vertex_in_closure_remaining (L : ℕ) [Fact (2 ≤ L)] :
   have h_decomp := sum_singleVtx_coords_eq_trimmed_add_origin L
   have h_const := sum_singleVtx_coords L
   have h_trim_plus_origin :
-      ((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum
-        + Stabilizer.Lattice.singleVtx (L := L) (originCoord L) =
+      ((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx p)).sum
+        + Stabilizer.Lattice.singleVtx (originCoord L) =
       (fun _ : Fin L × Fin L => (1 : ZMod 2)) := h_decomp ▸ h_const
   have h_cutMap_trim_eq :
       δ⁰ (L := L)
-          (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum)
+          (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx p)).sum)
         = δ⁰ (L := L)
-            (Stabilizer.Lattice.singleVtx (L := L) (originCoord L)) := by
+            (Stabilizer.Lattice.singleVtx (originCoord L)) := by
     have h_apply := congrArg (δ⁰ (L := L)) h_trim_plus_origin
     rw [LinearMap.map_add, toricVertexCutMap_constOne] at h_apply
     -- h_apply : cutMap trim + cutMap (singleVtx origin) = 0.
@@ -375,25 +375,25 @@ private theorem dropped_vertex_in_closure_remaining (L : ℕ) [Fact (2 ≤ L)] :
         _ = 0 := by rw [h2, zero_mul]
     ext e
     have he : (δ⁰ (L := L)
-        (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum)) e +
+        (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx p)).sum)) e +
         (δ⁰ (L := L)
-        (Stabilizer.Lattice.singleVtx (L := L) (originCoord L))) e = 0 :=
+        (Stabilizer.Lattice.singleVtx (originCoord L))) e = 0 :=
       congrFun h_apply e
     have heq : (δ⁰ (L := L)
-        (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum)) e =
+        (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx p)).sum)) e =
         (δ⁰ (L := L)
-        (Stabilizer.Lattice.singleVtx (L := L) (originCoord L))) e := by
+        (Stabilizer.Lattice.singleVtx (originCoord L))) e := by
       have hself := h_self_zero (δ⁰ (L := L)
-        (Stabilizer.Lattice.singleVtx (L := L) (originCoord L)) e)
+        (Stabilizer.Lattice.singleVtx (originCoord L)) e)
       -- From he and hself, conclude
       have : (δ⁰ (L := L)
-        (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum)) e +
+        (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx p)).sum)) e +
         (δ⁰ (L := L)
-        (Stabilizer.Lattice.singleVtx (L := L) (originCoord L))) e =
+        (Stabilizer.Lattice.singleVtx (originCoord L))) e =
         (δ⁰ (L := L)
-        (Stabilizer.Lattice.singleVtx (L := L) (originCoord L))) e +
+        (Stabilizer.Lattice.singleVtx (originCoord L))) e +
         (δ⁰ (L := L)
-        (Stabilizer.Lattice.singleVtx (L := L) (originCoord L))) e := by
+        (Stabilizer.Lattice.singleVtx (originCoord L))) e := by
         rw [he, hself]
       exact add_right_cancel this
     exact heq
@@ -425,14 +425,14 @@ private theorem dropped_face_in_closure_remaining (L : ℕ) [Fact (2 ≤ L)] :
   have h_decomp := sum_singleFace_coords_eq_trimmed_add_origin L
   have h_const := sum_singleFace_coords L
   have h_trim_plus_origin :
-      ((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleFace (L := L) p)).sum
-        + Stabilizer.Lattice.singleFace (L := L) (originCoord L) =
+      ((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleFace p)).sum
+        + Stabilizer.Lattice.singleFace (originCoord L) =
       (fun _ : Fin L × Fin L => (1 : ZMod 2)) := h_decomp ▸ h_const
   have h_b2_trim_eq :
       ∂₂ (L := L)
-          (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleFace (L := L) p)).sum)
+          (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleFace p)).sum)
         = ∂₂ (L := L)
-            (Stabilizer.Lattice.singleFace (L := L) (originCoord L)) := by
+            (Stabilizer.Lattice.singleFace (originCoord L)) := by
     have h_apply := congrArg (∂₂ (L := L)) h_trim_plus_origin
     rw [LinearMap.map_add, toricBoundary2_constOne] at h_apply
     have h_self_zero : ∀ a : ZMod 2, a + a = 0 := fun a => by
@@ -441,20 +441,20 @@ private theorem dropped_face_in_closure_remaining (L : ℕ) [Fact (2 ≤ L)] :
         _ = 0 := by rw [h2, zero_mul]
     ext e
     have he : (∂₂ (L := L)
-        (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleFace (L := L) p)).sum)) e +
+        (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleFace p)).sum)) e +
         (∂₂ (L := L)
-        (Stabilizer.Lattice.singleFace (L := L) (originCoord L))) e = 0 :=
+        (Stabilizer.Lattice.singleFace (originCoord L))) e = 0 :=
       congrFun h_apply e
     have hself := h_self_zero (∂₂ (L := L)
-      (Stabilizer.Lattice.singleFace (L := L) (originCoord L)) e)
+      (Stabilizer.Lattice.singleFace (originCoord L)) e)
     have : (∂₂ (L := L)
-      (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleFace (L := L) p)).sum)) e +
+      (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleFace p)).sum)) e +
       (∂₂ (L := L)
-      (Stabilizer.Lattice.singleFace (L := L) (originCoord L))) e =
+      (Stabilizer.Lattice.singleFace (originCoord L))) e =
       (∂₂ (L := L)
-      (Stabilizer.Lattice.singleFace (L := L) (originCoord L))) e +
+      (Stabilizer.Lattice.singleFace (originCoord L))) e +
       (∂₂ (L := L)
-      (Stabilizer.Lattice.singleFace (L := L) (originCoord L))) e := by
+      (Stabilizer.Lattice.singleFace (originCoord L))) e := by
       rw [he, hself]
     exact add_right_cancel this
   have h_prod_eq : (generatorsListXTrimmed L).prod = faceStab L (zeroCoord L) (zeroCoord L) := by
@@ -1123,14 +1123,14 @@ private lemma coordsTrimmed_not_mem_origin (L : ℕ) [Fact (0 < L)] :
 trimmed coords whose `cutMap` is `0` must have all-zero coefficients. -/
 private lemma trimmed_combo_singleVtx_eq_zero (L : ℕ) [Fact (0 < L)]
     (c : Fin (coordsTrimmed L).length → ZMod 2)
-    (hker : (∑ i, c i • Stabilizer.Lattice.singleVtx (L := L) ((coordsTrimmed L).get i)) ∈
+    (hker : (∑ i, c i • Stabilizer.Lattice.singleVtx ((coordsTrimmed L).get i)) ∈
         LinearMap.ker (δ⁰ (L := L))) :
     ∀ i, c i = 0 := by
   classical
   rw [Stabilizer.Lattice.mem_ker_cutMap_iff] at hker
   obtain ⟨k, hk⟩ := hker
   -- Evaluate at origin: sum is 0 (origin ∉ trimmed), so k = 0.
-  have h_orig : (∑ i, c i • Stabilizer.Lattice.singleVtx (L := L)
+  have h_orig : (∑ i, c i • Stabilizer.Lattice.singleVtx
       ((coordsTrimmed L).get i)) (originCoord L) = 0 := by
     rw [Finset.sum_apply]
     apply Finset.sum_eq_zero
@@ -1140,7 +1140,7 @@ private lemma trimmed_combo_singleVtx_eq_zero (L : ℕ) [Fact (0 < L)]
       intro heq
       rw [heq] at this
       exact coordsTrimmed_not_mem_origin L this
-    change c i * Stabilizer.Lattice.singleVtx (L := L) ((coordsTrimmed L).get i)
+    change c i * Stabilizer.Lattice.singleVtx ((coordsTrimmed L).get i)
         (originCoord L) = 0
     rw [Stabilizer.Lattice.singleVtx_apply_ne (Ne.symm h_get_ne)]
     ring
@@ -1149,18 +1149,18 @@ private lemma trimmed_combo_singleVtx_eq_zero (L : ℕ) [Fact (0 < L)]
     rw [h_orig] at this
     exact this.symm
   -- So the sum is identically 0.
-  have h_sum_zero : (∑ i, c i • Stabilizer.Lattice.singleVtx (L := L)
+  have h_sum_zero : (∑ i, c i • Stabilizer.Lattice.singleVtx
       ((coordsTrimmed L).get i)) = 0 := by
     rw [hk]; ext; simp [hk_zero]
   -- Extract each c j = 0 by evaluating at (coordsTrimmed L).get j.
   intro j
-  have h_at_j : (∑ i, c i • Stabilizer.Lattice.singleVtx (L := L)
+  have h_at_j : (∑ i, c i • Stabilizer.Lattice.singleVtx
       ((coordsTrimmed L).get i)) ((coordsTrimmed L).get j) = 0 := by
     rw [h_sum_zero]; rfl
   rw [Finset.sum_apply] at h_at_j
   rw [Finset.sum_eq_single j] at h_at_j
   · change c j = 0
-    have : c j * Stabilizer.Lattice.singleVtx (L := L) ((coordsTrimmed L).get j)
+    have : c j * Stabilizer.Lattice.singleVtx ((coordsTrimmed L).get j)
         ((coordsTrimmed L).get j) = 0 := h_at_j
     rw [Stabilizer.Lattice.singleVtx_apply_self] at this
     simpa using this
@@ -1168,7 +1168,7 @@ private lemma trimmed_combo_singleVtx_eq_zero (L : ℕ) [Fact (0 < L)]
     have hne : (coordsTrimmed L).get i ≠ (coordsTrimmed L).get j := by
       intro heq
       exact hij (List.nodup_iff_injective_get.mp (coordsTrimmed_nodup L) heq)
-    change c i * Stabilizer.Lattice.singleVtx (L := L) ((coordsTrimmed L).get i)
+    change c i * Stabilizer.Lattice.singleVtx ((coordsTrimmed L).get i)
         ((coordsTrimmed L).get j) = 0
     rw [Stabilizer.Lattice.singleVtx_apply_ne (Ne.symm hne)]
     ring
@@ -1177,13 +1177,13 @@ private lemma trimmed_combo_singleVtx_eq_zero (L : ℕ) [Fact (0 < L)]
 /-- Face-side block kernel collapse: same as Z-side but for `singleFace` and `boundary2`. -/
 private lemma trimmed_combo_singleFace_eq_zero (L : ℕ) [Fact (0 < L)]
     (c : Fin (coordsTrimmed L).length → ZMod 2)
-    (hker : (∑ i, c i • Stabilizer.Lattice.singleFace (L := L) ((coordsTrimmed L).get i)) ∈
+    (hker : (∑ i, c i • Stabilizer.Lattice.singleFace ((coordsTrimmed L).get i)) ∈
         LinearMap.ker (∂₂ (L := L))) :
     ∀ i, c i = 0 := by
   classical
   rw [Stabilizer.Lattice.mem_ker_boundary2_iff] at hker
   obtain ⟨k, hk⟩ := hker
-  have h_orig : (∑ i, c i • Stabilizer.Lattice.singleFace (L := L)
+  have h_orig : (∑ i, c i • Stabilizer.Lattice.singleFace
       ((coordsTrimmed L).get i)) (originCoord L) = 0 := by
     rw [Finset.sum_apply]
     apply Finset.sum_eq_zero
@@ -1193,7 +1193,7 @@ private lemma trimmed_combo_singleFace_eq_zero (L : ℕ) [Fact (0 < L)]
       intro heq
       rw [heq] at this
       exact coordsTrimmed_not_mem_origin L this
-    change c i * Stabilizer.Lattice.singleFace (L := L) ((coordsTrimmed L).get i)
+    change c i * Stabilizer.Lattice.singleFace ((coordsTrimmed L).get i)
         (originCoord L) = 0
     rw [Stabilizer.Lattice.singleFace_apply_ne (Ne.symm h_get_ne)]
     ring
@@ -1201,16 +1201,16 @@ private lemma trimmed_combo_singleFace_eq_zero (L : ℕ) [Fact (0 < L)]
     have := congr_fun hk (originCoord L)
     rw [h_orig] at this
     exact this.symm
-  have h_sum_zero : (∑ i, c i • Stabilizer.Lattice.singleFace (L := L)
+  have h_sum_zero : (∑ i, c i • Stabilizer.Lattice.singleFace
       ((coordsTrimmed L).get i)) = 0 := by
     rw [hk]; ext; simp [hk_zero]
   intro j
-  have h_at_j : (∑ i, c i • Stabilizer.Lattice.singleFace (L := L)
+  have h_at_j : (∑ i, c i • Stabilizer.Lattice.singleFace
       ((coordsTrimmed L).get i)) ((coordsTrimmed L).get j) = 0 := by
     rw [h_sum_zero]; rfl
   rw [Finset.sum_apply] at h_at_j
   rw [Finset.sum_eq_single j] at h_at_j
-  · have : c j * Stabilizer.Lattice.singleFace (L := L) ((coordsTrimmed L).get j)
+  · have : c j * Stabilizer.Lattice.singleFace ((coordsTrimmed L).get j)
         ((coordsTrimmed L).get j) = 0 := h_at_j
     rw [Stabilizer.Lattice.singleFace_apply_self] at this
     simpa using this
@@ -1218,7 +1218,7 @@ private lemma trimmed_combo_singleFace_eq_zero (L : ℕ) [Fact (0 < L)]
     have hne : (coordsTrimmed L).get i ≠ (coordsTrimmed L).get j := by
       intro heq
       exact hij (List.nodup_iff_injective_get.mp (coordsTrimmed_nodup L) heq)
-    change c i * Stabilizer.Lattice.singleFace (L := L) ((coordsTrimmed L).get i)
+    change c i * Stabilizer.Lattice.singleFace ((coordsTrimmed L).get i)
         ((coordsTrimmed L).get j) = 0
     rw [Stabilizer.Lattice.singleFace_apply_ne (Ne.symm hne)]
     ring
@@ -1247,7 +1247,7 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
         simp [generatorsListZTrimmed]
       omega⟩
   -- The Z-half of the sum at each edge yields the chain combination.
-  have h_chain_Z : (∑ i, cZ i • Stabilizer.Lattice.singleVtx (L := L)
+  have h_chain_Z : (∑ i, cZ i • Stabilizer.Lattice.singleVtx
       ((coordsTrimmed L).get i)) ∈
       LinearMap.ker (δ⁰ (L := L)) := by
     rw [LinearMap.mem_ker]
@@ -1327,14 +1327,14 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
           ⟨k.val, by have := k.isLt; omega⟩
           (Fin.natAdd (numQubits L) (Stabilizer.Lattice.edgeToQubitIdx L e)) =
         δ⁰ (L := L)
-          (Stabilizer.Lattice.singleVtx (L := L) ((coordsTrimmed L).get k)) e := by
+          (Stabilizer.Lattice.singleVtx ((coordsTrimmed L).get k)) e := by
       intro k
       have hp_eq := get_packaged_Z L k (by have := k.isLt; omega)
       unfold NQubitPauliGroupElement.checkMatrix
       rw [hp_eq, toSymplectic_vertexStab_Z_eq, qubitToEdgeIdx_edgeToQubitIdx]
     have h_col' : ∑ k : Fin (coordsTrimmed L).length, cZ k *
         δ⁰ (L := L)
-          (Stabilizer.Lattice.singleVtx (L := L) ((coordsTrimmed L).get k)) e = 0 := by
+          (Stabilizer.Lattice.singleVtx ((coordsTrimmed L).get k)) e = 0 := by
       rw [← h_col]
       apply Finset.sum_congr rfl
       intro k _
@@ -1347,9 +1347,9 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
     intro k _
     rw [LinearMap.map_smul]
     change cZ k • δ⁰ (L := L)
-        (Stabilizer.Lattice.singleVtx (L := L) ((coordsTrimmed L).get k)) e =
+        (Stabilizer.Lattice.singleVtx ((coordsTrimmed L).get k)) e =
       cZ k * δ⁰ (L := L)
-        (Stabilizer.Lattice.singleVtx (L := L) ((coordsTrimmed L).get k)) e
+        (Stabilizer.Lattice.singleVtx ((coordsTrimmed L).get k)) e
     rw [smul_eq_mul]
   -- Now apply Z-block kernel collapse to get cZ = 0.
   have hZ_zero : ∀ i, cZ i = 0 := trimmed_combo_singleVtx_eq_zero L cZ h_chain_Z
@@ -1363,7 +1363,7 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
         simp [generatorsListZTrimmed, generatorsListXTrimmed]
       have := i.isLt
       omega⟩
-  have h_chain_X : (∑ i, cX i • Stabilizer.Lattice.singleFace (L := L)
+  have h_chain_X : (∑ i, cX i • Stabilizer.Lattice.singleFace
       ((coordsTrimmed L).get i)) ∈
       LinearMap.ker (∂₂ (L := L)) := by
     rw [LinearMap.mem_ker]
@@ -1447,7 +1447,7 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
           ⟨nZ + k.val, by have := k.isLt; omega⟩
           (Fin.castAdd (numQubits L) (Stabilizer.Lattice.edgeToQubitIdx L e)) =
         ∂₂ (L := L)
-          (Stabilizer.Lattice.singleFace (L := L) ((coordsTrimmed L).get k)) e := by
+          (Stabilizer.Lattice.singleFace ((coordsTrimmed L).get k)) e := by
       intro k
       have hge : nZ ≤ nZ + k.val := Nat.le_add_right _ _
       have hsub : nZ + k.val - nZ < nZ := by
@@ -1467,7 +1467,7 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
       rw [hcoord_eq]
     have h_col' : ∑ k : Fin (coordsTrimmed L).length, cX k *
         ∂₂ (L := L)
-          (Stabilizer.Lattice.singleFace (L := L) ((coordsTrimmed L).get k)) e = 0 := by
+          (Stabilizer.Lattice.singleFace ((coordsTrimmed L).get k)) e = 0 := by
       rw [← h_col]
       apply Finset.sum_congr rfl
       intro k _
@@ -1479,9 +1479,9 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
     intro k _
     rw [LinearMap.map_smul]
     change cX k • ∂₂ (L := L)
-        (Stabilizer.Lattice.singleFace (L := L) ((coordsTrimmed L).get k)) e =
+        (Stabilizer.Lattice.singleFace ((coordsTrimmed L).get k)) e =
       cX k * ∂₂ (L := L)
-        (Stabilizer.Lattice.singleFace (L := L) ((coordsTrimmed L).get k)) e
+        (Stabilizer.Lattice.singleFace ((coordsTrimmed L).get k)) e
     rw [smul_eq_mul]
   have hX_zero : ∀ i, cX i = 0 := trimmed_combo_singleFace_eq_zero L cX h_chain_X
   -- Combine: f = 0.

--- a/QEC/Stabilizer/Codes/Toric/StabilizerCode.lean
+++ b/QEC/Stabilizer/Codes/Toric/StabilizerCode.lean
@@ -32,6 +32,7 @@ namespace StabilizerGroup
 namespace ToricCodeN
 
 open NQubitPauliGroupElement
+open scoped ToricChain
 open Stabilizer.Lattice
 
 -- ---------------------------------------------------------------------------
@@ -183,14 +184,14 @@ lemma generators_commute_packaged (L : ℕ) [Fact (2 ≤ L)] :
 /-- The cut map sends the constant-1 0-chain to the zero 1-chain (each edge
 collects `1 + 1 = 0` from its two incident vertices). -/
 private lemma toricVertexCutMap_constOne (L : ℕ) [Fact (0 < L)] :
-    Stabilizer.Lattice.toricVertexCutMap (L := L) (fun _ : Fin L × Fin L => (1 : ZMod 2)) = 0 := by
+    δ⁰ (L := L) (fun _ : Fin L × Fin L => (1 : ZMod 2)) = 0 := by
   ext e
   have h : (1 : ZMod 2) + 1 = 0 := by decide
   cases e <;> simp [Stabilizer.Lattice.toricVertexCutMap, h]
 
 /-- `∂₂` sends the constant-1 2-chain to zero (each edge collects `1 + 1 = 0`). -/
 private lemma toricBoundary2_constOne (L : ℕ) [Fact (0 < L)] :
-    Stabilizer.Lattice.toricBoundary2 (L := L) (fun _ : Fin L × Fin L => (1 : ZMod 2)) = 0 := by
+    ∂₂ (L := L) (fun _ : Fin L × Fin L => (1 : ZMod 2)) = 0 := by
   ext e
   have h : (1 : ZMod 2) + 1 = 0 := by decide
   cases e <;> simp [Stabilizer.Lattice.toricBoundary2, h]
@@ -202,7 +203,7 @@ private lemma vertexStab_listProd_eq_chain (L : ℕ) [Fact (2 ≤ L)]
     (lst : List (Fin L × Fin L)) :
     (lst.map (fun p => vertexStab L p.1 p.2)).prod =
       Stabilizer.Lattice.toricZOperatorOfChain L
-        (Stabilizer.Lattice.toricVertexCutMap (L := L)
+        (δ⁰ (L := L)
           ((lst.map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum)) := by
   haveI : Fact (0 < L) := ⟨lt_of_lt_of_le (by decide : 0 < 2) Fact.out⟩
   induction lst with
@@ -220,7 +221,7 @@ private lemma faceStab_listProd_eq_chain (L : ℕ) [Fact (2 ≤ L)]
     (lst : List (Fin L × Fin L)) :
     (lst.map (fun p => faceStab L p.1 p.2)).prod =
       Stabilizer.Lattice.toricXOperatorOfChain L
-        (Stabilizer.Lattice.toricBoundary2 (L := L)
+        (∂₂ (L := L)
           ((lst.map (fun p => Stabilizer.Lattice.singleFace (L := L) p)).sum)) := by
   haveI : Fact (0 < L) := ⟨lt_of_lt_of_le (by decide : 0 < 2) Fact.out⟩
   induction lst with
@@ -360,11 +361,11 @@ private theorem dropped_vertex_in_closure_remaining (L : ℕ) [Fact (2 ≤ L)] :
         + Stabilizer.Lattice.singleVtx (L := L) (originCoord L) =
       (fun _ : Fin L × Fin L => (1 : ZMod 2)) := h_decomp ▸ h_const
   have h_cutMap_trim_eq :
-      Stabilizer.Lattice.toricVertexCutMap (L := L)
+      δ⁰ (L := L)
           (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum)
-        = Stabilizer.Lattice.toricVertexCutMap (L := L)
+        = δ⁰ (L := L)
             (Stabilizer.Lattice.singleVtx (L := L) (originCoord L)) := by
-    have h_apply := congrArg (Stabilizer.Lattice.toricVertexCutMap (L := L)) h_trim_plus_origin
+    have h_apply := congrArg (δ⁰ (L := L)) h_trim_plus_origin
     rw [LinearMap.map_add, toricVertexCutMap_constOne] at h_apply
     -- h_apply : cutMap trim + cutMap (singleVtx origin) = 0.
     -- In ZMod 2, a + b = 0 implies a = b.
@@ -373,25 +374,25 @@ private theorem dropped_vertex_in_closure_remaining (L : ℕ) [Fact (2 ≤ L)] :
       calc a + a = (2 : ZMod 2) * a := by ring
         _ = 0 := by rw [h2, zero_mul]
     ext e
-    have he : (Stabilizer.Lattice.toricVertexCutMap (L := L)
+    have he : (δ⁰ (L := L)
         (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum)) e +
-        (Stabilizer.Lattice.toricVertexCutMap (L := L)
+        (δ⁰ (L := L)
         (Stabilizer.Lattice.singleVtx (L := L) (originCoord L))) e = 0 :=
       congrFun h_apply e
-    have heq : (Stabilizer.Lattice.toricVertexCutMap (L := L)
+    have heq : (δ⁰ (L := L)
         (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum)) e =
-        (Stabilizer.Lattice.toricVertexCutMap (L := L)
+        (δ⁰ (L := L)
         (Stabilizer.Lattice.singleVtx (L := L) (originCoord L))) e := by
-      have hself := h_self_zero (Stabilizer.Lattice.toricVertexCutMap (L := L)
+      have hself := h_self_zero (δ⁰ (L := L)
         (Stabilizer.Lattice.singleVtx (L := L) (originCoord L)) e)
       -- From he and hself, conclude
-      have : (Stabilizer.Lattice.toricVertexCutMap (L := L)
+      have : (δ⁰ (L := L)
         (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleVtx (L := L) p)).sum)) e +
-        (Stabilizer.Lattice.toricVertexCutMap (L := L)
+        (δ⁰ (L := L)
         (Stabilizer.Lattice.singleVtx (L := L) (originCoord L))) e =
-        (Stabilizer.Lattice.toricVertexCutMap (L := L)
+        (δ⁰ (L := L)
         (Stabilizer.Lattice.singleVtx (L := L) (originCoord L))) e +
-        (Stabilizer.Lattice.toricVertexCutMap (L := L)
+        (δ⁰ (L := L)
         (Stabilizer.Lattice.singleVtx (L := L) (originCoord L))) e := by
         rw [he, hself]
       exact add_right_cancel this
@@ -428,31 +429,31 @@ private theorem dropped_face_in_closure_remaining (L : ℕ) [Fact (2 ≤ L)] :
         + Stabilizer.Lattice.singleFace (L := L) (originCoord L) =
       (fun _ : Fin L × Fin L => (1 : ZMod 2)) := h_decomp ▸ h_const
   have h_b2_trim_eq :
-      Stabilizer.Lattice.toricBoundary2 (L := L)
+      ∂₂ (L := L)
           (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleFace (L := L) p)).sum)
-        = Stabilizer.Lattice.toricBoundary2 (L := L)
+        = ∂₂ (L := L)
             (Stabilizer.Lattice.singleFace (L := L) (originCoord L)) := by
-    have h_apply := congrArg (Stabilizer.Lattice.toricBoundary2 (L := L)) h_trim_plus_origin
+    have h_apply := congrArg (∂₂ (L := L)) h_trim_plus_origin
     rw [LinearMap.map_add, toricBoundary2_constOne] at h_apply
     have h_self_zero : ∀ a : ZMod 2, a + a = 0 := fun a => by
       have h2 : (2 : ZMod 2) = 0 := by decide
       calc a + a = (2 : ZMod 2) * a := by ring
         _ = 0 := by rw [h2, zero_mul]
     ext e
-    have he : (Stabilizer.Lattice.toricBoundary2 (L := L)
+    have he : (∂₂ (L := L)
         (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleFace (L := L) p)).sum)) e +
-        (Stabilizer.Lattice.toricBoundary2 (L := L)
+        (∂₂ (L := L)
         (Stabilizer.Lattice.singleFace (L := L) (originCoord L))) e = 0 :=
       congrFun h_apply e
-    have hself := h_self_zero (Stabilizer.Lattice.toricBoundary2 (L := L)
+    have hself := h_self_zero (∂₂ (L := L)
       (Stabilizer.Lattice.singleFace (L := L) (originCoord L)) e)
-    have : (Stabilizer.Lattice.toricBoundary2 (L := L)
+    have : (∂₂ (L := L)
       (((coordsTrimmed L).map (fun p => Stabilizer.Lattice.singleFace (L := L) p)).sum)) e +
-      (Stabilizer.Lattice.toricBoundary2 (L := L)
+      (∂₂ (L := L)
       (Stabilizer.Lattice.singleFace (L := L) (originCoord L))) e =
-      (Stabilizer.Lattice.toricBoundary2 (L := L)
+      (∂₂ (L := L)
       (Stabilizer.Lattice.singleFace (L := L) (originCoord L))) e +
-      (Stabilizer.Lattice.toricBoundary2 (L := L)
+      (∂₂ (L := L)
       (Stabilizer.Lattice.singleFace (L := L) (originCoord L))) e := by
       rw [he, hself]
     exact add_right_cancel this
@@ -988,15 +989,15 @@ private lemma toSymplectic_vertexStab_Z_eq (L : ℕ) [Fact (2 ≤ L)]
     (p : Fin L × Fin L) (i : Fin (numQubits L)) :
     NQubitPauliOperator.toSymplectic (vertexStab L p.1 p.2).operators
         (Fin.natAdd (numQubits L) i) =
-      Stabilizer.Lattice.toricVertexCutMap (L := L)
+      δ⁰ (L := L)
         (Stabilizer.Lattice.singleVtx p) (qubitToEdgeIdx L i) := by
   haveI : Fact (0 < L) := ⟨lt_of_lt_of_le (by decide : 0 < 2) Fact.out⟩
   rw [NQubitPauliOperator.toSymplectic_Z_part]
   rw [show vertexStab L p.1 p.2 = Stabilizer.Lattice.toricZOperatorOfChain L
-        (Stabilizer.Lattice.toricVertexCutMap (L := L) (Stabilizer.Lattice.singleVtx p)) from
+        (δ⁰ (L := L) (Stabilizer.Lattice.singleVtx p)) from
     (Stabilizer.Lattice.toricZOperatorOfChain_cutMap_singleVtx L p.1 p.2).symm]
   rw [Stabilizer.Lattice.toricZOperatorOfChain_op_at]
-  set v := Stabilizer.Lattice.toricVertexCutMap (L := L)
+  set v := δ⁰ (L := L)
     (Stabilizer.Lattice.singleVtx p) (qubitToEdgeIdx L i) with hv
   rcases zmod2_zero_or_one v with h0 | h1
   · -- v = 0: no edge index has chain value 1 at i; symplectic = 0.
@@ -1022,15 +1023,15 @@ private lemma toSymplectic_faceStab_X_eq (L : ℕ) [Fact (2 ≤ L)]
     (p : Fin L × Fin L) (i : Fin (numQubits L)) :
     NQubitPauliOperator.toSymplectic (faceStab L p.1 p.2).operators
         (Fin.castAdd (numQubits L) i) =
-      Stabilizer.Lattice.toricBoundary2 (L := L)
+      ∂₂ (L := L)
         (Stabilizer.Lattice.singleFace p) (qubitToEdgeIdx L i) := by
   haveI : Fact (0 < L) := ⟨lt_of_lt_of_le (by decide : 0 < 2) Fact.out⟩
   rw [NQubitPauliOperator.toSymplectic_X_part]
   rw [show faceStab L p.1 p.2 = Stabilizer.Lattice.toricXOperatorOfChain L
-        (Stabilizer.Lattice.toricBoundary2 (L := L) (Stabilizer.Lattice.singleFace p)) from
+        (∂₂ (L := L) (Stabilizer.Lattice.singleFace p)) from
     (Stabilizer.Lattice.toricXOperatorOfChain_boundary_singleFace L p.1 p.2).symm]
   rw [Stabilizer.Lattice.toricXOperatorOfChain_op_at]
-  set v := Stabilizer.Lattice.toricBoundary2 (L := L)
+  set v := ∂₂ (L := L)
     (Stabilizer.Lattice.singleFace p) (qubitToEdgeIdx L i) with hv
   rcases zmod2_zero_or_one v with h0 | h1
   · rw [if_neg ?_]
@@ -1123,7 +1124,7 @@ trimmed coords whose `cutMap` is `0` must have all-zero coefficients. -/
 private lemma trimmed_combo_singleVtx_eq_zero (L : ℕ) [Fact (0 < L)]
     (c : Fin (coordsTrimmed L).length → ZMod 2)
     (hker : (∑ i, c i • Stabilizer.Lattice.singleVtx (L := L) ((coordsTrimmed L).get i)) ∈
-        LinearMap.ker (Stabilizer.Lattice.toricVertexCutMap (L := L))) :
+        LinearMap.ker (δ⁰ (L := L))) :
     ∀ i, c i = 0 := by
   classical
   rw [Stabilizer.Lattice.mem_ker_cutMap_iff] at hker
@@ -1177,7 +1178,7 @@ private lemma trimmed_combo_singleVtx_eq_zero (L : ℕ) [Fact (0 < L)]
 private lemma trimmed_combo_singleFace_eq_zero (L : ℕ) [Fact (0 < L)]
     (c : Fin (coordsTrimmed L).length → ZMod 2)
     (hker : (∑ i, c i • Stabilizer.Lattice.singleFace (L := L) ((coordsTrimmed L).get i)) ∈
-        LinearMap.ker (Stabilizer.Lattice.toricBoundary2 (L := L))) :
+        LinearMap.ker (∂₂ (L := L))) :
     ∀ i, c i = 0 := by
   classical
   rw [Stabilizer.Lattice.mem_ker_boundary2_iff] at hker
@@ -1248,7 +1249,7 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
   -- The Z-half of the sum at each edge yields the chain combination.
   have h_chain_Z : (∑ i, cZ i • Stabilizer.Lattice.singleVtx (L := L)
       ((coordsTrimmed L).get i)) ∈
-      LinearMap.ker (Stabilizer.Lattice.toricVertexCutMap (L := L)) := by
+      LinearMap.ker (δ⁰ (L := L)) := by
     rw [LinearMap.mem_ker]
     ext e
     -- Specialize hsum at column Fin.natAdd (numQubits L) (edgeToQubitIdx L e).
@@ -1325,14 +1326,14 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
         NQubitPauliGroupElement.checkMatrix (generatorsListPackaged L)
           ⟨k.val, by have := k.isLt; omega⟩
           (Fin.natAdd (numQubits L) (Stabilizer.Lattice.edgeToQubitIdx L e)) =
-        Stabilizer.Lattice.toricVertexCutMap (L := L)
+        δ⁰ (L := L)
           (Stabilizer.Lattice.singleVtx (L := L) ((coordsTrimmed L).get k)) e := by
       intro k
       have hp_eq := get_packaged_Z L k (by have := k.isLt; omega)
       unfold NQubitPauliGroupElement.checkMatrix
       rw [hp_eq, toSymplectic_vertexStab_Z_eq, qubitToEdgeIdx_edgeToQubitIdx]
     have h_col' : ∑ k : Fin (coordsTrimmed L).length, cZ k *
-        Stabilizer.Lattice.toricVertexCutMap (L := L)
+        δ⁰ (L := L)
           (Stabilizer.Lattice.singleVtx (L := L) ((coordsTrimmed L).get k)) e = 0 := by
       rw [← h_col]
       apply Finset.sum_congr rfl
@@ -1345,9 +1346,9 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
     apply Finset.sum_congr rfl
     intro k _
     rw [LinearMap.map_smul]
-    change cZ k • Stabilizer.Lattice.toricVertexCutMap (L := L)
+    change cZ k • δ⁰ (L := L)
         (Stabilizer.Lattice.singleVtx (L := L) ((coordsTrimmed L).get k)) e =
-      cZ k * Stabilizer.Lattice.toricVertexCutMap (L := L)
+      cZ k * δ⁰ (L := L)
         (Stabilizer.Lattice.singleVtx (L := L) ((coordsTrimmed L).get k)) e
     rw [smul_eq_mul]
   -- Now apply Z-block kernel collapse to get cZ = 0.
@@ -1364,7 +1365,7 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
       omega⟩
   have h_chain_X : (∑ i, cX i • Stabilizer.Lattice.singleFace (L := L)
       ((coordsTrimmed L).get i)) ∈
-      LinearMap.ker (Stabilizer.Lattice.toricBoundary2 (L := L)) := by
+      LinearMap.ker (∂₂ (L := L)) := by
     rw [LinearMap.mem_ker]
     ext e
     have h_col := congr_fun hsum (Fin.castAdd (numQubits L)
@@ -1445,7 +1446,7 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
         NQubitPauliGroupElement.checkMatrix (generatorsListPackaged L)
           ⟨nZ + k.val, by have := k.isLt; omega⟩
           (Fin.castAdd (numQubits L) (Stabilizer.Lattice.edgeToQubitIdx L e)) =
-        Stabilizer.Lattice.toricBoundary2 (L := L)
+        ∂₂ (L := L)
           (Stabilizer.Lattice.singleFace (L := L) ((coordsTrimmed L).get k)) e := by
       intro k
       have hge : nZ ≤ nZ + k.val := Nat.le_add_right _ _
@@ -1465,7 +1466,7 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
         omega
       rw [hcoord_eq]
     have h_col' : ∑ k : Fin (coordsTrimmed L).length, cX k *
-        Stabilizer.Lattice.toricBoundary2 (L := L)
+        ∂₂ (L := L)
           (Stabilizer.Lattice.singleFace (L := L) ((coordsTrimmed L).get k)) e = 0 := by
       rw [← h_col]
       apply Finset.sum_congr rfl
@@ -1477,9 +1478,9 @@ private theorem rowsLinearIndependent_generatorsListPackaged (L : ℕ) [Fact (2 
     apply Finset.sum_congr rfl
     intro k _
     rw [LinearMap.map_smul]
-    change cX k • Stabilizer.Lattice.toricBoundary2 (L := L)
+    change cX k • ∂₂ (L := L)
         (Stabilizer.Lattice.singleFace (L := L) ((coordsTrimmed L).get k)) e =
-      cX k * Stabilizer.Lattice.toricBoundary2 (L := L)
+      cX k * ∂₂ (L := L)
         (Stabilizer.Lattice.singleFace (L := L) ((coordsTrimmed L).get k)) e
     rw [smul_eq_mul]
   have hX_zero : ∀ i, cX i = 0 := trimmed_combo_singleFace_eq_zero L cX h_chain_X

--- a/QEC/Stabilizer/Codes/Toric/WrappingInvariants.lean
+++ b/QEC/Stabilizer/Codes/Toric/WrappingInvariants.lean
@@ -8,6 +8,7 @@ namespace Stabilizer
 namespace Lattice
 
 open scoped BigOperators
+open scoped Homology
 open scoped ToricChain
 
 variable (L : ℕ)
@@ -46,15 +47,15 @@ def vAtLinear (y0 : Fin L) : C1 L →ₗ[ZMod 2] ZMod 2 where
 variable [Fact (0 < L)]
 
 /-- Section-6 invariant `h` on cycles (using distinguished column `x=0`). -/
-def hWrap (c : toricCycles (L := L)) : ZMod 2 :=
+def hWrap (c : Z₁ L) : ZMod 2 :=
   hAt (L := L) (zeroCoord L) c.1
 
 /-- Section-6 invariant `v` on cycles (using distinguished row `y=0`). -/
-def vWrap (c : toricCycles (L := L)) : ZMod 2 :=
+def vWrap (c : Z₁ L) : ZMod 2 :=
   vAt (L := L) (zeroCoord L) c.1
 
 /-- Pairing of cycle invariants `(h,v)` before quotienting by boundaries. -/
-def phiOnCycles (c : toricCycles (L := L)) : ZMod 2 × ZMod 2 :=
+def phiOnCycles (c : Z₁ L) : ZMod 2 × ZMod 2 :=
   (hWrap (L := L) c, vWrap (L := L) c)
 
 /-- `hAt` is linear in the chain argument. -/
@@ -72,7 +73,7 @@ theorem vAt_linear (y0 : Fin L) :
   simp [vAt, Finset.sum_add_distrib]
 
 /-- `hAt` is independent of the chosen column on cycles. -/
-theorem hAt_independent_on_cycles (c : toricCycles (L := L)) (x0 x1 : Fin L) :
+theorem hAt_independent_on_cycles (c : Z₁ L) (x0 x1 : Fin L) :
     hAt (L := L) x0 c.1 = hAt (L := L) x1 c.1 := by
   have hAt_indep : ∀ x : Fin L, hAt L x c.1 = hAt L (prev L x) c.1 := by
     intro x
@@ -119,7 +120,7 @@ theorem hAt_independent_on_cycles (c : toricCycles (L := L)) (x0 x1 : Fin L) :
     (show (x0 : ℕ) ≤ x1 + L from by linarith [Fin.is_lt x0, Fin.is_lt x1]), Nat.mod_eq_of_lt]
 
 /-- `vAt` is independent of the chosen row on cycles. -/
-theorem vAt_independent_on_cycles (c : toricCycles (L := L)) (y0 y1 : Fin L) :
+theorem vAt_independent_on_cycles (c : Z₁ L) (y0 y1 : Fin L) :
     vAt (L := L) y0 c.1 = vAt (L := L) y1 c.1 := by
   have h_B1_gen : ∀ y : Fin L, vAt (L := L) y (c.1) = vAt (L := L) (prev (L := L) y) (c.1) := by
     intro y
@@ -160,7 +161,7 @@ theorem vAt_independent_on_cycles (c : toricCycles (L := L)) (y0 y1 : Fin L) :
     (show (y0 : ℕ) ≤ y1 + L from by linarith [Fin.is_lt y0, Fin.is_lt y1]), Nat.mod_eq_of_lt]
 
 /-- Boundaries have trivial `h` invariant. -/
-theorem h_boundary_zero (b : toricBoundaries (L := L)) :
+theorem h_boundary_zero (b : B₁ L) :
     hAt (L := L) (zeroCoord L) b.1 = 0 := by
   rcases b with ⟨b, hb⟩
   rcases hb with ⟨f, rfl⟩
@@ -188,7 +189,7 @@ theorem h_boundary_zero (b : toricBoundaries (L := L)) :
   simpa [toricBoundary2, Finset.sum_add_distrib, hsum_prev] using hdouble_zero
 
 /-- Boundaries have trivial `v` invariant. -/
-theorem v_boundary_zero (b : toricBoundaries (L := L)) :
+theorem v_boundary_zero (b : B₁ L) :
     vAt (L := L) (zeroCoord L) b.1 = 0 := by
   rcases b with ⟨b, hb⟩
   rcases hb with ⟨f, rfl⟩
@@ -216,14 +217,14 @@ theorem v_boundary_zero (b : toricBoundaries (L := L)) :
   simpa [toricBoundary2, Finset.sum_add_distrib, hsum_prev] using hdouble_zero
 
 /-- Quotient-level `(h,v)` map is well-defined. -/
-noncomputable def phi : toricH1 (L := L) → ZMod 2 × ZMod 2 :=
+noncomputable def phi : H₁ L → ZMod 2 × ZMod 2 :=
   -- Inline the boundary-submodule-in-cycles so Lean can synthesize instances on
   -- the explicit `⧸` quotient, sidestepping the opaque `toricH1` def.
-  let N : Submodule (ZMod 2) (toricCycles (L := L)) :=
-    Submodule.comap (toricCycles (L := L)).subtype (toricBoundaries (L := L))
+  let N : Submodule (ZMod 2) (Z₁ L) :=
+    Submodule.comap (Z₁ L).subtype (B₁ L)
   -- Define phiLin with an explicit toFun so application reduces by rfl,
   -- avoiding the `Pi.prod` intermediate form from `LinearMap.prod`.
-  let phiLin : toricCycles (L := L) →ₗ[ZMod 2] ZMod 2 × ZMod 2 :=
+  let phiLin : Z₁ L →ₗ[ZMod 2] ZMod 2 × ZMod 2 :=
     { toFun := fun c => (hAt (L := L) (zeroCoord L) c.1, vAt (L := L) (zeroCoord L) c.1)
       map_add' := fun a b => by
         simp only [Submodule.coe_add]
@@ -232,19 +233,19 @@ noncomputable def phi : toricH1 (L := L) → ZMod 2 × ZMod 2 :=
       map_smul' := fun r c => by
         simp only [RingHom.id_apply, Submodule.coe_smul_of_tower]
         ext <;> simp [hAt, vAt, Finset.mul_sum] }
-  -- `Submodule.liftQ` produces a linear map on `toricCycles L ⧸ N`,
-  -- which is definitionally `toricH1 L`.
+  -- `Submodule.liftQ` produces a linear map on `Z₁ L ⧸ N`,
+  -- which is definitionally `H₁ L`.
   Submodule.liftQ N phiLin (by
     intro c hc
     rw [LinearMap.mem_ker]
     rw [Submodule.mem_comap] at hc
-    -- hc : c.1 ∈ toricBoundaries L
+    -- hc : c.1 ∈ B₁ L
     have hh := h_boundary_zero (L := L) ⟨c.1, hc⟩
     have hv := v_boundary_zero (L := L) ⟨c.1, hc⟩
     exact Prod.ext hh hv)
 
 /-- `phi` agrees with the underlying linear lift on equivalence classes. -/
-theorem phi_liftQ_eq (c : toricCycles (L := L)) :
+theorem phi_liftQ_eq (c : Z₁ L) :
     phi (L := L) (Submodule.Quotient.mk c) =
       (hAt (L := L) (zeroCoord L) c.1, vAt (L := L) (zeroCoord L) c.1) := by
   simp only [phi, Submodule.liftQ_apply, LinearMap.coe_mk, AddHom.coe_mk]
@@ -273,8 +274,8 @@ theorem phi_surjective :
   simp +decide [ hAt, vAt, hc ]
 
 /-- phi as an explicit linear map. -/
-noncomputable def phiLinearMap : (toricCycles (L := L) ⧸
-    Submodule.comap (toricCycles (L := L)).subtype (toricBoundaries (L := L))) →ₗ[ZMod 2]
+noncomputable def phiLinearMap : (Z₁ L ⧸
+    Submodule.comap (Z₁ L).subtype (B₁ L)) →ₗ[ZMod 2]
     ZMod 2 × ZMod 2 :=
   Submodule.liftQ _ {
     toFun := fun c => (hAt (L := L) (zeroCoord L) c.1, vAt (L := L) (zeroCoord L) c.1)
@@ -296,7 +297,7 @@ noncomputable def phiLinearMap : (toricCycles (L := L) ⧸
 /-
 phi agrees with phiLinearMap.
 -/
-theorem phi_eq_phiLinearMap (x : toricH1 (L := L)) :
+theorem phi_eq_phiLinearMap (x : H₁ L) :
     phi (L := L) x = phiLinearMap (L := L) x := by
   convert rfl
 
@@ -307,9 +308,9 @@ theorem phi_injective :
   have h1 : Function.Injective (⇑(phiLinearMap (L := L))) ↔
       Function.Surjective (⇑(phiLinearMap (L := L))) := by
     apply LinearMap.injective_iff_surjective_of_finrank_eq_finrank
-    have : Module.finrank (ZMod 2)
-        (↑(toricCycles (L := L)) ⧸
-          Submodule.comap (toricCycles (L := L)).subtype (toricBoundaries (L := L))) = 2 :=
+    have : dim₂
+        (↑(Z₁ L) ⧸
+          Submodule.comap (Z₁ L).subtype (B₁ L)) = 2 :=
       toric_finrank_H1_eq_two (L := L)
     rw [this]
     simp [Module.finrank_prod]
@@ -324,7 +325,7 @@ theorem phi_injective :
 /-- `H₁ ≃ (Z/2Z)²` via wrapping invariants. -/
 theorem phi_equiv
     :
-    ∃ _ : toricH1 (L := L) ≃ₗ[ZMod 2] (ZMod 2 × ZMod 2), True := by
+    ∃ _ : H₁ L ≃ₗ[ZMod 2] (ZMod 2 × ZMod 2), True := by
   have hphiLin_inj : Function.Injective (⇑(phiLinearMap (L := L))) := by
     intro x y hxy
     apply phi_injective (L := L)
@@ -334,7 +335,7 @@ theorem phi_equiv
     obtain ⟨x, hx⟩ := phi_surjective (L := L) z
     refine ⟨x, ?_⟩
     simpa [phi_eq_phiLinearMap (L := L) x] using hx
-  let e : toricH1 (L := L) ≃ₗ[ZMod 2] (ZMod 2 × ZMod 2) :=
+  let e : H₁ L ≃ₗ[ZMod 2] (ZMod 2 × ZMod 2) :=
     LinearEquiv.ofBijective (phiLinearMap (L := L)) ⟨hphiLin_inj, hphiLin_surj⟩
   exact ⟨e, trivial⟩
 

--- a/QEC/Stabilizer/Codes/Toric/WrappingInvariants.lean
+++ b/QEC/Stabilizer/Codes/Toric/WrappingInvariants.lean
@@ -8,6 +8,7 @@ namespace Stabilizer
 namespace Lattice
 
 open scoped BigOperators
+open scoped ToricChain
 
 variable (L : ℕ)
 
@@ -83,7 +84,7 @@ theorem hAt_independent_on_cycles (c : toricCycles (L := L)) (x0 x1 : Fin L) :
           c.val (EdgeIdx.h x y) + c.val (EdgeIdx.h (prev L x) y) +
             c.val (EdgeIdx.v x y) + c.val (EdgeIdx.v x (prev L y)) = 0 := by
         intro y
-        have h_cycle : toricBoundary1 (L := L) c.val (x, y) = 0 := by
+        have h_cycle : ∂₁ (L := L) c.val (x, y) = 0 := by
           exact c.2 |> fun h => by simp ;
         convert h_cycle using 1;
       aesop;
@@ -183,7 +184,7 @@ theorem h_boundary_zero (b : toricBoundaries (L := L)) :
             simp [two_mul]
       _ = 0 := by simp [h2]
   change (∑ y : Fin L,
-      toricBoundary2 (L := L) f (EdgeIdx.h z0 y)) = 0
+      ∂₂ (L := L) f (EdgeIdx.h z0 y)) = 0
   simpa [toricBoundary2, Finset.sum_add_distrib, hsum_prev] using hdouble_zero
 
 /-- Boundaries have trivial `v` invariant. -/
@@ -211,7 +212,7 @@ theorem v_boundary_zero (b : toricBoundaries (L := L)) :
             simp [two_mul]
       _ = 0 := by simp [h2]
   change (∑ x : Fin L,
-      toricBoundary2 (L := L) f (EdgeIdx.v x z0)) = 0
+      ∂₂ (L := L) f (EdgeIdx.v x z0)) = 0
   simpa [toricBoundary2, Finset.sum_add_distrib, hsum_prev] using hdouble_zero
 
 /-- Quotient-level `(h,v)` map is well-defined. -/
@@ -258,7 +259,7 @@ theorem phi_surjective :
   obtain ⟨c, hc⟩ : ∃ c : C1 L,
       (∀ x' : Fin L, ∀ y' : Fin L, c (EdgeIdx.h x' y') = if y' = zeroCoord L then x else 0) ∧
       (∀ x' : Fin L, ∀ y' : Fin L, c (EdgeIdx.v x' y') = if x' = zeroCoord L then y else 0) ∧
-      toricBoundary1 (L := L) c = 0 := by
+      ∂₁ (L := L) c = 0 := by
     refine ⟨
       (fun e =>
         match e with

--- a/QEC/Stabilizer/Codes/_TEMPLATE.lean
+++ b/QEC/Stabilizer/Codes/_TEMPLATE.lean
@@ -42,7 +42,8 @@ straightforwardly to:
   `logical_commute_cross` — for `k = 1` the `Subsingleton.elim` shortcut
   suffices; for `k ≥ 2` you need explicit case-splits on `Fin k × Fin k`.
 - **Parametric families** (toric, rotated surface, …) — generators are
-  defined as functions of `L`, the subgroup is parametric, and the
+  defined as functions of `L` (written with the symbolic `σ[n | i ↦ Z, …]`
+  form, see §1), the subgroup is parametric, and the
   `StabilizerCode` packaging often requires a *trimmed* generator list (see
   `ToricCodeNStabilizerCode.lean` for the pattern). The distance proof
   typically lives in a *separate file* (`<Code>Distance.lean`).
@@ -127,6 +128,24 @@ Conventions:
 
 **Non-CSS variant.** Mixed-Pauli generators use the same notation (e.g., the
 5-qubit perfect code's `σ[XZZXI]`); there is no Z/X partition.
+
+**Parametric variant.** When the qubit count and the positions are terms
+rather than numerals, use the symbolic form with the same leading tokens:
+
+```lean
+/-- The adjacent Z-check `Z_i Z_{i+1}` on `n + 2` qubits. -/
+def ZPair (n : ℕ) (i : Fin (n + 1)) : NQubitPauliGroupElement (n + 2) :=
+  σ[n + 2 | Fin.castSucc i ↦ Z, Fin.succ i ↦ Z]
+```
+
+`σ[n | i ↦ Z, j ↦ Z]` elaborates to exactly
+`⟨0, ((NQubitPauliOperator.identity n).set i PauliOperator.Z).set j PauliOperator.Z⟩`,
+the `.set`s in the written order, so the usual
+`simp [NQubitPauliOperator.set, NQubitPauliOperator.identity]` unfolding is
+unchanged; `P[n | …]` is the phase-less string, and the phase prefixes work the
+same way. Letters are `X`, `Y`, `Z` only — leave identity qubits out. See
+`Repetition/N.lean`, `Iceberg/N.lean`, and `Toric/CodeN.lean` (`vertexStab`,
+`faceStab`) for uses.
 -/
 
 /-!

--- a/QEC/Stabilizer/Codes/_TEMPLATE.lean
+++ b/QEC/Stabilizer/Codes/_TEMPLATE.lean
@@ -120,6 +120,10 @@ Conventions:
   `-σ[…]` = phase `-1`, `-iσ[…]` = phase `-i`.)
 - 0-based qubit indexing: the k-th letter is the operator on qubit k.
 - One `def` per generator. Name them `Z1, Z2, …, X1, X2, …`.
+- The bare Pauli string with no phase (an `NQubitPauliOperator n`) is `P[…]`:
+  `σ[ZZZIZII].operators = P[ZZZIZII]` by `rfl`, and `P[…]` elaborates to exactly
+  the bare `.set` chain. Reach for it in `operators`-level statements (support,
+  check-matrix rows) rather than spelling the chain out.
 
 **Non-CSS variant.** Mixed-Pauli generators use the same notation (e.g., the
 5-qubit perfect code's `σ[XZZXI]`); there is no Z/X partition.

--- a/QEC/Stabilizer/Codes/_TEMPLATE.lean
+++ b/QEC/Stabilizer/Codes/_TEMPLATE.lean
@@ -42,8 +42,10 @@ straightforwardly to:
   `logical_commute_cross` — for `k = 1` the `Subsingleton.elim` shortcut
   suffices; for `k ≥ 2` you need explicit case-splits on `Fin k × Fin k`.
 - **Parametric families** (toric, rotated surface, …) — generators are
-  defined as functions of `L` (written with the symbolic `σ[n | i ↦ Z, …]`
-  form, see §1), the subgroup is parametric, and the
+  defined as functions of `L` (the toric, repetition and iceberg families
+  write theirs with the symbolic `σ[n | i ↦ Z, …]` form, see §1; the rotated
+  surface code builds them through the homological-code layer instead),
+  the subgroup is parametric, and the
   `StabilizerCode` packaging often requires a *trimmed* generator list (see
   `ToricCodeNStabilizerCode.lean` for the pattern). The distance proof
   typically lives in a *separate file* (`<Code>Distance.lean`).

--- a/QEC/Stabilizer/Foundations/BinarySymplectic/SymplecticInner.lean
+++ b/QEC/Stabilizer/Foundations/BinarySymplectic/SymplecticInner.lean
@@ -57,22 +57,12 @@ exactly that operator-level form** — so `commutes_iff_symplectic_inner_zero`,
 the delaborator prints the form back as `⟪p, q⟫ₛ`. The `ₛ` suffix keeps it clear of
 mathlib's inner-product brackets `⟪x, y⟫_𝕜`.
 
-`NQubitPauliGroupElement.symplecticInner p q` and `NQubitPauliGroupElement.symp g` are the
-same two quantities as plain definitions (dot notation `p.symplecticInner q`, `g.symp`, and
-`symp '' S` as a set image); both unfold to the operator-level form by `rfl`
-(`symplecticInner_def`, `symp_def`, both `simp`). `symplecticInner` is `protected` so a bare
-`symplecticInner` keeps meaning the operator-level one in files that open both namespaces. -/
+The delaborator is `scoped` with the notation, so `⟪p, q⟫ₛ` only appears in files that can
+parse it; elsewhere the operator-level form prints as is. There is deliberately no
+group-level definition behind the notation: the operator-level function is the single
+normal form every lemma is stated in. -/
 
 namespace NQubitPauliGroupElement
-
-/-- Symplectic inner product of two Pauli group elements: that of their operator parts
-(`⟪p, q⟫ₛ` is notation for the unfolded form, see `symplecticInner_def`). -/
-protected def symplecticInner (p q : NQubitPauliGroupElement n) : ZMod 2 :=
-  NQubitPauliOperator.symplecticInner p.operators q.operators
-
-/-- The symplectic vector of a Pauli group element: that of its operator part. -/
-def symp (g : NQubitPauliGroupElement n) : Fin (n + n) → ZMod 2 :=
-  NQubitPauliOperator.toSymplectic g.operators
 
 /-- `⟪p, q⟫ₛ` is the symplectic inner product of the operator parts of the Pauli group
 elements `p`, `q`: it elaborates to exactly
@@ -82,16 +72,10 @@ scoped notation:max "⟪" p ", " q "⟫ₛ" =>
   NQubitPauliOperator.symplecticInner (NQubitPauliGroupElement.operators p)
     (NQubitPauliGroupElement.operators q)
 
-@[simp] lemma symplecticInner_def (p q : NQubitPauliGroupElement n) :
-    p.symplecticInner q = ⟪p, q⟫ₛ := rfl
-
-@[simp] lemma symp_def (g : NQubitPauliGroupElement n) :
-    symp g = NQubitPauliOperator.toSymplectic g.operators := rfl
-
 open Lean PrettyPrinter Delaborator SubExpr in
 /-- Display `NQubitPauliOperator.symplecticInner p.operators q.operators` as `⟪p, q⟫ₛ`;
 any other application of `symplecticInner` keeps the default printer. -/
-@[app_delab Quantum.NQubitPauliOperator.symplecticInner]
+@[scoped app_delab Quantum.NQubitPauliOperator.symplecticInner]
 def delabSymplecticInner : Delab :=
   whenPPOption getPPNotation <| whenNotPPOption getPPExplicit do
     let e ← getExpr
@@ -107,10 +91,27 @@ section RoundTrip
 example (p q : NQubitPauliGroupElement n) :
     ⟪p, q⟫ₛ = NQubitPauliOperator.symplecticInner p.operators q.operators := rfl
 
-example (p q : NQubitPauliGroupElement n) : p.symplecticInner q = ⟪p, q⟫ₛ := rfl
+open Lean Elab Command in
+/-- Display test: elaborate `stx` and check that its pretty-printed text is `expected`
+(`exact := false`: contains `expected`). Run through `run_cmd` so no `#`-command is needed. -/
+private def checkDisplay (stx : Syntax) (expected : String) (exact : Bool := true) :
+    CommandElabM Unit :=
+  liftTermElabM do
+    let e ← Term.elabTerm stx none
+    Term.synthesizeSyntheticMVarsNoPostponing
+    let s := toString (← Meta.ppExpr (← instantiateMVars e))
+    unless (if exact then s == expected else (s.splitOn expected).length > 1) do
+      throwError "display test failed:{indentD s}\nexpected{indentD expected}"
 
-example (g : NQubitPauliGroupElement n) : symp g = NQubitPauliOperator.toSymplectic g.operators :=
-  rfl
+run_cmd do
+  checkDisplay (← `(fun (p q : NQubitPauliGroupElement 3) => ⟪p, q⟫ₛ))
+    "⟪p, q⟫ₛ" (exact := false)
+-- a bare operator on one side keeps the default printer
+run_cmd do
+  checkDisplay
+    (← `(fun (op : NQubitPauliOperator 3) (q : NQubitPauliGroupElement 3) =>
+          NQubitPauliOperator.symplecticInner op q.operators))
+    "op.symplecticInner q.operators" (exact := false)
 
 end RoundTrip
 
@@ -225,8 +226,8 @@ lemma toSymplectic_inv_operators (g : NQubitPauliGroupElement n) :
   span of the symplectic vectors of the set. -/
 lemma toSymplectic_mem_span_of_mem_closure {S : Set (NQubitPauliGroupElement n)}
     {x : NQubitPauliGroupElement n} (hx : x ∈ Subgroup.closure S) :
-    toSymplectic x.operators ∈ span (ZMod 2) (NQubitPauliGroupElement.symp '' S) := by
-  let sp := span (ZMod 2) (NQubitPauliGroupElement.symp '' S)
+    toSymplectic x.operators ∈ span (ZMod 2) ((fun g => toSymplectic g.operators) '' S) := by
+  let sp := span (ZMod 2) ((fun g => toSymplectic g.operators) '' S)
   suffices toSymplectic x.operators ∈ sp by exact this
   refine Subgroup.closure_induction
     (p := fun k _ => toSymplectic k.operators ∈ sp) ?_ ?_ ?_ ?_ hx

--- a/QEC/Stabilizer/Foundations/BinarySymplectic/SymplecticInner.lean
+++ b/QEC/Stabilizer/Foundations/BinarySymplectic/SymplecticInner.lean
@@ -43,6 +43,83 @@ def symplecticInner (op₁ op₂ : NQubitPauliOperator n) : ZMod 2 :=
   (Finset.univ : Finset (Fin n)).sum (fun i =>
     PauliOperator.symplecticProductSingle (op₁ i) (op₂ i))
 
+end NQubitPauliOperator
+
+/-! ## Group-element level: `⟪p, q⟫ₛ` and `symp`
+
+Statements about Pauli group elements read the symplectic form off the operator parts,
+`symplecticInner p.operators q.operators`, and the symplectic vector as
+`toSymplectic g.operators`. The scoped notation `⟪p, q⟫ₛ` (scope
+`Quantum.NQubitPauliGroupElement`: active in that namespace and under
+`open NQubitPauliGroupElement` / `open scoped NQubitPauliGroupElement`) is a **macro onto
+exactly that operator-level form** — so `commutes_iff_symplectic_inner_zero`,
+`unfold NQubitPauliOperator.symplecticInner` and every existing lemma apply verbatim — and
+the delaborator prints the form back as `⟪p, q⟫ₛ`. The `ₛ` suffix keeps it clear of
+mathlib's inner-product brackets `⟪x, y⟫_𝕜`.
+
+`NQubitPauliGroupElement.symplecticInner p q` and `NQubitPauliGroupElement.symp g` are the
+same two quantities as plain definitions (dot notation `p.symplecticInner q`, `g.symp`, and
+`symp '' S` as a set image); both unfold to the operator-level form by `rfl`
+(`symplecticInner_def`, `symp_def`, both `simp`). `symplecticInner` is `protected` so a bare
+`symplecticInner` keeps meaning the operator-level one in files that open both namespaces. -/
+
+namespace NQubitPauliGroupElement
+
+/-- Symplectic inner product of two Pauli group elements: that of their operator parts
+(`⟪p, q⟫ₛ` is notation for the unfolded form, see `symplecticInner_def`). -/
+protected def symplecticInner (p q : NQubitPauliGroupElement n) : ZMod 2 :=
+  NQubitPauliOperator.symplecticInner p.operators q.operators
+
+/-- The symplectic vector of a Pauli group element: that of its operator part. -/
+def symp (g : NQubitPauliGroupElement n) : Fin (n + n) → ZMod 2 :=
+  NQubitPauliOperator.toSymplectic g.operators
+
+/-- `⟪p, q⟫ₛ` is the symplectic inner product of the operator parts of the Pauli group
+elements `p`, `q`: it elaborates to exactly
+`NQubitPauliOperator.symplecticInner p.operators q.operators`. Scoped: enable with
+`open scoped NQubitPauliGroupElement`. -/
+scoped notation:max "⟪" p ", " q "⟫ₛ" =>
+  NQubitPauliOperator.symplecticInner (NQubitPauliGroupElement.operators p)
+    (NQubitPauliGroupElement.operators q)
+
+@[simp] lemma symplecticInner_def (p q : NQubitPauliGroupElement n) :
+    p.symplecticInner q = ⟪p, q⟫ₛ := rfl
+
+@[simp] lemma symp_def (g : NQubitPauliGroupElement n) :
+    symp g = NQubitPauliOperator.toSymplectic g.operators := rfl
+
+open Lean PrettyPrinter Delaborator SubExpr in
+/-- Display `NQubitPauliOperator.symplecticInner p.operators q.operators` as `⟪p, q⟫ₛ`;
+any other application of `symplecticInner` keeps the default printer. -/
+@[app_delab Quantum.NQubitPauliOperator.symplecticInner]
+def delabSymplecticInner : Delab :=
+  whenPPOption getPPNotation <| whenNotPPOption getPPExplicit do
+    let e ← getExpr
+    guard (e.isAppOfArity ``Quantum.NQubitPauliOperator.symplecticInner 3)
+    guard ((e.getArg! 1).isAppOfArity ``Quantum.NQubitPauliGroupElement.operators 2)
+    guard ((e.getArg! 2).isAppOfArity ``Quantum.NQubitPauliGroupElement.operators 2)
+    let p ← withNaryArg 1 <| withNaryArg 1 delab
+    let q ← withNaryArg 2 <| withNaryArg 1 delab
+    `(⟪$p, $q⟫ₛ)
+
+section RoundTrip
+
+example (p q : NQubitPauliGroupElement n) :
+    ⟪p, q⟫ₛ = NQubitPauliOperator.symplecticInner p.operators q.operators := rfl
+
+example (p q : NQubitPauliGroupElement n) : p.symplecticInner q = ⟪p, q⟫ₛ := rfl
+
+example (g : NQubitPauliGroupElement n) : symp g = NQubitPauliOperator.toSymplectic g.operators :=
+  rfl
+
+end RoundTrip
+
+end NQubitPauliGroupElement
+
+namespace NQubitPauliOperator
+
+open scoped NQubitPauliGroupElement
+
 /-- The symplectic vector of the product operator is the pointwise sum (in ZMod 2)
   of the two symplectic vectors. -/
 lemma toSymplectic_add (p q : NQubitPauliOperator n) (j : Fin (n + n)) :
@@ -59,7 +136,7 @@ lemma toSymplectic_add (p q : NQubitPauliOperator n) (j : Fin (n + n)) :
   operator parts) is 0. The equivalence with the existing `commutes_iff_even_anticommutes`
   is proved later. -/
 theorem commutes_iff_symplectic_inner_zero (p q : NQubitPauliGroupElement n) :
-    p * q = q * p ↔ symplecticInner p.operators q.operators = 0 := by
+    p * q = q * p ↔ ⟪p, q⟫ₛ = 0 := by
   rw [NQubitPauliGroupElement.commutes_iff_even_anticommutes]
   unfold NQubitPauliOperator.symplecticInner;
   have h_symplecticProductSingle : ∀ P Q : PauliOperator,
@@ -74,7 +151,7 @@ theorem commutes_iff_symplectic_inner_zero (p q : NQubitPauliGroupElement n) :
 /-- Two n-qubit Pauli group elements anticommute iff their symplectic inner product
   (on the operator parts) is 1. -/
 theorem anticommutes_iff_symplectic_inner_one (p q : NQubitPauliGroupElement n) :
-    NQubitPauliGroupElement.Anticommute p q ↔ symplecticInner p.operators q.operators = 1 := by
+    NQubitPauliGroupElement.Anticommute p q ↔ ⟪p, q⟫ₛ = 1 := by
   rw [NQubitPauliGroupElement.anticommutes_iff_odd_anticommutes, Nat.odd_iff]
   unfold symplecticInner
   have h_symplecticProductSingle : ∀ P Q : PauliOperator,
@@ -123,6 +200,7 @@ The same proof idea as `mem_closure_implies_symp_in_span` in `SymplecticSpan.lea
 `S = listToSet L \ {g}`. -/
 
 open NQubitPauliOperator Submodule
+open scoped NQubitPauliGroupElement
 
 /-- The symplectic vector of the product is the sum of the symplectic vectors. -/
 lemma toSymplectic_mul (p q : NQubitPauliGroupElement n) (j : Fin (n + n)) :
@@ -147,8 +225,8 @@ lemma toSymplectic_inv_operators (g : NQubitPauliGroupElement n) :
   span of the symplectic vectors of the set. -/
 lemma toSymplectic_mem_span_of_mem_closure {S : Set (NQubitPauliGroupElement n)}
     {x : NQubitPauliGroupElement n} (hx : x ∈ Subgroup.closure S) :
-    toSymplectic x.operators ∈ span (ZMod 2) ((fun g => toSymplectic g.operators) '' S) := by
-  let sp := span (ZMod 2) ((fun g => toSymplectic g.operators) '' S)
+    toSymplectic x.operators ∈ span (ZMod 2) (NQubitPauliGroupElement.symp '' S) := by
+  let sp := span (ZMod 2) (NQubitPauliGroupElement.symp '' S)
   suffices toSymplectic x.operators ∈ sp by exact this
   refine Subgroup.closure_induction
     (p := fun k _ => toSymplectic k.operators ∈ sp) ?_ ?_ ?_ ?_ hx

--- a/QEC/Stabilizer/Foundations/PauliGroup/Notation.lean
+++ b/QEC/Stabilizer/Foundations/PauliGroup/Notation.lean
@@ -12,16 +12,21 @@ way the physics literature does:
 - `-σ[XXIXII]` — phase `-1` (`phasePower = 2`)
 - `-iσ[XXIXII]` — phase `-i` (`phasePower = 3`)
 
+and for the bare Pauli string with no phase at all, an `NQubitPauliOperator`:
+
+- `P[XXIXII]` — the operator part on its own, i.e. `σ[XXIXII].operators`
+
 The letters between the brackets form a single identifier over the alphabet `X`, `Y`,
 `Z`, `I`, read left to right as qubits `0, 1, …`; the number of letters fixes the number
-of qubits, so `σ[XIZ] : NQubitPauliGroupElement 3` with no ascription needed.
+of qubits, so `σ[XIZ] : NQubitPauliGroupElement 3` and `P[XIZ] : NQubitPauliOperator 3`
+with no ascription needed.
 
 The notation is **scoped**: enable it with `open scoped Pauli`. It must be opt-in
 because any notation whose leading token is `σ[` takes over that token from `GetElem`
-indexing (`σ[i]`) for variables named `σ` (likewise `iσ[…]` for variables named `iσ`).
-The phase prefixes are part of the leading token (`-σ[`, `iσ[`, `-iσ[`): write them with
-no space before `σ[`, and keep spaces around a binary `-` (`a - σ[XX]`) when you mean
-subtraction with the scope open.
+indexing (`σ[i]`) for variables named `σ` (likewise `iσ[…]` for variables named `iσ`, and
+`P[…]` for variables named `P`). The phase prefixes are part of the leading token (`-σ[`,
+`iσ[`, `-iσ[`): write them with no space before `σ[`, and keep spaces around a binary `-`
+(`a - σ[XX]`) when you mean subtraction with the scope open.
 
 ## Elaboration guarantee
 
@@ -32,20 +37,24 @@ concrete code files:
 ⟨phase, ((NQubitPauliOperator.identity n).set i₀ op₀).set i₁ op₁ ⋯⟩
 ```
 
-with `.set` applied only at the non-identity positions, in increasing index order. The
-notation is a macro (pure syntax expansion into that form), so kernel-reduction behavior
-and every existing `simp`/`decide`/`rfl` proof over such literals are unchanged. In
-particular there is deliberately no `ofList`-style helper on the elaboration path: a list
-lookup is an O(n) walk under kernel reduction (see the axiom-policy notes in
-`CLAUDE.md`), whereas the `.set` chain is the form all existing proofs already consume.
+with `.set` applied only at the non-identity positions, in increasing index order, and
+`P[…]` elaborates to exactly the operator half of that form, the bare `.set` chain (so
+`P[II…I]` is `NQubitPauliOperator.identity n` itself). The notation is a macro (pure
+syntax expansion into that form), so kernel-reduction behavior and every existing
+`simp`/`decide`/`rfl` proof over such literals are unchanged. In particular there is
+deliberately no `ofList`-style helper on the elaboration path: a list lookup is an O(n)
+walk under kernel reduction (see the axiom-policy notes in `CLAUDE.md`), whereas the
+`.set` chain is the form all existing proofs already consume.
 
 ## Delaborator
 
 Terms of exactly that literal shape (literal phase, literal indices, `PauliOperator`
 constructors, literal qubit count) display back as `σ[…]`/`iσ[…]`/`-σ[…]`/`-iσ[…]` in
-goals and diagnostics. Anything else — variable phase or operators, symbolic indices, a
-partially reduced chain — is left to the default printer. The delaborator is registered
-globally, so the display is independent of whether the scope is open;
+goals and diagnostics, and a literal-shaped `.set` chain on its own displays as `P[…]`
+(so an element whose phase is not a literal shows as `⟨k, P[…]⟩`; a bare `identity n`
+keeps its name). Anything else — variable phase or operators, symbolic indices, a
+partially reduced chain — is left to the default printer. The delaborators are
+registered globally, so the display is independent of whether the scope is open;
 `set_option pp.notation false` (or `pp.explicit true`) recovers the raw term.
 -/
 
@@ -71,6 +80,12 @@ scoped syntax:max (name := negSigma) "-σ[" ident "]" : term
 Scoped: enable with `open scoped Pauli`. -/
 scoped syntax:max (name := negISigma) "-iσ[" ident "]" : term
 
+/-- `P[XZIX]` is the bare Pauli string, an `NQubitPauliOperator` with no phase, whose
+operator at qubit `k` is the `k`-th letter (letters `X`, `Y`, `Z`, `I`; qubit count =
+letter count); it is `σ[XZIX].operators`. Scoped: enable with `open scoped Pauli`.
+Elaborates to the literal `(NQubitPauliOperator.identity n).set i₀ op₀ …` normal form. -/
+scoped syntax:max (name := pauliString) "P[" ident "]" : term
+
 /-- Split the letters identifier of a `σ[…]`-family literal into its characters, checking
 that the identifier is a single atomic name over the alphabet `X`, `Y`, `Z`, `I`. -/
 def pauliLetters (stx : Syntax) : MacroM (List Char) := do
@@ -82,10 +97,11 @@ def pauliLetters (stx : Syntax) : MacroM (List Char) := do
       Macro.throwErrorAt stx s!"invalid Pauli letter '{c}': expected X, Y, Z, or I"
   return cs
 
-/-- Expand a `σ[…]`-family literal with the given `phasePower` into the canonical normal
-form `NQubitPauliGroupElement.mk phase ((NQubitPauliOperator.identity n).set i₀ op₀ …)`,
-setting only the non-identity positions, in increasing index order. -/
-def expandSigma (phase : Nat) (letters : Syntax) : MacroM Term := do
+/-- Expand the letters of a literal into the canonical operator-string normal form
+`(NQubitPauliOperator.identity n).set i₀ op₀ …`, setting only the non-identity positions,
+in increasing index order. This is the expansion of `P[…]`, and the operator half of the
+`σ[…]` family. -/
+def expandPauliString (letters : Syntax) : MacroM Term := do
   let cs ← pauliLetters letters
   let mut ops : Term ← `(Quantum.NQubitPauliOperator.identity $(quote cs.length))
   let mut i : Nat := 0
@@ -97,6 +113,13 @@ def expandSigma (phase : Nat) (letters : Syntax) : MacroM Term := do
         | _ => `(Quantum.PauliOperator.Z)
       ops ← `(Quantum.NQubitPauliOperator.set $ops $(quote i) $opStx)
     i := i + 1
+  return ops
+
+/-- Expand a `σ[…]`-family literal with the given `phasePower` into the canonical normal
+form `NQubitPauliGroupElement.mk phase ((NQubitPauliOperator.identity n).set i₀ op₀ …)`,
+whose operator part is the `expandPauliString` chain. -/
+def expandSigma (phase : Nat) (letters : Syntax) : MacroM Term := do
+  let ops ← expandPauliString letters
   `(Quantum.NQubitPauliGroupElement.mk $(quote phase) $ops)
 
 macro_rules
@@ -104,11 +127,13 @@ macro_rules
   | `(iσ[$letters:ident]) => expandSigma 1 letters
   | `(-σ[$letters:ident]) => expandSigma 2 letters
   | `(-iσ[$letters:ident]) => expandSigma 3 letters
+  | `(P[$letters:ident]) => expandPauliString letters
 
 /-!
 ## Delaborator
 
-Displays literal-shaped `NQubitPauliGroupElement.mk` applications back as `σ[…]`.
+Displays literal-shaped `NQubitPauliGroupElement.mk` applications back as `σ[…]`, and
+literal-shaped `NQubitPauliOperator.set` chains back as `P[…]`.
 -/
 
 section Delaborator
@@ -153,6 +178,16 @@ partial def setChain? (e : Expr) (acc : List (Nat × Char) := []) :
   else
     none
 
+/-- The letters identifier of a literal chain over `n > 0` qubits whose indices are all
+in range, or `none` otherwise. Later (outer) `.set`s override earlier ones, so the
+innermost-first assignment list is folded left to right. -/
+def lettersOf? (n : Nat) (sets : List (Nat × Char)) : Option Ident := do
+  guard (0 < n)
+  guard (sets.all fun ic => ic.1 < n)
+  let letters := String.ofList <| (List.range n).map fun j =>
+    sets.foldl (fun acc ic => if ic.1 == j then ic.2 else acc) 'I'
+  return mkIdent (.mkSimple letters)
+
 /-- Delaborate literal-shaped `NQubitPauliGroupElement.mk` applications back to the
 `σ[…]`/`iσ[…]`/`-σ[…]`/`-iσ[…]` notation. Fires only when the phase is a literal
 `0`–`3`, the operator part is a literal `set`-chain over `identity n` with in-range
@@ -164,18 +199,27 @@ def delabSigma : Delab :=
     unless e.isAppOfArity ``Quantum.NQubitPauliGroupElement.mk 3 do failure
     let some phase := natLitOf? (e.getArg! 1) | failure
     let some (n, sets) := setChain? (e.getArg! 2) | failure
-    unless 0 < n do failure
-    unless sets.all (fun ic => ic.1 < n) do failure
-    -- Later (outer) `.set`s override earlier ones, so fold innermost-first.
-    let letters := String.ofList <| (List.range n).map fun j =>
-      sets.foldl (fun acc ic => if ic.1 == j then ic.2 else acc) 'I'
-    let letters := mkIdent (.mkSimple letters)
+    let some letters := lettersOf? n sets | failure
     match phase with
     | 0 => `(σ[$letters])
     | 1 => `(iσ[$letters])
     | 2 => `(-σ[$letters])
     | 3 => `(-iσ[$letters])
     | _ => failure
+
+/-- Delaborate literal-shaped `NQubitPauliOperator.set` chains back to the `P[…]`
+notation. Fires only on a `set` application whose whole chain is literal over
+`identity n` with in-range literal indices and `n > 0`; stays silent otherwise (in
+particular a bare `identity n` keeps its name). An over-applied chain — the operator
+string evaluated at a qubit, `P[XIZ] i` — is handled by `withOverApp`, so the extra
+arguments follow the notation. -/
+@[app_delab Quantum.NQubitPauliOperator.set]
+def delabPauliString : Delab :=
+  whenPPOption getPPNotation <| whenNotPPOption getPPExplicit <| withOverApp 4 do
+    let e ← getExpr
+    let some (n, sets) := setChain? e | failure
+    let some letters := lettersOf? n sets | failure
+    `(P[$letters])
 
 end Delaborator
 
@@ -184,7 +228,8 @@ end Pauli
 /-!
 ## Round-trip tests
 
-Each phase prefix elaborates to exactly the hand-written literal normal form.
+Each phase prefix elaborates to exactly the hand-written literal normal form, and `P[…]`
+to exactly its operator half.
 -/
 
 section RoundTrip
@@ -219,5 +264,17 @@ example : σ[XIZ].phasePower = 0 := rfl
 example : σ[XIZ].operators 2 = PauliOperator.Z := rfl
 
 example : σ[XIZ].operators 1 = PauliOperator.I := rfl
+
+example :
+    P[XIZ] = ((NQubitPauliOperator.identity 3).set 0 PauliOperator.X).set 2 PauliOperator.Z :=
+  rfl
+
+example : P[III] = NQubitPauliOperator.identity 3 := rfl
+
+example : P[XIZ] 2 = PauliOperator.Z := rfl
+
+example : σ[XIZ].operators = P[XIZ] := rfl
+
+example : (⟨1, P[YY]⟩ : NQubitPauliGroupElement 2) = iσ[YY] := rfl
 
 end RoundTrip

--- a/QEC/Stabilizer/Foundations/PauliGroup/Notation.lean
+++ b/QEC/Stabilizer/Foundations/PauliGroup/Notation.lean
@@ -21,6 +21,16 @@ The letters between the brackets form a single identifier over the alphabet `X`,
 of qubits, so `σ[XIZ] : NQubitPauliGroupElement 3` and `P[XIZ] : NQubitPauliOperator 3`
 with no ascription needed.
 
+Parametric families, whose qubit count and positions are terms rather than numerals, use
+the **symbolic form** with the same leading tokens:
+
+- `σ[n | i ↦ Z, j ↦ Z]` — `Z` at qubits `i` and `j` of `n`, phase `+1`
+- `iσ[n | …]`, `-σ[n | …]`, `-iσ[n | …]` — the same with the phase prefixes
+- `P[n | i ↦ Z, j ↦ Z]` — the bare Pauli string
+
+where `n` and the indices are arbitrary terms and the letters are `X`, `Y`, `Z` (see
+§ "Symbolic (parametric) form" below).
+
 The notation is **scoped**: enable it with `open scoped Pauli`. It must be opt-in
 because any notation whose leading token is `σ[` takes over that token from `GetElem`
 indexing (`σ[i]`) for variables named `σ` (likewise `iσ[…]` for variables named `iσ`, and
@@ -52,10 +62,14 @@ Terms of exactly that literal shape (literal phase, literal indices, `PauliOpera
 constructors, literal qubit count) display back as `σ[…]`/`iσ[…]`/`-σ[…]`/`-iσ[…]` in
 goals and diagnostics, and a literal-shaped `.set` chain on its own displays as `P[…]`
 (so an element whose phase is not a literal shows as `⟨k, P[…]⟩`; a bare `identity n`
-keeps its name). Anything else — variable phase or operators, symbolic indices, a
-partially reduced chain — is left to the default printer. The delaborators are
-registered globally, so the display is independent of whether the scope is open;
-`set_option pp.notation false` (or `pp.explicit true`) recovers the raw term.
+keeps its name). A `.set` chain over an `identity n` that is not of that literal shape —
+symbolic qubit count or indices, an out-of-range literal index — displays in the symbolic
+form `σ[n | i ↦ Z, …]` / `P[n | i ↦ Z, …]` as long as its operators are `X`/`Y`/`Z`
+constructors, with the `.set`s listed innermost first (the written order). Anything else
+— variable phase or operators, an explicit `I`, a chain not rooted at `identity` — is left
+to the default printer. The delaborators are registered globally, so the display is
+independent of whether the scope is open; `set_option pp.notation false` (or
+`pp.explicit true`) recovers the raw term.
 -/
 
 namespace Pauli
@@ -130,10 +144,92 @@ macro_rules
   | `(P[$letters:ident]) => expandPauliString letters
 
 /-!
+## Symbolic (parametric) form
+
+`σ[n | i ↦ Z, j ↦ Z]` is the same literal with the qubit count `n` and the indices
+`i`, `j` arbitrary terms — the form parametric families need, where the qubit count is
+`numQubits L` or `n + 2` and the positions are `hEdge L x y` or `Fin.succ i`. It expands
+to exactly
+
+```lean
+⟨0, ((NQubitPauliOperator.identity n).set i PauliOperator.Z).set j PauliOperator.Z⟩
+```
+
+with the `.set`s applied **in the written order** (there is no index to sort by), so a
+downstream `simp [NQubitPauliOperator.set, NQubitPauliOperator.identity]` sees the same
+chain it always did. The letters are `X`, `Y`, `Z` (an explicit `I` is rejected: leave the
+qubit out instead). The phase prefixes and `P[n | …]` work the same way.
+-/
+
+/-- One qubit assignment `i ↦ Z` in a symbolic `σ[n | …]`-family literal: the index `i` is
+an arbitrary term, the letter is `X`, `Y`, or `Z`. -/
+syntax pauliAssign := term " ↦ " ident
+
+/-- `σ[n | i ↦ Z, j ↦ Z]` is the `NQubitPauliGroupElement n` with phase `+1` whose
+operator at `i` is `Z`, at `j` is `Z`, and `I` elsewhere, for arbitrary terms `n`, `i`,
+`j` (letters `X`, `Y`, `Z`). Scoped: enable with `open scoped Pauli`. Elaborates to the
+literal `⟨0, ((NQubitPauliOperator.identity n).set i Z).set j Z⟩`, the `.set`s in the
+written order. -/
+scoped syntax:max (name := sigmaSym) "σ[" term " | " pauliAssign,+ "]" : term
+
+/-- `iσ[n | i ↦ Z, …]`: as `σ[n | i ↦ Z, …]` but with phase `i` (`phasePower = 1`).
+Scoped: enable with `open scoped Pauli`. -/
+scoped syntax:max (name := iSigmaSym) "iσ[" term " | " pauliAssign,+ "]" : term
+
+/-- `-σ[n | i ↦ Z, …]`: as `σ[n | i ↦ Z, …]` but with phase `-1` (`phasePower = 2`).
+Scoped: enable with `open scoped Pauli`. -/
+scoped syntax:max (name := negSigmaSym) "-σ[" term " | " pauliAssign,+ "]" : term
+
+/-- `-iσ[n | i ↦ Z, …]`: as `σ[n | i ↦ Z, …]` but with phase `-i` (`phasePower = 3`).
+Scoped: enable with `open scoped Pauli`. -/
+scoped syntax:max (name := negISigmaSym) "-iσ[" term " | " pauliAssign,+ "]" : term
+
+/-- `P[n | i ↦ Z, j ↦ Z]` is the bare Pauli string on `n` qubits with `Z` at `i` and at
+`j`, for arbitrary terms `n`, `i`, `j`; it is `σ[n | i ↦ Z, j ↦ Z].operators`. Scoped:
+enable with `open scoped Pauli`. Elaborates to the literal
+`((NQubitPauliOperator.identity n).set i Z).set j Z`, the `.set`s in the written order. -/
+scoped syntax:max (name := pauliStringSym) "P[" term " | " pauliAssign,+ "]" : term
+
+/-- The `PauliOperator` constructor named by a letter identifier `X`, `Y`, or `Z`. -/
+def pauliOpOfLetter (c : Ident) : MacroM Term :=
+  match c.getId.eraseMacroScopes with
+  | .str .anonymous "X" => `(Quantum.PauliOperator.X)
+  | .str .anonymous "Y" => `(Quantum.PauliOperator.Y)
+  | .str .anonymous "Z" => `(Quantum.PauliOperator.Z)
+  | _ => Macro.throwErrorAt c "expected a Pauli letter X, Y, or Z"
+
+/-- Expand the symbolic assignments `i₀ ↦ op₀, i₁ ↦ op₁, …` on `n` qubits into the chain
+`((NQubitPauliOperator.identity n).set i₀ op₀).set i₁ op₁ …`, in the written order. This
+is the expansion of `P[n | …]`, and the operator half of the `σ[n | …]` family. -/
+def expandSymbolicString (n : Term) (idxs : Array Term) (letters : Array Ident) :
+    MacroM Term := do
+  let mut ops : Term ← `(Quantum.NQubitPauliOperator.identity $n)
+  for i in idxs, c in letters do
+    let opStx ← pauliOpOfLetter c
+    ops ← `(Quantum.NQubitPauliOperator.set $ops $i $opStx)
+  return ops
+
+/-- Expand a symbolic `σ[n | …]`-family literal with the given `phasePower` into
+`NQubitPauliGroupElement.mk phase ((NQubitPauliOperator.identity n).set i₀ op₀ …)`. -/
+def expandSymbolicSigma (phase : Nat) (n : Term) (idxs : Array Term)
+    (letters : Array Ident) : MacroM Term := do
+  let ops ← expandSymbolicString n idxs letters
+  `(Quantum.NQubitPauliGroupElement.mk $(quote phase) $ops)
+
+macro_rules
+  | `(σ[$n | $[$is ↦ $cs],*]) => expandSymbolicSigma 0 n is cs
+  | `(iσ[$n | $[$is ↦ $cs],*]) => expandSymbolicSigma 1 n is cs
+  | `(-σ[$n | $[$is ↦ $cs],*]) => expandSymbolicSigma 2 n is cs
+  | `(-iσ[$n | $[$is ↦ $cs],*]) => expandSymbolicSigma 3 n is cs
+  | `(P[$n | $[$is ↦ $cs],*]) => expandSymbolicString n is cs
+
+/-!
 ## Delaborator
 
 Displays literal-shaped `NQubitPauliGroupElement.mk` applications back as `σ[…]`, and
-literal-shaped `NQubitPauliOperator.set` chains back as `P[…]`.
+literal-shaped `NQubitPauliOperator.set` chains back as `P[…]`; any other `.set` chain over
+an `identity n` whose operators are `X`/`Y`/`Z` constructors displays in the symbolic form
+`σ[n | i ↦ Z, …]` / `P[n | i ↦ Z, …]`.
 -/
 
 section Delaborator
@@ -188,38 +284,76 @@ def lettersOf? (n : Nat) (sets : List (Nat × Char)) : Option Ident := do
     sets.foldl (fun acc ic => if ic.1 == j then ic.2 else acc) 'I'
   return mkIdent (.mkSimple letters)
 
-/-- Delaborate literal-shaped `NQubitPauliGroupElement.mk` applications back to the
-`σ[…]`/`iσ[…]`/`-σ[…]`/`-iσ[…]` notation. Fires only when the phase is a literal
-`0`–`3`, the operator part is a literal `set`-chain over `identity n` with in-range
-literal indices, and `n > 0`; stays silent otherwise. -/
+/-- The letters identifier of the literal `set`-chain at the current position, if it is
+one over `n > 0` qubits with in-range literal indices. -/
+def literalLetters? (e : Expr) : Option Ident := do
+  let (n, sets) ← setChain? e
+  lettersOf? n sets
+
+/-- Delaborate the symbolic `set`-chain at the current position: a chain
+`((NQubitPauliOperator.identity n).set i₀ op₀).set i₁ op₁ …` whose operators are `X`/`Y`/`Z`
+constructors, with `n` and the indices arbitrary. Returns the delaborated `n` and the
+delaborated indices with their letters, innermost first (the written order of the
+notation); each subterm is delaborated at its own position, so hover and
+`pp.` options behave as usual. Fails on any other shape, including an explicit `I`. -/
+partial def delabSymbolicChain : DelabM (Term × Array Term × Array Ident) := do
+  let e ← getExpr
+  if e.isAppOfArity ``Quantum.NQubitPauliOperator.set 4 then
+    let some c := pauliOpChar? (e.getArg! 3) | failure
+    if c == 'I' then failure
+    let (n, is, cs) ← withNaryArg 1 delabSymbolicChain
+    let i ← withNaryArg 2 delab
+    return (n, is.push i, cs.push (mkIdent (.mkSimple (toString c))))
+  else if e.isAppOfArity ``Quantum.NQubitPauliOperator.identity 1 then
+    let n ← withNaryArg 0 delab
+    return (n, #[], #[])
+  else
+    failure
+
+/-- Delaborate `NQubitPauliGroupElement.mk` applications back to the
+`σ[…]`/`iσ[…]`/`-σ[…]`/`-iσ[…]` notation. Fires only when the phase is a literal `0`–`3`
+and the operator part is a `set`-chain over `identity n`: a literal chain (literal `n > 0`,
+in-range literal indices) displays in the letters form `σ[XIZ]`, any other chain with
+`X`/`Y`/`Z` operators in the symbolic form `σ[n | i ↦ Z, …]`; stays silent otherwise. -/
 @[app_delab Quantum.NQubitPauliGroupElement.mk]
 def delabSigma : Delab :=
   whenPPOption getPPNotation <| whenNotPPOption getPPExplicit do
     let e ← getExpr
     unless e.isAppOfArity ``Quantum.NQubitPauliGroupElement.mk 3 do failure
     let some phase := natLitOf? (e.getArg! 1) | failure
-    let some (n, sets) := setChain? (e.getArg! 2) | failure
-    let some letters := lettersOf? n sets | failure
-    match phase with
-    | 0 => `(σ[$letters])
-    | 1 => `(iσ[$letters])
-    | 2 => `(-σ[$letters])
-    | 3 => `(-iσ[$letters])
-    | _ => failure
+    if let some letters := literalLetters? (e.getArg! 2) then
+      match phase with
+      | 0 => `(σ[$letters])
+      | 1 => `(iσ[$letters])
+      | 2 => `(-σ[$letters])
+      | 3 => `(-iσ[$letters])
+      | _ => failure
+    else
+      let (n, is, cs) ← withNaryArg 2 delabSymbolicChain
+      if is.isEmpty then failure
+      match phase with
+      | 0 => `(σ[$n | $[$is ↦ $cs],*])
+      | 1 => `(iσ[$n | $[$is ↦ $cs],*])
+      | 2 => `(-σ[$n | $[$is ↦ $cs],*])
+      | 3 => `(-iσ[$n | $[$is ↦ $cs],*])
+      | _ => failure
 
-/-- Delaborate literal-shaped `NQubitPauliOperator.set` chains back to the `P[…]`
-notation. Fires only on a `set` application whose whole chain is literal over
-`identity n` with in-range literal indices and `n > 0`; stays silent otherwise (in
-particular a bare `identity n` keeps its name). An over-applied chain — the operator
-string evaluated at a qubit, `P[XIZ] i` — is handled by `withOverApp`, so the extra
-arguments follow the notation. -/
+/-- Delaborate `NQubitPauliOperator.set` chains back to the `P[…]` notation. Fires only on
+a `set` application whose whole chain runs over an `identity n`: a literal chain (literal
+`n > 0`, in-range literal indices) displays as `P[XIZ]`, any other chain with `X`/`Y`/`Z`
+operators as `P[n | i ↦ Z, …]`; stays silent otherwise (in particular a bare `identity n`
+keeps its name). An over-applied chain — the operator string evaluated at a qubit,
+`P[XIZ] i` — is handled by `withOverApp`, so the extra arguments follow the notation. -/
 @[app_delab Quantum.NQubitPauliOperator.set]
 def delabPauliString : Delab :=
   whenPPOption getPPNotation <| whenNotPPOption getPPExplicit <| withOverApp 4 do
     let e ← getExpr
-    let some (n, sets) := setChain? e | failure
-    let some letters := lettersOf? n sets | failure
-    `(P[$letters])
+    if let some letters := literalLetters? e then
+      `(P[$letters])
+    else
+      let (n, is, cs) ← delabSymbolicChain
+      if is.isEmpty then failure
+      `(P[$n | $[$is ↦ $cs],*])
 
 end Delaborator
 
@@ -276,5 +410,40 @@ example : P[XIZ] 2 = PauliOperator.Z := rfl
 example : σ[XIZ].operators = P[XIZ] := rfl
 
 example : (⟨1, P[YY]⟩ : NQubitPauliGroupElement 2) = iσ[YY] := rfl
+
+/-! The symbolic form expands to the same chain with the `.set`s in the written order. -/
+
+example (n : ℕ) (i : Fin (n + 1)) :
+    σ[n + 2 | Fin.castSucc i ↦ Z, Fin.succ i ↦ Z] =
+      ⟨0, ((NQubitPauliOperator.identity (n + 2)).set (Fin.castSucc i) PauliOperator.Z).set
+        (Fin.succ i) PauliOperator.Z⟩ :=
+  rfl
+
+example (n : ℕ) (i j : Fin n) :
+    σ[n | j ↦ X, i ↦ Y] =
+      ⟨0, ((NQubitPauliOperator.identity n).set j PauliOperator.X).set i PauliOperator.Y⟩ :=
+  rfl
+
+example (n : ℕ) (i : Fin n) :
+    iσ[n | i ↦ Z] = ⟨1, (NQubitPauliOperator.identity n).set i PauliOperator.Z⟩ :=
+  rfl
+
+example (n : ℕ) (i : Fin n) :
+    -σ[n | i ↦ Z] = ⟨2, (NQubitPauliOperator.identity n).set i PauliOperator.Z⟩ :=
+  rfl
+
+example (n : ℕ) (i : Fin n) :
+    -iσ[n | i ↦ X] = ⟨3, (NQubitPauliOperator.identity n).set i PauliOperator.X⟩ :=
+  rfl
+
+example (n : ℕ) (i j : Fin n) :
+    P[n | i ↦ X, j ↦ Z] =
+      ((NQubitPauliOperator.identity n).set i PauliOperator.X).set j PauliOperator.Z :=
+  rfl
+
+example (n : ℕ) (i j : Fin n) : σ[n | i ↦ X, j ↦ Z].operators = P[n | i ↦ X, j ↦ Z] := rfl
+
+example (i : Fin 3) : P[3 | i ↦ Z] = (NQubitPauliOperator.identity 3).set i PauliOperator.Z :=
+  rfl
 
 end RoundTrip

--- a/QEC/Stabilizer/Foundations/PauliGroup/Notation.lean
+++ b/QEC/Stabilizer/Foundations/PauliGroup/Notation.lean
@@ -62,13 +62,15 @@ Terms of exactly that literal shape (literal phase, literal indices, `PauliOpera
 constructors, literal qubit count) display back as `σ[…]`/`iσ[…]`/`-σ[…]`/`-iσ[…]` in
 goals and diagnostics, and a literal-shaped `.set` chain on its own displays as `P[…]`
 (so an element whose phase is not a literal shows as `⟨k, P[…]⟩`; a bare `identity n`
-keeps its name). A `.set` chain over an `identity n` that is not of that literal shape —
-symbolic qubit count or indices, an out-of-range literal index — displays in the symbolic
-form `σ[n | i ↦ Z, …]` / `P[n | i ↦ Z, …]` as long as its operators are `X`/`Y`/`Z`
-constructors, with the `.set`s listed innermost first (the written order). Anything else
-— variable phase or operators, an explicit `I`, a chain not rooted at `identity` — is left
-to the default printer. The delaborators are registered globally, so the display is
-independent of whether the scope is open; `set_option pp.notation false` (or
+keeps its name). The letters form is used only for a chain in the literal normal form —
+literal indices in strictly increasing order, no explicit `I` — so that the display
+re-parses to the very same term. Any other `.set` chain over an `identity n` whose
+operators are `X`/`Y`/`Z` constructors — symbolic qubit count or indices, literal indices
+out of order or out of range — displays in the symbolic form `σ[n | i ↦ Z, …]` /
+`P[n | i ↦ Z, …]`, with the `.set`s listed innermost first (the written order). Anything
+else — variable phase or operators, an explicit `I`, a chain not rooted at `identity` — is
+left to the default printer. The delaborators are `scoped` with the notation, so a goal
+only ever shows syntax the current file can parse; `set_option pp.notation false` (or
 `pp.explicit true`) recovers the raw term.
 -/
 
@@ -284,10 +286,16 @@ def lettersOf? (n : Nat) (sets : List (Nat × Char)) : Option Ident := do
     sets.foldl (fun acc ic => if ic.1 == j then ic.2 else acc) 'I'
   return mkIdent (.mkSimple letters)
 
-/-- The letters identifier of the literal `set`-chain at the current position, if it is
-one over `n > 0` qubits with in-range literal indices. -/
+/-- The letters identifier of the `set`-chain `e`, if it is in the literal normal form the
+letters notation expands to: literal `n > 0`, literal in-range indices in strictly
+increasing order, and no explicit `I`. A chain of any other shape (an out-of-order literal
+index, a set `I`) is left to the symbolic printer, so that the display always re-parses to
+the same term. -/
 def literalLetters? (e : Expr) : Option Ident := do
   let (n, sets) ← setChain? e
+  guard (sets.all fun ic => ic.2 != 'I')
+  let idxs := sets.map (·.1)
+  guard ((idxs.zip (idxs.drop 1)).all fun ab => ab.1 < ab.2)
   lettersOf? n sets
 
 /-- Delaborate the symbolic `set`-chain at the current position: a chain
@@ -312,10 +320,11 @@ partial def delabSymbolicChain : DelabM (Term × Array Term × Array Ident) := d
 
 /-- Delaborate `NQubitPauliGroupElement.mk` applications back to the
 `σ[…]`/`iσ[…]`/`-σ[…]`/`-iσ[…]` notation. Fires only when the phase is a literal `0`–`3`
-and the operator part is a `set`-chain over `identity n`: a literal chain (literal `n > 0`,
-in-range literal indices) displays in the letters form `σ[XIZ]`, any other chain with
-`X`/`Y`/`Z` operators in the symbolic form `σ[n | i ↦ Z, …]`; stays silent otherwise. -/
-@[app_delab Quantum.NQubitPauliGroupElement.mk]
+and the operator part is a `set`-chain over `identity n`: a chain in the literal normal
+form (see `literalLetters?`) displays in the letters form `σ[XIZ]`, any other chain with
+`X`/`Y`/`Z` operators in the symbolic form `σ[n | i ↦ Z, …]`; stays silent otherwise.
+Scoped with the notation. -/
+@[scoped app_delab Quantum.NQubitPauliGroupElement.mk]
 def delabSigma : Delab :=
   whenPPOption getPPNotation <| whenNotPPOption getPPExplicit do
     let e ← getExpr
@@ -339,12 +348,13 @@ def delabSigma : Delab :=
       | _ => failure
 
 /-- Delaborate `NQubitPauliOperator.set` chains back to the `P[…]` notation. Fires only on
-a `set` application whose whole chain runs over an `identity n`: a literal chain (literal
-`n > 0`, in-range literal indices) displays as `P[XIZ]`, any other chain with `X`/`Y`/`Z`
+a `set` application whose whole chain runs over an `identity n`: a chain in the literal
+normal form (see `literalLetters?`) displays as `P[XIZ]`, any other chain with `X`/`Y`/`Z`
 operators as `P[n | i ↦ Z, …]`; stays silent otherwise (in particular a bare `identity n`
 keeps its name). An over-applied chain — the operator string evaluated at a qubit,
-`P[XIZ] i` — is handled by `withOverApp`, so the extra arguments follow the notation. -/
-@[app_delab Quantum.NQubitPauliOperator.set]
+`P[XIZ] i` — is handled by `withOverApp`, so the extra arguments follow the notation.
+Scoped with the notation. -/
+@[scoped app_delab Quantum.NQubitPauliOperator.set]
 def delabPauliString : Delab :=
   whenPPOption getPPNotation <| whenNotPPOption getPPExplicit <| withOverApp 4 do
     let e ← getExpr
@@ -445,5 +455,52 @@ example (n : ℕ) (i j : Fin n) : σ[n | i ↦ X, j ↦ Z].operators = P[n | i �
 
 example (i : Fin 3) : P[3 | i ↦ Z] = (NQubitPauliOperator.identity 3).set i PauliOperator.Z :=
   rfl
+
+/-! ### Display
+
+The printers are checked on their output: literal normal forms print in the letters form,
+everything else that re-parses prints in the symbolic form, and a chain that would not
+re-parse to itself (an explicit `I`) is left to the default printer. -/
+
+open Lean Elab Command in
+/-- Display test: elaborate `stx` and check that its pretty-printed text is `expected`
+(`exact := false`: contains `expected`). Run through `run_cmd` so no `#`-command is needed. -/
+private def checkDisplay (stx : Syntax) (expected : String) (exact : Bool := true) :
+    CommandElabM Unit :=
+  liftTermElabM do
+    let e ← Term.elabTerm stx none
+    Term.synthesizeSyntheticMVarsNoPostponing
+    let s := toString (← Meta.ppExpr (← instantiateMVars e))
+    unless (if exact then s == expected else (s.splitOn expected).length > 1) do
+      throwError "display test failed:{indentD s}\nexpected{indentD expected}"
+
+run_cmd do
+  checkDisplay (← `(σ[XIZ])) "σ[XIZ]"
+run_cmd do
+  checkDisplay (← `(-iσ[XI])) "-iσ[XI]"
+run_cmd do
+  checkDisplay (← `(P[XIZ])) "P[XIZ]"
+run_cmd do
+  checkDisplay (← `(σ[IIII])) "σ[IIII]"
+-- written order that is not the sorted normal form stays symbolic (a different term)
+run_cmd do
+  checkDisplay (← `(σ[3 | 1 ↦ Z, 0 ↦ X])) "σ[3 | 1 ↦ Z, 0 ↦ X]"
+run_cmd do
+  checkDisplay (← `(P[3 | 1 ↦ Z, 0 ↦ Z])) "P[3 | 1 ↦ Z, 0 ↦ Z]"
+-- sorted written order is the literal normal form
+run_cmd do
+  checkDisplay (← `(P[3 | 0 ↦ Z, 1 ↦ Z])) "P[ZZI]"
+-- an explicit `I` never prints as a letters string that would drop it
+run_cmd do
+  checkDisplay
+    (← `(((NQubitPauliOperator.identity 3).set 0 PauliOperator.X).set 1 PauliOperator.I))
+    "P[XII].set 1 PauliOperator.I"
+-- symbolic qubit count and indices
+run_cmd do
+  checkDisplay (← `(fun (n : ℕ) (i j : Fin n) => σ[n | j ↦ X, i ↦ Y]))
+    "σ[n | j ↦ X, i ↦ Y]" (exact := false)
+run_cmd do
+  checkDisplay (← `(fun (n : ℕ) (i : Fin n) => P[n | i ↦ Z] i))
+    "P[n | i ↦ Z] i" (exact := false)
 
 end RoundTrip

--- a/QEC/Stabilizer/Framework/Concatenation/Constructor.lean
+++ b/QEC/Stabilizer/Framework/Concatenation/Constructor.lean
@@ -38,13 +38,13 @@ variable (D : ConcatCSSData n₁ n₂ k₂)
 /-! ## R6 foundations: the inner logicals as zero-phase operators -/
 
 /-- `ofOperator Xbar` is the inner logical `X` (they agree because `X̄` has phase 0). -/
-lemma ofOperator_Xbar : ofOperator D.Xbar = (D.Cin.logicalOps 0).xOp := by
+lemma ofOperator_Xbar : ofOperator D.Xbar = D.Cin.logicalX 0 := by
   apply NQubitPauliGroupElement.ext
   · rw [ofOperator_phasePower, D.innerLogX_phaseZero]
   · rfl
 
 /-- `ofOperator Zbar` is the inner logical `Z`. -/
-lemma ofOperator_Zbar : ofOperator D.Zbar = (D.Cin.logicalOps 0).zOp := by
+lemma ofOperator_Zbar : ofOperator D.Zbar = D.Cin.logicalZ 0 := by
   apply NQubitPauliGroupElement.ext
   · rw [ofOperator_phasePower, D.innerLogZ_phaseZero]
   · rfl
@@ -200,14 +200,14 @@ lemma promote_anticommute_parity (h₁ h₂ : NQubitPauliGroupElement n₂)
 which the logical centralizes). -/
 lemma inner_gen_comm_logicalX (g : NQubitPauliGroupElement n₁)
     (hg : g ∈ NQubitPauliGroupElement.listToSet D.Cin.generatorsList) :
-    g * (D.Cin.logicalOps 0).xOp = (D.Cin.logicalOps 0).xOp * g :=
+    g * D.Cin.logicalX 0 = D.Cin.logicalX 0 * g :=
   (mem_centralizer_iff _ _).mp (D.Cin.logicalOps 0).x_mem_centralizer g
     (Subgroup.subset_closure hg)
 
 /-- An inner generator commutes with the inner logical `Z`. -/
 lemma inner_gen_comm_logicalZ (g : NQubitPauliGroupElement n₁)
     (hg : g ∈ NQubitPauliGroupElement.listToSet D.Cin.generatorsList) :
-    g * (D.Cin.logicalOps 0).zOp = (D.Cin.logicalOps 0).zOp * g :=
+    g * D.Cin.logicalZ 0 = D.Cin.logicalZ 0 * g :=
   (mem_centralizer_iff _ _).mp (D.Cin.logicalOps 0).z_mem_centralizer g
     (Subgroup.subset_closure hg)
 
@@ -342,15 +342,15 @@ noncomputable def concatStabGroup : StabilizerGroup (n₁ * n₂) :=
 
 /-- Concatenated logical `X` for logical qubit `ℓ`: the promoted outer logical `X`. -/
 def concatLogicalX (ℓ : Fin k₂) : NQubitPauliGroupElement (n₁ * n₂) :=
-  promoteE D.Xbar D.Zbar (D.Cout.logicalOps ℓ).xOp
+  promoteE D.Xbar D.Zbar (D.Cout.logicalX ℓ)
 
 /-- Concatenated logical `Z` for logical qubit `ℓ`: the promoted outer logical `Z`. -/
 def concatLogicalZ (ℓ : Fin k₂) : NQubitPauliGroupElement (n₁ * n₂) :=
-  promoteE D.Xbar D.Zbar (D.Cout.logicalOps ℓ).zOp
+  promoteE D.Xbar D.Zbar (D.Cout.logicalZ ℓ)
 
 /-- The promoted outer logical `X` centralizes the concatenated stabilizer. Against an
 embedded inner generator it is `embedBlock_promoteE_commute`; against a promoted outer
-generator it is `promote_anticommute_parity` plus `(Cout.logicalOps ℓ).xOp` centralizing
+generator it is `promote_anticommute_parity` plus `Cout.logicalX ℓ` centralizing
 `Cout`'s stabilizer. -/
 lemma concatLogicalX_mem_centralizer (ℓ : Fin k₂) :
     concatLogicalX D ℓ ∈ centralizer (concatStabGroup D) := by
@@ -360,10 +360,10 @@ lemma concatLogicalX_mem_centralizer (ℓ : Fin k₂) :
     D.concatGeneratorsList rfl
   intro s hs
   rcases D.mem_concatGeneratorsList s hs with ⟨b, z, hz, rfl⟩ | ⟨y, hy, rfl⟩
-  · exact D.embedBlock_promoteE_commute b z hz (D.Cout.logicalOps ℓ).xOp
+  · exact D.embedBlock_promoteE_commute b z hz (D.Cout.logicalX ℓ)
       (noY_of_isXType (D.outerLogX_isX ℓ))
   · rw [commutes_iff_even_anticommutes,
-      D.promote_anticommute_parity y (D.Cout.logicalOps ℓ).xOp
+      D.promote_anticommute_parity y (D.Cout.logicalX ℓ)
         (D.outer_gen_noY y hy) (noY_of_isXType (D.outerLogX_isX ℓ)),
       ← commutes_iff_even_anticommutes]
     have hy_mem : y ∈ NQubitPauliGroupElement.listToSet D.Cout.generatorsList :=
@@ -381,10 +381,10 @@ lemma concatLogicalZ_mem_centralizer (ℓ : Fin k₂) :
     D.concatGeneratorsList rfl
   intro s hs
   rcases D.mem_concatGeneratorsList s hs with ⟨b, z, hz, rfl⟩ | ⟨y, hy, rfl⟩
-  · exact D.embedBlock_promoteE_commute b z hz (D.Cout.logicalOps ℓ).zOp
+  · exact D.embedBlock_promoteE_commute b z hz (D.Cout.logicalZ ℓ)
       (noY_of_isZType (D.outerLogZ_isZ ℓ))
   · rw [commutes_iff_even_anticommutes,
-      D.promote_anticommute_parity y (D.Cout.logicalOps ℓ).zOp
+      D.promote_anticommute_parity y (D.Cout.logicalZ ℓ)
         (D.outer_gen_noY y hy) (noY_of_isZType (D.outerLogZ_isZ ℓ)),
       ← commutes_iff_even_anticommutes]
     have hy_mem : y ∈ NQubitPauliGroupElement.listToSet D.Cout.generatorsList :=
@@ -399,7 +399,7 @@ lemma concatLogical_anticommute (ℓ : Fin k₂) :
   classical
   simp only [concatLogicalX, concatLogicalZ]
   rw [anticommutes_iff_odd_anticommutes, ← Nat.not_even_iff_odd,
-    D.promote_anticommute_parity (D.Cout.logicalOps ℓ).xOp (D.Cout.logicalOps ℓ).zOp
+    D.promote_anticommute_parity (D.Cout.logicalX ℓ) (D.Cout.logicalZ ℓ)
       (noY_of_isXType (D.outerLogX_isX ℓ)) (noY_of_isZType (D.outerLogZ_isZ ℓ)),
     Nat.not_even_iff_odd]
   exact (anticommutes_iff_odd_anticommutes _ _).mp (D.Cout.logicalOps ℓ).anticommute

--- a/QEC/Stabilizer/Framework/Concatenation/Correspondence.lean
+++ b/QEC/Stabilizer/Framework/Concatenation/Correspondence.lean
@@ -292,8 +292,8 @@ open NQubitPauliOperator in
 /-- `symplecticInner` is additive in the left argument under the group product (it depends only
 on the operator part, whose symplectic vector adds, and the form is bilinear). -/
 lemma symplecticInner_group_mul_left {m : ℕ} (p q L : NQubitPauliGroupElement m) :
-    symplecticInner (p * q).operators L.operators
-      = symplecticInner p.operators L.operators + symplecticInner q.operators L.operators := by
+    ⟪(p * q), L⟫ₛ
+      = ⟪p, L⟫ₛ + ⟪q, L⟫ₛ := by
   rw [← symplecticBilinear_toSymplectic, ← symplecticBilinear_toSymplectic,
     ← symplecticBilinear_toSymplectic,
     show toSymplectic (p * q).operators
@@ -304,7 +304,7 @@ lemma symplecticInner_group_mul_left {m : ℕ} (p q L : NQubitPauliGroupElement 
 open NQubitPauliOperator in
 /-- The identity commutes with everything, so its symplectic inner product is zero. -/
 lemma symplecticInner_one_left {m : ℕ} (L : NQubitPauliGroupElement m) :
-    symplecticInner (1 : NQubitPauliGroupElement m).operators L.operators = 0 :=
+    ⟪(1 : NQubitPauliGroupElement m), L⟫ₛ = 0 :=
   (commutes_iff_symplectic_inner_zero 1 L).mp (by rw [one_mul, mul_one])
 
 open NQubitPauliOperator in
@@ -319,9 +319,9 @@ open NQubitPauliOperator in
 multiplies block-wise, so its symplectic inner product against `L` is additive. -/
 lemma symplecticInner_restrictBlock_mul (b : Fin n₂) (x y : NQubitPauliGroupElement (n₁ * n₂))
     (L : NQubitPauliGroupElement n₁) :
-    symplecticInner (restrictBlock b (x * y)).operators L.operators
-      = symplecticInner (restrictBlock b x).operators L.operators
-        + symplecticInner (restrictBlock b y).operators L.operators := by
+    ⟪restrictBlock b (x * y), L⟫ₛ
+      = ⟪restrictBlock b x, L⟫ₛ
+        + ⟪restrictBlock b y, L⟫ₛ := by
   rw [show (restrictBlock b (x * y)).operators
       = (restrictBlock b x * restrictBlock b y).operators from by funext i; rfl]
   exact symplecticInner_group_mul_left (restrictBlock b x) (restrictBlock b y) L
@@ -332,16 +332,16 @@ symplectic inner products of the restriction with `Z̄₁` and `X̄₁`. -/
 lemma inducedOuterOp_toSymplecticSingle (D : ConcatCSSData n₁ n₂ k₂)
     (x : NQubitPauliGroupElement (n₁ * n₂)) (b : Fin n₂) :
     (inducedOuterOp D x b).toSymplecticSingle
-      = (symplecticInner (restrictBlock b x).operators (D.Cin.logicalOps 0).zOp.operators,
-         symplecticInner (restrictBlock b x).operators (D.Cin.logicalOps 0).xOp.operators) := by
+      = (⟪restrictBlock b x, (D.Cin.logicalOps 0).zOp⟫ₛ,
+         ⟪restrictBlock b x, (D.Cin.logicalOps 0).xOp⟫ₛ) := by
   classical
-  have hz : symplecticInner (restrictBlock b x).operators (D.Cin.logicalOps 0).zOp.operators
+  have hz : ⟪restrictBlock b x, (D.Cin.logicalOps 0).zOp⟫ₛ
       = if Anticommute (restrictBlock b x) (D.Cin.logicalOps 0).zOp then (1 : ZMod 2) else 0 := by
     split_ifs with h
     · exact (anticommutes_iff_symplectic_inner_one _ _).mp h
     · exact (commutes_iff_symplectic_inner_zero _ _).mp
         ((commute_or_anticommute _ _).resolve_right h)
-  have hx : symplecticInner (restrictBlock b x).operators (D.Cin.logicalOps 0).xOp.operators
+  have hx : ⟪restrictBlock b x, (D.Cin.logicalOps 0).xOp⟫ₛ
       = if Anticommute (restrictBlock b x) (D.Cin.logicalOps 0).xOp then (1 : ZMod 2) else 0 := by
     split_ifs with h
     · exact (anticommutes_iff_symplectic_inner_one _ _).mp h
@@ -376,25 +376,25 @@ lemma exists_concatStab_matching_induced (g : NQubitPauliGroupElement (n₁ * n�
           = (D.Cin.logicalOps 0).zOp * restrictBlock b (g * u) := by
   classical
   -- Symplectic-inner values of the inner logical pair.
-  have hXZ : symplecticInner (D.Cin.logicalOps 0).xOp.operators (D.Cin.logicalOps 0).zOp.operators
+  have hXZ : ⟪(D.Cin.logicalOps 0).xOp, (D.Cin.logicalOps 0).zOp⟫ₛ
       = 1 := (anticommutes_iff_symplectic_inner_one _ _).mp (D.Cin.logicalOps 0).anticommute
-  have hZX : symplecticInner (D.Cin.logicalOps 0).zOp.operators (D.Cin.logicalOps 0).xOp.operators
+  have hZX : ⟪(D.Cin.logicalOps 0).zOp, (D.Cin.logicalOps 0).xOp⟫ₛ
       = 1 := (anticommutes_iff_symplectic_inner_one _ _).mp
         (NQubitPauliGroupElement.anticommute_symm _ _ (D.Cin.logicalOps 0).anticommute)
-  have hXX : symplecticInner (D.Cin.logicalOps 0).xOp.operators (D.Cin.logicalOps 0).xOp.operators
+  have hXX : ⟪(D.Cin.logicalOps 0).xOp, (D.Cin.logicalOps 0).xOp⟫ₛ
       = 0 := (commutes_iff_symplectic_inner_zero _ _).mp rfl
-  have hZZ : symplecticInner (D.Cin.logicalOps 0).zOp.operators (D.Cin.logicalOps 0).zOp.operators
+  have hZZ : ⟪(D.Cin.logicalOps 0).zOp, (D.Cin.logicalOps 0).zOp⟫ₛ
       = 0 := (commutes_iff_symplectic_inner_zero _ _).mp rfl
   -- Step 1: build a class-matching concatenated stabilizer `u` with `inducedOuterOp u = t`.
   have ht' : t ∈ Subgroup.closure (NQubitPauliGroupElement.listToSet D.Cout.generatorsList) := ht
   obtain ⟨u, hu_mem, hu_sig⟩ : ∃ u ∈ D.concatStabGroup.toSubgroup, ∀ b : Fin n₂,
-      ((symplecticInner (restrictBlock b u).operators (D.Cin.logicalOps 0).zOp.operators,
-        symplecticInner (restrictBlock b u).operators (D.Cin.logicalOps 0).xOp.operators)
+      ((⟪restrictBlock b u, (D.Cin.logicalOps 0).zOp⟫ₛ,
+        ⟪restrictBlock b u, (D.Cin.logicalOps 0).xOp⟫ₛ)
         : ZMod 2 × ZMod 2) = (t.operators b).toSymplecticSingle := by
     refine Subgroup.closure_induction
       (p := fun t _ => ∃ u ∈ D.concatStabGroup.toSubgroup, ∀ b : Fin n₂,
-        ((symplecticInner (restrictBlock b u).operators (D.Cin.logicalOps 0).zOp.operators,
-          symplecticInner (restrictBlock b u).operators (D.Cin.logicalOps 0).xOp.operators)
+        ((⟪restrictBlock b u, (D.Cin.logicalOps 0).zOp⟫ₛ,
+          ⟪restrictBlock b u, (D.Cin.logicalOps 0).xOp⟫ₛ)
           : ZMod 2 × ZMod 2) = (t.operators b).toSymplecticSingle)
       ?_ ?_ ?_ ?_ ht'
     · -- mem: a `Y`-free outer generator `y` promotes to a matching concat generator.
@@ -433,13 +433,13 @@ lemma exists_concatStab_matching_induced (g : NQubitPauliGroupElement (n₁ * n�
       obtain ⟨u₁, hu₁, hsig₁⟩ := iha
       obtain ⟨u₂, hu₂, hsig₂⟩ := iha'
       refine ⟨u₁ * u₂, Subgroup.mul_mem _ hu₁ hu₂, fun b => ?_⟩
-      have e1 : symplecticInner (restrictBlock b u₁).operators (D.Cin.logicalOps 0).zOp.operators
+      have e1 : ⟪restrictBlock b u₁, (D.Cin.logicalOps 0).zOp⟫ₛ
           = ((a.operators b).toSymplecticSingle).1 := congrArg Prod.fst (hsig₁ b)
-      have e2 : symplecticInner (restrictBlock b u₁).operators (D.Cin.logicalOps 0).xOp.operators
+      have e2 : ⟪restrictBlock b u₁, (D.Cin.logicalOps 0).xOp⟫ₛ
           = ((a.operators b).toSymplecticSingle).2 := congrArg Prod.snd (hsig₁ b)
-      have e3 : symplecticInner (restrictBlock b u₂).operators (D.Cin.logicalOps 0).zOp.operators
+      have e3 : ⟪restrictBlock b u₂, (D.Cin.logicalOps 0).zOp⟫ₛ
           = ((a'.operators b).toSymplecticSingle).1 := congrArg Prod.fst (hsig₂ b)
-      have e4 : symplecticInner (restrictBlock b u₂).operators (D.Cin.logicalOps 0).xOp.operators
+      have e4 : ⟪restrictBlock b u₂, (D.Cin.logicalOps 0).xOp⟫ₛ
           = ((a'.operators b).toSymplecticSingle).2 := congrArg Prod.snd (hsig₂ b)
       rw [symplecticInner_restrictBlock_mul, symplecticInner_restrictBlock_mul,
         show (a * a').operators b
@@ -456,16 +456,16 @@ lemma exists_concatStab_matching_induced (g : NQubitPauliGroupElement (n₁ * n�
   -- Step 2: `inducedOuterOp u = inducedOuterOp g`, so `g * u` restricts to commuting elements.
   refine ⟨u, hu_mem, fun b => ?_⟩
   have hsig_g : (t.operators b).toSymplecticSingle
-      = (symplecticInner (restrictBlock b g).operators (D.Cin.logicalOps 0).zOp.operators,
-         symplecticInner (restrictBlock b g).operators (D.Cin.logicalOps 0).xOp.operators) := by
+      = (⟪restrictBlock b g, (D.Cin.logicalOps 0).zOp⟫ₛ,
+         ⟪restrictBlock b g, (D.Cin.logicalOps 0).xOp⟫ₛ) := by
     rw [htop, inducedOuter_operators]
     exact D.inducedOuterOp_toSymplecticSingle g b
   have hpair := (hu_sig b).trans hsig_g
-  have hzg : symplecticInner (restrictBlock b u).operators (D.Cin.logicalOps 0).zOp.operators
-      = symplecticInner (restrictBlock b g).operators (D.Cin.logicalOps 0).zOp.operators :=
+  have hzg : ⟪restrictBlock b u, (D.Cin.logicalOps 0).zOp⟫ₛ
+      = ⟪restrictBlock b g, (D.Cin.logicalOps 0).zOp⟫ₛ :=
     congrArg Prod.fst hpair
-  have hxg : symplecticInner (restrictBlock b u).operators (D.Cin.logicalOps 0).xOp.operators
-      = symplecticInner (restrictBlock b g).operators (D.Cin.logicalOps 0).xOp.operators :=
+  have hxg : ⟪restrictBlock b u, (D.Cin.logicalOps 0).xOp⟫ₛ
+      = ⟪restrictBlock b g, (D.Cin.logicalOps 0).xOp⟫ₛ :=
     congrArg Prod.snd hpair
   refine ⟨?_, ?_⟩
   · refine (commutes_iff_symplectic_inner_zero _ _).mpr ?_

--- a/QEC/Stabilizer/Framework/Concatenation/Correspondence.lean
+++ b/QEC/Stabilizer/Framework/Concatenation/Correspondence.lean
@@ -46,11 +46,11 @@ the inner logicals: `I` if it commutes with both, `X`/`Z` for a single anticommu
 noncomputable def inducedOuterOp (D : ConcatCSSData n₁ n₂ k₂)
     (g : NQubitPauliGroupElement (n₁ * n₂)) : NQubitPauliOperator n₂ :=
   fun b =>
-    if Anticommute (restrictBlock b g) (D.Cin.logicalOps 0).zOp then
-      (if Anticommute (restrictBlock b g) (D.Cin.logicalOps 0).xOp
+    if Anticommute (restrictBlock b g) (D.Cin.logicalZ 0) then
+      (if Anticommute (restrictBlock b g) (D.Cin.logicalX 0)
         then PauliOperator.Y else PauliOperator.X)
     else
-      (if Anticommute (restrictBlock b g) (D.Cin.logicalOps 0).xOp
+      (if Anticommute (restrictBlock b g) (D.Cin.logicalX 0)
         then PauliOperator.Z else PauliOperator.I)
 
 /-- The induced outer operator as a phase-0 group element. -/
@@ -70,8 +70,8 @@ variable (D : ConcatCSSData n₁ n₂ k₂)
 logicals. -/
 lemma inducedOuterOp_eq_I_iff (g : NQubitPauliGroupElement (n₁ * n₂)) (b : Fin n₂) :
     inducedOuterOp D g b = PauliOperator.I
-      ↔ ¬ Anticommute (restrictBlock b g) (D.Cin.logicalOps 0).zOp
-        ∧ ¬ Anticommute (restrictBlock b g) (D.Cin.logicalOps 0).xOp := by
+      ↔ ¬ Anticommute (restrictBlock b g) (D.Cin.logicalZ 0)
+        ∧ ¬ Anticommute (restrictBlock b g) (D.Cin.logicalX 0) := by
   unfold inducedOuterOp
   split_ifs with h1 h2 h3
   · exact iff_of_false (by decide) (fun hc => hc.1 h1)
@@ -96,7 +96,7 @@ lemma induced_block_anticommute_iff (g : NQubitPauliGroupElement (n₁ * n₂))
     exact not_anticommute_one_right _
   · -- X: both sides ↔ anticommuting with X̄₁ (the Z-component bit)
     rw [show ofOperator (promoteSingle D.Xbar D.Zbar PauliOperator.X)
-        = (D.Cin.logicalOps 0).xOp from by simp only [promoteSingle]; exact D.ofOperator_Xbar]
+        = (D.Cin.logicalX 0) from by simp only [promoteSingle]; exact D.ofOperator_Xbar]
     simp only [NQubitPauliGroupElement.anticommutesAt, inducedOuterOp, hPb]
     split_ifs with h1 h2 h3 <;>
       first
@@ -105,7 +105,7 @@ lemma induced_block_anticommute_iff (g : NQubitPauliGroupElement (n₁ * n₂))
   · exact absurd hPb hP
   · -- Z: both sides ↔ anticommuting with Z̄₁ (the X-component bit)
     rw [show ofOperator (promoteSingle D.Xbar D.Zbar PauliOperator.Z)
-        = (D.Cin.logicalOps 0).zOp from by simp only [promoteSingle]; exact D.ofOperator_Zbar]
+        = (D.Cin.logicalZ 0) from by simp only [promoteSingle]; exact D.ofOperator_Zbar]
     simp only [NQubitPauliGroupElement.anticommutesAt, inducedOuterOp, hPb]
     split_ifs with h1 h2 h3 <;>
       first
@@ -231,26 +231,26 @@ logicals centralise the stabilizer). -/
 lemma restrict_commutes_both_iff_stab (g : NQubitPauliGroupElement (n₁ * n₂))
     (hg : g ∈ centralizer D.concatStabGroup)
     (hindep : rowsLinearIndependent D.Cin.generatorsList) (b : Fin n₂) :
-    (¬ Anticommute (restrictBlock b g) (D.Cin.logicalOps 0).zOp
-      ∧ ¬ Anticommute (restrictBlock b g) (D.Cin.logicalOps 0).xOp)
+    (¬ Anticommute (restrictBlock b g) (D.Cin.logicalZ 0)
+      ∧ ¬ Anticommute (restrictBlock b g) (D.Cin.logicalX 0))
     ↔ ∃ s ∈ D.Cin.toStabilizerGroup.toSubgroup, s.operators = (restrictBlock b g).operators := by
   constructor
   · rintro ⟨hZ, hX⟩
-    have hcomm_x : restrictBlock b g * (D.Cin.logicalOps 0).xOp
-        = (D.Cin.logicalOps 0).xOp * restrictBlock b g :=
+    have hcomm_x : restrictBlock b g * D.Cin.logicalX 0
+        = D.Cin.logicalX 0 * restrictBlock b g :=
       (commute_or_anticommute _ _).resolve_right hX
-    have hcomm_z : restrictBlock b g * (D.Cin.logicalOps 0).zOp
-        = (D.Cin.logicalOps 0).zOp * restrictBlock b g :=
+    have hcomm_z : restrictBlock b g * D.Cin.logicalZ 0
+        = D.Cin.logicalZ 0 * restrictBlock b g :=
       (commute_or_anticommute _ _).resolve_right hZ
     exact operators_eq_stab_of_commutes_both_logicals D.Cin hindep (restrictBlock b g)
       (D.restrictBlock_mem_centralizer g hg b) hcomm_x hcomm_z
   · rintro ⟨s, hs, hsop⟩
     refine ⟨commute_not_anticommute ?_, commute_not_anticommute ?_⟩
     · rw [commutes_iff_even_anticommutes, ← hsop, ← commutes_iff_even_anticommutes]
-      exact (mem_centralizer_iff (D.Cin.logicalOps 0).zOp D.Cin.toStabilizerGroup).mp
+      exact (mem_centralizer_iff (D.Cin.logicalZ 0) D.Cin.toStabilizerGroup).mp
         (D.Cin.logicalOps 0).z_mem_centralizer s hs
     · rw [commutes_iff_even_anticommutes, ← hsop, ← commutes_iff_even_anticommutes]
-      exact (mem_centralizer_iff (D.Cin.logicalOps 0).xOp D.Cin.toStabilizerGroup).mp
+      exact (mem_centralizer_iff (D.Cin.logicalX 0) D.Cin.toStabilizerGroup).mp
         (D.Cin.logicalOps 0).x_mem_centralizer s hs
 
 /-- **(M5.)** Block `b` is in the support of the induced outer operator exactly when the
@@ -332,17 +332,17 @@ symplectic inner products of the restriction with `Z̄₁` and `X̄₁`. -/
 lemma inducedOuterOp_toSymplecticSingle (D : ConcatCSSData n₁ n₂ k₂)
     (x : NQubitPauliGroupElement (n₁ * n₂)) (b : Fin n₂) :
     (inducedOuterOp D x b).toSymplecticSingle
-      = (⟪restrictBlock b x, (D.Cin.logicalOps 0).zOp⟫ₛ,
-         ⟪restrictBlock b x, (D.Cin.logicalOps 0).xOp⟫ₛ) := by
+      = (⟪restrictBlock b x, (D.Cin.logicalZ 0)⟫ₛ,
+         ⟪restrictBlock b x, (D.Cin.logicalX 0)⟫ₛ) := by
   classical
-  have hz : ⟪restrictBlock b x, (D.Cin.logicalOps 0).zOp⟫ₛ
-      = if Anticommute (restrictBlock b x) (D.Cin.logicalOps 0).zOp then (1 : ZMod 2) else 0 := by
+  have hz : ⟪restrictBlock b x, (D.Cin.logicalZ 0)⟫ₛ
+      = if Anticommute (restrictBlock b x) (D.Cin.logicalZ 0) then (1 : ZMod 2) else 0 := by
     split_ifs with h
     · exact (anticommutes_iff_symplectic_inner_one _ _).mp h
     · exact (commutes_iff_symplectic_inner_zero _ _).mp
         ((commute_or_anticommute _ _).resolve_right h)
-  have hx : ⟪restrictBlock b x, (D.Cin.logicalOps 0).xOp⟫ₛ
-      = if Anticommute (restrictBlock b x) (D.Cin.logicalOps 0).xOp then (1 : ZMod 2) else 0 := by
+  have hx : ⟪restrictBlock b x, (D.Cin.logicalX 0)⟫ₛ
+      = if Anticommute (restrictBlock b x) (D.Cin.logicalX 0) then (1 : ZMod 2) else 0 := by
     split_ifs with h
     · exact (anticommutes_iff_symplectic_inner_one _ _).mp h
     · exact (commutes_iff_symplectic_inner_zero _ _).mp
@@ -370,31 +370,31 @@ lemma exists_concatStab_matching_induced (g : NQubitPauliGroupElement (n₁ * n�
     (t : NQubitPauliGroupElement n₂) (ht : t ∈ D.Cout.toStabilizerGroup.toSubgroup)
     (htop : t.operators = (inducedOuter D g).operators) :
     ∃ u ∈ D.concatStabGroup.toSubgroup, ∀ b : Fin n₂,
-      restrictBlock b (g * u) * (D.Cin.logicalOps 0).xOp
-          = (D.Cin.logicalOps 0).xOp * restrictBlock b (g * u)
-        ∧ restrictBlock b (g * u) * (D.Cin.logicalOps 0).zOp
-          = (D.Cin.logicalOps 0).zOp * restrictBlock b (g * u) := by
+      restrictBlock b (g * u) * D.Cin.logicalX 0
+          = D.Cin.logicalX 0 * restrictBlock b (g * u)
+        ∧ restrictBlock b (g * u) * D.Cin.logicalZ 0
+          = D.Cin.logicalZ 0 * restrictBlock b (g * u) := by
   classical
   -- Symplectic-inner values of the inner logical pair.
-  have hXZ : ⟪(D.Cin.logicalOps 0).xOp, (D.Cin.logicalOps 0).zOp⟫ₛ
+  have hXZ : ⟪(D.Cin.logicalX 0), (D.Cin.logicalZ 0)⟫ₛ
       = 1 := (anticommutes_iff_symplectic_inner_one _ _).mp (D.Cin.logicalOps 0).anticommute
-  have hZX : ⟪(D.Cin.logicalOps 0).zOp, (D.Cin.logicalOps 0).xOp⟫ₛ
+  have hZX : ⟪(D.Cin.logicalZ 0), (D.Cin.logicalX 0)⟫ₛ
       = 1 := (anticommutes_iff_symplectic_inner_one _ _).mp
         (NQubitPauliGroupElement.anticommute_symm _ _ (D.Cin.logicalOps 0).anticommute)
-  have hXX : ⟪(D.Cin.logicalOps 0).xOp, (D.Cin.logicalOps 0).xOp⟫ₛ
+  have hXX : ⟪(D.Cin.logicalX 0), (D.Cin.logicalX 0)⟫ₛ
       = 0 := (commutes_iff_symplectic_inner_zero _ _).mp rfl
-  have hZZ : ⟪(D.Cin.logicalOps 0).zOp, (D.Cin.logicalOps 0).zOp⟫ₛ
+  have hZZ : ⟪(D.Cin.logicalZ 0), (D.Cin.logicalZ 0)⟫ₛ
       = 0 := (commutes_iff_symplectic_inner_zero _ _).mp rfl
   -- Step 1: build a class-matching concatenated stabilizer `u` with `inducedOuterOp u = t`.
   have ht' : t ∈ Subgroup.closure (NQubitPauliGroupElement.listToSet D.Cout.generatorsList) := ht
   obtain ⟨u, hu_mem, hu_sig⟩ : ∃ u ∈ D.concatStabGroup.toSubgroup, ∀ b : Fin n₂,
-      ((⟪restrictBlock b u, (D.Cin.logicalOps 0).zOp⟫ₛ,
-        ⟪restrictBlock b u, (D.Cin.logicalOps 0).xOp⟫ₛ)
+      ((⟪restrictBlock b u, (D.Cin.logicalZ 0)⟫ₛ,
+        ⟪restrictBlock b u, (D.Cin.logicalX 0)⟫ₛ)
         : ZMod 2 × ZMod 2) = (t.operators b).toSymplecticSingle := by
     refine Subgroup.closure_induction
       (p := fun t _ => ∃ u ∈ D.concatStabGroup.toSubgroup, ∀ b : Fin n₂,
-        ((⟪restrictBlock b u, (D.Cin.logicalOps 0).zOp⟫ₛ,
-          ⟪restrictBlock b u, (D.Cin.logicalOps 0).xOp⟫ₛ)
+        ((⟪restrictBlock b u, (D.Cin.logicalZ 0)⟫ₛ,
+          ⟪restrictBlock b u, (D.Cin.logicalX 0)⟫ₛ)
           : ZMod 2 × ZMod 2) = (t.operators b).toSymplecticSingle)
       ?_ ?_ ?_ ?_ ht'
     · -- mem: a `Y`-free outer generator `y` promotes to a matching concat generator.
@@ -433,13 +433,13 @@ lemma exists_concatStab_matching_induced (g : NQubitPauliGroupElement (n₁ * n�
       obtain ⟨u₁, hu₁, hsig₁⟩ := iha
       obtain ⟨u₂, hu₂, hsig₂⟩ := iha'
       refine ⟨u₁ * u₂, Subgroup.mul_mem _ hu₁ hu₂, fun b => ?_⟩
-      have e1 : ⟪restrictBlock b u₁, (D.Cin.logicalOps 0).zOp⟫ₛ
+      have e1 : ⟪restrictBlock b u₁, (D.Cin.logicalZ 0)⟫ₛ
           = ((a.operators b).toSymplecticSingle).1 := congrArg Prod.fst (hsig₁ b)
-      have e2 : ⟪restrictBlock b u₁, (D.Cin.logicalOps 0).xOp⟫ₛ
+      have e2 : ⟪restrictBlock b u₁, (D.Cin.logicalX 0)⟫ₛ
           = ((a.operators b).toSymplecticSingle).2 := congrArg Prod.snd (hsig₁ b)
-      have e3 : ⟪restrictBlock b u₂, (D.Cin.logicalOps 0).zOp⟫ₛ
+      have e3 : ⟪restrictBlock b u₂, (D.Cin.logicalZ 0)⟫ₛ
           = ((a'.operators b).toSymplecticSingle).1 := congrArg Prod.fst (hsig₂ b)
-      have e4 : ⟪restrictBlock b u₂, (D.Cin.logicalOps 0).xOp⟫ₛ
+      have e4 : ⟪restrictBlock b u₂, (D.Cin.logicalX 0)⟫ₛ
           = ((a'.operators b).toSymplecticSingle).2 := congrArg Prod.snd (hsig₂ b)
       rw [symplecticInner_restrictBlock_mul, symplecticInner_restrictBlock_mul,
         show (a * a').operators b
@@ -456,16 +456,16 @@ lemma exists_concatStab_matching_induced (g : NQubitPauliGroupElement (n₁ * n�
   -- Step 2: `inducedOuterOp u = inducedOuterOp g`, so `g * u` restricts to commuting elements.
   refine ⟨u, hu_mem, fun b => ?_⟩
   have hsig_g : (t.operators b).toSymplecticSingle
-      = (⟪restrictBlock b g, (D.Cin.logicalOps 0).zOp⟫ₛ,
-         ⟪restrictBlock b g, (D.Cin.logicalOps 0).xOp⟫ₛ) := by
+      = (⟪restrictBlock b g, (D.Cin.logicalZ 0)⟫ₛ,
+         ⟪restrictBlock b g, (D.Cin.logicalX 0)⟫ₛ) := by
     rw [htop, inducedOuter_operators]
     exact D.inducedOuterOp_toSymplecticSingle g b
   have hpair := (hu_sig b).trans hsig_g
-  have hzg : ⟪restrictBlock b u, (D.Cin.logicalOps 0).zOp⟫ₛ
-      = ⟪restrictBlock b g, (D.Cin.logicalOps 0).zOp⟫ₛ :=
+  have hzg : ⟪restrictBlock b u, (D.Cin.logicalZ 0)⟫ₛ
+      = ⟪restrictBlock b g, (D.Cin.logicalZ 0)⟫ₛ :=
     congrArg Prod.fst hpair
-  have hxg : ⟪restrictBlock b u, (D.Cin.logicalOps 0).xOp⟫ₛ
-      = ⟪restrictBlock b g, (D.Cin.logicalOps 0).xOp⟫ₛ :=
+  have hxg : ⟪restrictBlock b u, (D.Cin.logicalX 0)⟫ₛ
+      = ⟪restrictBlock b g, (D.Cin.logicalX 0)⟫ₛ :=
     congrArg Prod.snd hpair
   refine ⟨?_, ?_⟩
   · refine (commutes_iff_symplectic_inner_zero _ _).mpr ?_

--- a/QEC/Stabilizer/Framework/Concatenation/Independence.lean
+++ b/QEC/Stabilizer/Framework/Concatenation/Independence.lean
@@ -312,7 +312,7 @@ are (`hlog`) and the outer generators are (`hout`). Each block restriction is a 
 `X̄₁, Z̄₁`; `hlog` forces the two aggregated coefficients to vanish at every block, which
 reassembles into an outer linear relation killed by `hout`. -/
 lemma rowsLinearIndependent_promotedOuterList
-    (hlog : rowsLinearIndependent [(D.Cin.logicalOps 0).xOp, (D.Cin.logicalOps 0).zOp])
+    (hlog : rowsLinearIndependent [D.Cin.logicalX 0, D.Cin.logicalZ 0])
     (hout : rowsLinearIndependent (D.outerZ ++ D.outerX)) :
     rowsLinearIndependent D.promotedOuterList := by
   rw [ConcatCSSData.promotedOuterList]
@@ -360,7 +360,7 @@ lemma rowsLinearIndependent_promotedOuterList
     -- Use independence of the two inner-logical rows.
     have hlog' := Fintype.linearIndependent_iff.mp hlog ![c1, c2]
     have hsum2 : (∑ j, (![c1, c2]) j
-        • checkMatrix [(D.Cin.logicalOps 0).xOp, (D.Cin.logicalOps 0).zOp] j) = 0 := by
+        • checkMatrix [D.Cin.logicalX 0, D.Cin.logicalZ 0] j) = 0 := by
       rw [Fin.sum_univ_two]
       simpa [checkMatrix, ConcatCSSData.Xbar, ConcatCSSData.Zbar] using h1
     exact ⟨by simpa using hlog' hsum2 0, by simpa using hlog' hsum2 1⟩
@@ -412,9 +412,9 @@ logical symplectic vectors. -/
 lemma blockRestrictSymp_mem_span_logicals (b : Fin n₂)
     {v : Fin (n₁ * n₂ + n₁ * n₂) → ZMod 2} (hv : v ∈ sympSpan D.promotedOuterList) :
     blockRestrictSymp b v
-      ∈ sympSpan [(D.Cin.logicalOps 0).xOp, (D.Cin.logicalOps 0).zOp] := by
+      ∈ sympSpan [D.Cin.logicalX 0, D.Cin.logicalZ 0] := by
   have hle : sympSpan D.promotedOuterList ≤ Submodule.comap (blockRestrictSymp b)
-      (sympSpan [(D.Cin.logicalOps 0).xOp, (D.Cin.logicalOps 0).zOp]) := by
+      (sympSpan [D.Cin.logicalX 0, D.Cin.logicalZ 0]) := by
     rw [sympSpan_eq_span_listToSet, Submodule.span_le]
     rintro x ⟨e, he, rfl⟩
     simp only [listToSet, Set.mem_setOf_eq, ConcatCSSData.promotedOuterList] at he
@@ -431,7 +431,7 @@ generators are independent from the two inner logicals (`hdisj`). Every block re
 shared vector lies in `sympSpan Cin.gens ⊓ span{X̄₁, Z̄₁} = 0`, so the vector itself is `0`. -/
 lemma disjoint_s1_promoted
     (hdisj : Disjoint (sympSpan D.Cin.generatorsList)
-      (sympSpan [(D.Cin.logicalOps 0).xOp, (D.Cin.logicalOps 0).zOp])) :
+      (sympSpan [D.Cin.logicalX 0, D.Cin.logicalZ 0])) :
     Disjoint (sympSpan D.s1PerBlockList) (sympSpan D.promotedOuterList) := by
   rw [Submodule.disjoint_def]
   intro v hv_s1 hv_promo
@@ -455,7 +455,7 @@ Both inputs are small (Steane: `2 ^ 8` and `2 ^ 6`), hence `decide`/`native_deci
 instance — unlike the `2 ^ (n₁ n₂ - k₂)` direct check on the concatenated list. -/
 theorem rowsLinearIndependent_concat
     (hin : rowsLinearIndependent (D.Cin.generatorsList ++
-      [(D.Cin.logicalOps 0).xOp, (D.Cin.logicalOps 0).zOp]))
+      [D.Cin.logicalX 0, D.Cin.logicalZ 0]))
     (hout : rowsLinearIndependent (D.outerZ ++ D.outerX)) :
     rowsLinearIndependent D.concatGeneratorsList := by
   obtain ⟨hCin, hlog, hdisj⟩ := (rowsLinearIndependent_append_iff _ _).mp hin
@@ -467,7 +467,7 @@ theorem rowsLinearIndependent_concat
 /-- The `GeneratorsIndependent` corollary, ready to feed `concatenate` and the M7 instances. -/
 theorem generatorsIndependent_concat
     (hin : rowsLinearIndependent (D.Cin.generatorsList ++
-      [(D.Cin.logicalOps 0).xOp, (D.Cin.logicalOps 0).zOp]))
+      [D.Cin.logicalX 0, D.Cin.logicalZ 0]))
     (hout : rowsLinearIndependent (D.outerZ ++ D.outerX)) :
     GeneratorsIndependent (n₁ * n₂) D.concatGeneratorsList :=
   GeneratorsIndependent_of_rowsLinearIndependent _ _ (D.rowsLinearIndependent_concat hin hout)

--- a/QEC/Stabilizer/Framework/Concatenation/Promotion.lean
+++ b/QEC/Stabilizer/Framework/Concatenation/Promotion.lean
@@ -107,8 +107,8 @@ lemma noY_of_isZType {n : ℕ} {op : NQubitPauliOperator n}
 
 /-- Input data for concatenating a `k₁ = 1` CSS inner code with a CSS outer code.
 Carries the typed (Z/X) splits of both generator lists and the CSS-typed,
-phase-0 inner logical representatives `X̄₁ = (Cin.logicalOps 0).xOp`,
-`Z̄₁ = (Cin.logicalOps 0).zOp`. -/
+phase-0 inner logical representatives `X̄₁ = (Cin.logicalX 0)`,
+`Z̄₁ = (Cin.logicalZ 0)`. -/
 structure ConcatCSSData (n₁ n₂ k₂ : ℕ) [NeZero n₁] where
   Cin : StabilizerCode n₁ 1
   Cout : StabilizerCode n₂ k₂
@@ -122,26 +122,26 @@ structure ConcatCSSData (n₁ n₂ k₂ : ℕ) [NeZero n₁] where
   outer_split : List.Perm Cout.generatorsList (outerZ ++ outerX)
   outerZ_isZ : ∀ g ∈ outerZ, IsZTypeElement g
   outerX_isX : ∀ g ∈ outerX, IsXTypeElement g
-  innerLogX_isX : NQubitPauliOperator.IsXType (Cin.logicalOps 0).xOp.operators
-  innerLogX_phaseZero : (Cin.logicalOps 0).xOp.phasePower = 0
-  innerLogZ_isZ : NQubitPauliOperator.IsZType (Cin.logicalOps 0).zOp.operators
-  innerLogZ_phaseZero : (Cin.logicalOps 0).zOp.phasePower = 0
+  innerLogX_isX : NQubitPauliOperator.IsXType (Cin.logicalX 0).operators
+  innerLogX_phaseZero : (Cin.logicalX 0).phasePower = 0
+  innerLogZ_isZ : NQubitPauliOperator.IsZType (Cin.logicalZ 0).operators
+  innerLogZ_phaseZero : (Cin.logicalZ 0).phasePower = 0
   /-- The outer logical `X` representatives are X-type (hence `Y`-free): required so that
   `promote_anticommute_parity` applies to the promoted logicals. A CSS outer code admits
   such representatives. -/
-  outerLogX_isX : ∀ ℓ : Fin k₂, NQubitPauliOperator.IsXType (Cout.logicalOps ℓ).xOp.operators
+  outerLogX_isX : ∀ ℓ : Fin k₂, NQubitPauliOperator.IsXType (Cout.logicalX ℓ).operators
   /-- The outer logical `Z` representatives are Z-type (hence `Y`-free). -/
-  outerLogZ_isZ : ∀ ℓ : Fin k₂, NQubitPauliOperator.IsZType (Cout.logicalOps ℓ).zOp.operators
+  outerLogZ_isZ : ∀ ℓ : Fin k₂, NQubitPauliOperator.IsZType (Cout.logicalZ ℓ).operators
 
 namespace ConcatCSSData
 
 variable (D : ConcatCSSData n₁ n₂ k₂)
 
 /-- The inner logical-`X` operator used as the `X ↦ X̄₁` promotion target. -/
-def Xbar : NQubitPauliOperator n₁ := (D.Cin.logicalOps 0).xOp.operators
+def Xbar : NQubitPauliOperator n₁ := (D.Cin.logicalX 0).operators
 
 /-- The inner logical-`Z` operator used as the `Z ↦ Z̄₁` promotion target. -/
-def Zbar : NQubitPauliOperator n₁ := (D.Cin.logicalOps 0).zOp.operators
+def Zbar : NQubitPauliOperator n₁ := (D.Cin.logicalZ 0).operators
 
 /-! ## The concatenated generator list -/
 

--- a/QEC/Stabilizer/Framework/Core.lean
+++ b/QEC/Stabilizer/Framework/Core.lean
@@ -1,6 +1,7 @@
 import QEC.Stabilizer.Framework.Core.Stabilizer
 import QEC.Stabilizer.Framework.Core.Logical
 import QEC.Stabilizer.Framework.Core.CSS
+import QEC.Stabilizer.Framework.Core.CodeNotation
 
 /-!
 # Framework.Core
@@ -9,4 +10,6 @@ Abstract stabilizer-formalism content, split into three buckets:
 - `QEC.Stabilizer.Framework.Core.Stabilizer` — stabilizer-group + codespace + centralizer
 - `QEC.Stabilizer.Framework.Core.Logical`    — logical-operator theory + code distance
 - `QEC.Stabilizer.Framework.Core.CSS`        — CSS-code theory
+- `QEC.Stabilizer.Framework.Core.CodeNotation` — scoped `Code[[n, k]]` /
+  `Code[[n, k, d]]` type notation for the bundled codes
 -/

--- a/QEC/Stabilizer/Framework/Core/CodeNotation.lean
+++ b/QEC/Stabilizer/Framework/Core/CodeNotation.lean
@@ -1,0 +1,57 @@
+import QEC.Stabilizer.Framework.Core.Logical.CodeDistance
+
+/-!
+# `[[n, k, d]]` code-parameter notation
+
+Scoped type notation for the two bundled code structures, following the standard
+`[[n, k, d]]` parameter convention described in `CodeDistance.lean`:
+
+- `Code[[n, k]]` is `StabilizerCode n k` — `n` physical qubits, `k` logical qubits;
+- `Code[[n, k, d]]` is `StabilizerCodeWithDistance n k d` — additionally, a proved
+  distance `d`.
+
+Bare `[[n, k]]` already parses as a nested list literal, hence the `Code` prefix: the
+leading token is `Code[[`, and the closing brackets are two ordinary `]` tokens (a single
+`]]` token would break every nested `[[…]]` / `#[#[…]]` literal in scope). The notation
+lives in the `Quantum.StabilizerGroup` scope, so it is active inside that namespace and
+after `open Quantum.StabilizerGroup` / `open scoped Quantum.StabilizerGroup`, and each
+form has an unexpander so goals and `#check` output display `Code[[7, 1]]` rather than
+`StabilizerCode 7 1`.
+-/
+
+namespace Quantum.StabilizerGroup
+
+/-- `Code[[n, k]]` is the type `StabilizerCode n k` of `[[n, k]]` stabilizer codes:
+`n` physical qubits, `k` logical qubits. Scoped: `open scoped Quantum.StabilizerGroup`. -/
+scoped notation:max "Code[[" n ", " k "]" "]" => StabilizerCode n k
+
+/-- `Code[[n, k, d]]` is the type `StabilizerCodeWithDistance n k d` of `[[n, k, d]]`
+stabilizer codes packaged with a proof that their distance is `d`.
+Scoped: `open scoped Quantum.StabilizerGroup`. -/
+scoped notation:max "Code[[" n ", " k ", " d "]" "]" => StabilizerCodeWithDistance n k d
+
+end Quantum.StabilizerGroup
+
+/-!
+## Round-trip tests
+
+Each form is the corresponding structure type, definitionally and syntactically.
+-/
+
+section RoundTrip
+
+open Quantum.StabilizerGroup
+
+example : Code[[7, 1]] = StabilizerCode 7 1 := rfl
+
+example : Code[[5, 1, 3]] = StabilizerCodeWithDistance 5 1 3 := rfl
+
+example (n k : ℕ) : Code[[n, k]] = StabilizerCode n k := rfl
+
+example (n k d : ℕ) : Code[[n, k, d]] = StabilizerCodeWithDistance n k d := rfl
+
+example (C : Code[[7, 1]]) : Code[[7, 1]] := C
+
+example (C : Code[[5, 1, 3]]) : Code[[5, 1]] := C.toStabilizerCode
+
+end RoundTrip

--- a/QEC/Stabilizer/Framework/Core/Stabilizer/StabilizerCode.lean
+++ b/QEC/Stabilizer/Framework/Core/Stabilizer/StabilizerCode.lean
@@ -110,45 +110,15 @@ namespace StabilizerCode
 noncomputable def toStabilizerGroup (C : StabilizerCode n k) : StabilizerGroup n :=
   mkStabilizerFromGenerators n C.generatorsList C.generators_commute C.closure_no_neg_identity
 
-/-- Logical X for logical qubit ℓ. -/
-def logicalX (C : StabilizerCode n k) (ℓ : Fin k) : NQubitPauliGroupElement n :=
+/-- Logical X for logical qubit ℓ, i.e. `(C.logicalOps ℓ).xOp`. A reducible abbreviation,
+so `simp` sees through it and lemmas may be stated in either spelling; there is deliberately
+no display rewriting between the two — a goal prints whichever spelling its term carries. -/
+abbrev logicalX (C : StabilizerCode n k) (ℓ : Fin k) : NQubitPauliGroupElement n :=
   (C.logicalOps ℓ).xOp
 
-/-- Logical Z for logical qubit ℓ. -/
-def logicalZ (C : StabilizerCode n k) (ℓ : Fin k) : NQubitPauliGroupElement n :=
+/-- Logical Z for logical qubit ℓ, i.e. `(C.logicalOps ℓ).zOp` (see `logicalX`). -/
+abbrev logicalZ (C : StabilizerCode n k) (ℓ : Fin k) : NQubitPauliGroupElement n :=
   (C.logicalOps ℓ).zOp
-
-section Delab
-
-open Lean PrettyPrinter Delaborator SubExpr
-
-/-- Build the syntax `C.f ℓ` (generalized field notation) from delaborated `C`, `ℓ`. -/
-private def mkFieldApp (C : Term) (f : Name) (ℓ : Term) : Term :=
-  let proj : Term := ⟨Syntax.node .none ``Lean.Parser.Term.proj #[C, mkAtom ".", mkIdent f]⟩
-  ⟨Syntax.node .none ``Lean.Parser.Term.app #[proj, Syntax.node .none nullKind #[ℓ]]⟩
-
-/-- Delaborate `(C.logicalOps ℓ).xOp` / `(C.logicalOps ℓ).zOp` as `C.logicalX ℓ` /
-`C.logicalZ ℓ`. Fires only when the `LogicalQubitOps` argument is literally a
-`StabilizerCode.logicalOps` application; any other projection keeps the default printer. -/
-private def delabLogicalProj (f : Name) : Delab :=
-  whenPPOption getPPNotation <| whenNotPPOption getPPExplicit do
-    let e ← getExpr
-    unless e.getAppNumArgs == 3 do failure
-    let ops := e.appArg!
-    unless ops.isAppOfArity ``Quantum.StabilizerGroup.StabilizerCode.logicalOps 4 do failure
-    let C ← withNaryArg 2 <| withNaryArg 2 delab
-    let ℓ ← withNaryArg 2 <| withNaryArg 3 delab
-    return mkFieldApp C f ℓ
-
-/-- `(C.logicalOps ℓ).xOp` displays as `C.logicalX ℓ`. -/
-@[app_delab Quantum.StabilizerGroup.LogicalQubitOps.xOp]
-def delabLogicalX : Delab := delabLogicalProj `logicalX
-
-/-- `(C.logicalOps ℓ).zOp` displays as `C.logicalZ ℓ`. -/
-@[app_delab Quantum.StabilizerGroup.LogicalQubitOps.zOp]
-def delabLogicalZ : Delab := delabLogicalProj `logicalZ
-
-end Delab
 
 /-- Logical X for qubit ℓ is not in the stabilizer subgroup. -/
 theorem logicalX_not_mem_subgroup (C : StabilizerCode n k) (ℓ : Fin k) :

--- a/QEC/Stabilizer/Framework/Core/Stabilizer/StabilizerCode.lean
+++ b/QEC/Stabilizer/Framework/Core/Stabilizer/StabilizerCode.lean
@@ -118,6 +118,38 @@ def logicalX (C : StabilizerCode n k) (ℓ : Fin k) : NQubitPauliGroupElement n 
 def logicalZ (C : StabilizerCode n k) (ℓ : Fin k) : NQubitPauliGroupElement n :=
   (C.logicalOps ℓ).zOp
 
+section Delab
+
+open Lean PrettyPrinter Delaborator SubExpr
+
+/-- Build the syntax `C.f ℓ` (generalized field notation) from delaborated `C`, `ℓ`. -/
+private def mkFieldApp (C : Term) (f : Name) (ℓ : Term) : Term :=
+  let proj : Term := ⟨Syntax.node .none ``Lean.Parser.Term.proj #[C, mkAtom ".", mkIdent f]⟩
+  ⟨Syntax.node .none ``Lean.Parser.Term.app #[proj, Syntax.node .none nullKind #[ℓ]]⟩
+
+/-- Delaborate `(C.logicalOps ℓ).xOp` / `(C.logicalOps ℓ).zOp` as `C.logicalX ℓ` /
+`C.logicalZ ℓ`. Fires only when the `LogicalQubitOps` argument is literally a
+`StabilizerCode.logicalOps` application; any other projection keeps the default printer. -/
+private def delabLogicalProj (f : Name) : Delab :=
+  whenPPOption getPPNotation <| whenNotPPOption getPPExplicit do
+    let e ← getExpr
+    unless e.getAppNumArgs == 3 do failure
+    let ops := e.appArg!
+    unless ops.isAppOfArity ``Quantum.StabilizerGroup.StabilizerCode.logicalOps 4 do failure
+    let C ← withNaryArg 2 <| withNaryArg 2 delab
+    let ℓ ← withNaryArg 2 <| withNaryArg 3 delab
+    return mkFieldApp C f ℓ
+
+/-- `(C.logicalOps ℓ).xOp` displays as `C.logicalX ℓ`. -/
+@[app_delab Quantum.StabilizerGroup.LogicalQubitOps.xOp]
+def delabLogicalX : Delab := delabLogicalProj `logicalX
+
+/-- `(C.logicalOps ℓ).zOp` displays as `C.logicalZ ℓ`. -/
+@[app_delab Quantum.StabilizerGroup.LogicalQubitOps.zOp]
+def delabLogicalZ : Delab := delabLogicalProj `logicalZ
+
+end Delab
+
 /-- Logical X for qubit ℓ is not in the stabilizer subgroup. -/
 theorem logicalX_not_mem_subgroup (C : StabilizerCode n k) (ℓ : Fin k) :
     C.logicalX ℓ ∉ C.toStabilizerGroup.toSubgroup :=

--- a/QEC/Stabilizer/Framework/Homological/BBBocksteinTransport.lean
+++ b/QEC/Stabilizer/Framework/Homological/BBBocksteinTransport.lean
@@ -56,6 +56,7 @@ namespace Homological
 namespace BB
 
 open scoped BigOperators
+open scoped Homology
 
 -- Defeq checks through `coverComplex`/`baseComplex` projections and the
 -- `liftCoverData` structure literal unfold deep `Prod`/`ZMod` instance
@@ -485,23 +486,23 @@ theorem bocksteinVanishes_of_elementForm (hEF : D.BocksteinElementForm) :
 /-- **The Bockstein rank equality** under the element form:
 `dim (1+σ)·H₁(cover) = k̃ − k`. -/
 theorem finrank_range_epsH1_eq_of_elementForm (hEF : D.BocksteinElementForm) :
-    Module.finrank (ZMod 2) (LinearMap.range D.epsH1)
-      = Module.finrank (ZMod 2) D.coverComplex.H1
-        - Module.finrank (ZMod 2) D.baseComplex.H1 :=
+    dim₂ (LinearMap.range D.epsH1)
+      = dim₂ D.coverComplex.H1
+        - dim₂ D.baseComplex.H1 :=
   D.finrank_range_epsH1_eq (D.bocksteinVanishes_of_elementForm hEF)
 
 /-- Additive form: `E + k = k̃` (in particular `k̃ ≥ k`). -/
 theorem finrank_range_epsH1_add_eq_of_elementForm
     (hEF : D.BocksteinElementForm) :
-    Module.finrank (ZMod 2) (LinearMap.range D.epsH1)
-        + Module.finrank (ZMod 2) D.baseComplex.H1
-      = Module.finrank (ZMod 2) D.coverComplex.H1 :=
+    dim₂ (LinearMap.range D.epsH1)
+        + dim₂ D.baseComplex.H1
+      = dim₂ D.coverComplex.H1 :=
   D.finrank_range_epsH1_add_eq (D.bocksteinVanishes_of_elementForm hEF)
 
 /-- Companion rank: `dim ker ε_* = k`. -/
 theorem finrank_ker_epsH1_eq_of_elementForm (hEF : D.BocksteinElementForm) :
-    Module.finrank (ZMod 2) (LinearMap.ker D.epsH1)
-      = Module.finrank (ZMod 2) D.baseComplex.H1 :=
+    dim₂ (LinearMap.ker D.epsH1)
+      = dim₂ D.baseComplex.H1 :=
   D.finrank_ker_epsH1_eq (D.bocksteinVanishes_of_elementForm hEF)
 
 /-! ## Discharging the element form from an order-4 lift of the deck -/
@@ -690,9 +691,9 @@ theorem finrank_range_epsH1_eq_of_orderFourLift {Ghat : Type}
     (hsurj : Function.Surjective ⇑q)
     (hshat : q shat = D.deckS)
     (hker : ∀ x : Ghat, q x = 0 ↔ x = 0 ∨ x = shat + shat) :
-    Module.finrank (ZMod 2) (LinearMap.range D.epsH1)
-      = Module.finrank (ZMod 2) D.coverComplex.H1
-        - Module.finrank (ZMod 2) D.baseComplex.H1 :=
+    dim₂ (LinearMap.range D.epsH1)
+      = dim₂ D.coverComplex.H1
+        - dim₂ D.baseComplex.H1 :=
   D.finrank_range_epsH1_eq
     (D.bocksteinVanishes_of_orderFourLift q shat horder hsurj hshat hker)
 
@@ -837,9 +838,9 @@ theorem finrank_range_epsH1_eq_of_zmod_double {n m : ℕ} [NeZero n] [NeZero m]
     (D : XDoubleCoverData (ZMod (2 * n) × ZMod m) H)
     (t : ZMod m) (ht : t + t = 0)
     (hdeck : D.deckS = (((n : ℕ) : ZMod (2 * n)), t)) :
-    Module.finrank (ZMod 2) (LinearMap.range D.epsH1)
-      = Module.finrank (ZMod 2) D.coverComplex.H1
-        - Module.finrank (ZMod 2) D.baseComplex.H1 :=
+    dim₂ (LinearMap.range D.epsH1)
+      = dim₂ D.coverComplex.H1
+        - dim₂ D.baseComplex.H1 :=
   D.finrank_range_epsH1_eq (D.bocksteinVanishes_of_zmod_double t ht hdeck)
 
 /-- **The element form for doubled-axis `ZMod` products, second-axis
@@ -959,9 +960,9 @@ theorem finrank_range_epsH1_eq_of_zmod_double_right {n m : ℕ}
     (D : XDoubleCoverData (ZMod m × ZMod (2 * n)) H)
     (t : ZMod m) (ht : t + t = 0)
     (hdeck : D.deckS = (t, ((n : ℕ) : ZMod (2 * n)))) :
-    Module.finrank (ZMod 2) (LinearMap.range D.epsH1)
-      = Module.finrank (ZMod 2) D.coverComplex.H1
-        - Module.finrank (ZMod 2) D.baseComplex.H1 :=
+    dim₂ (LinearMap.range D.epsH1)
+      = dim₂ D.coverComplex.H1
+        - dim₂ D.baseComplex.H1 :=
   D.finrank_range_epsH1_eq
     (D.bocksteinVanishes_of_zmod_double_right t ht hdeck)
 

--- a/QEC/Stabilizer/Framework/Homological/BBBocksteinTransport.lean
+++ b/QEC/Stabilizer/Framework/Homological/BBBocksteinTransport.lean
@@ -102,16 +102,16 @@ variable {G : Type} [Fintype G] [AddCommGroup G]
 
 /-- The left half of `∂₂ f` is `A ⋆ f`. -/
 lemma leftHalf_bbBoundary2Fn (A B f : G → ZMod 2) :
-    leftHalf (bbBoundary2Fn A B f) = conv A f := by
+    leftHalf (bbBoundary2Fn A B f) = A ⋆ f := by
   funext g
-  change (if (0 : Fin 2) = 0 then conv A f g else conv B f g) = conv A f g
+  change (if (0 : Fin 2) = 0 then (A ⋆ f) g else (B ⋆ f) g) = (A ⋆ f) g
   rw [if_pos rfl]
 
 /-- The right half of `∂₂ f` is `B ⋆ f`. -/
 lemma rightHalf_bbBoundary2Fn (A B f : G → ZMod 2) :
-    rightHalf (bbBoundary2Fn A B f) = conv B f := by
+    rightHalf (bbBoundary2Fn A B f) = B ⋆ f := by
   funext g
-  change (if (1 : Fin 2) = 0 then conv A f g else conv B f g) = conv B f g
+  change (if (1 : Fin 2) = 0 then (A ⋆ f) g else (B ⋆ f) g) = (B ⋆ f) g
   rw [if_neg (by decide)]
 
 end BoundaryHalves
@@ -310,7 +310,7 @@ convolved with its sheet-0 lift.  This is the multiplication-operator
 form of the transfer, the key identity that turns `τ₁(seamC ζ) = liftStab ζ`
 into the `ε`-divisibility hypotheses of the element form. -/
 theorem pull0_eq_conv_deckPoly_liftC2 (u : H → ZMod 2) :
-    D.pull0 u = conv D.deckPoly (D.liftC2 u) := by
+    D.pull0 u = D.deckPoly ⋆ D.liftC2 u := by
   have h1 : D.push0 (D.liftC2 u) = u := by
     change fiberSumFn (⇑D.proj) (D.liftC2 u) = u
     exact D.push0_liftC2 u
@@ -318,7 +318,7 @@ theorem pull0_eq_conv_deckPoly_liftC2 (u : H → ZMod 2) :
 
 /-- Multiplication by `deckPoly` lands in `ker p₀`. -/
 theorem push0_conv_deckPoly_eq_zero (w : G → ZMod 2) :
-    D.push0 (conv D.deckPoly w) = 0 := by
+    D.push0 (D.deckPoly ⋆ w) = 0 := by
   rw [D.conv_deckPoly_eq, ← D.pull0_push0]
   exact D.push0_pull0_eq_zero _
 
@@ -352,11 +352,11 @@ lemma rightHalf_pull1 (u : H × Fin 2 → ZMod 2) :
 component of `τ₁(seamC ζ) = liftStab ζ` read through `τ₀ = ε·lift`. -/
 theorem conv_Ac_liftC2_seamC {ζ : H → ZMod 2}
     (hζ : bbBoundary2Fn D.Ab D.Bb ζ = 0) :
-    conv D.Ac (D.liftC2 ζ)
-      = conv D.deckPoly (D.liftC2 (leftHalf (D.seamC ζ))) := by
+    D.Ac ⋆ D.liftC2 ζ
+      = D.deckPoly ⋆ D.liftC2 (leftHalf (D.seamC ζ)) := by
   have hL := congrArg leftHalf (D.pull1_seamC hζ)
   rw [D.leftHalf_pull1, D.pull0_eq_conv_deckPoly_liftC2] at hL
-  have hstab : leftHalf (D.liftStab ζ) = conv D.Ac (D.liftC2 ζ) :=
+  have hstab : leftHalf (D.liftStab ζ) = D.Ac ⋆ D.liftC2 ζ :=
     leftHalf_bbBoundary2Fn D.Ac D.Bc (D.liftC2 ζ)
   rw [hstab] at hL
   exact hL.symm
@@ -364,11 +364,11 @@ theorem conv_Ac_liftC2_seamC {ζ : H → ZMod 2}
 /-- `B⋆(lift ζ) = ε⋆(lift of the right half of seamC ζ)`. -/
 theorem conv_Bc_liftC2_seamC {ζ : H → ZMod 2}
     (hζ : bbBoundary2Fn D.Ab D.Bb ζ = 0) :
-    conv D.Bc (D.liftC2 ζ)
-      = conv D.deckPoly (D.liftC2 (rightHalf (D.seamC ζ))) := by
+    D.Bc ⋆ D.liftC2 ζ
+      = D.deckPoly ⋆ D.liftC2 (rightHalf (D.seamC ζ)) := by
   have hR := congrArg rightHalf (D.pull1_seamC hζ)
   rw [D.rightHalf_pull1, D.pull0_eq_conv_deckPoly_liftC2] at hR
-  have hstab : rightHalf (D.liftStab ζ) = conv D.Bc (D.liftC2 ζ) :=
+  have hstab : rightHalf (D.liftStab ζ) = D.Bc ⋆ D.liftC2 ζ :=
     rightHalf_bbBoundary2Fn D.Ac D.Bc (D.liftC2 ζ)
   rw [hstab] at hR
   exact hR.symm
@@ -383,11 +383,11 @@ lies in `ε·(A, B)`.  This is the `δ₁∘δ₂ = 0` element fact (A13 §1, cl
 deck. -/
 def BocksteinElementForm : Prop :=
   ∀ z a b : G → ZMod 2,
-    conv D.Ac z = conv D.deckPoly a →
-    conv D.Bc z = conv D.deckPoly b →
+    D.Ac ⋆ z = D.deckPoly ⋆ a →
+    D.Bc ⋆ z = D.deckPoly ⋆ b →
     ∃ r s : G → ZMod 2,
-      conv D.Ac b + conv D.Bc a
-        = conv D.deckPoly (conv D.Ac r + conv D.Bc s)
+      D.Ac ⋆ b + D.Bc ⋆ a
+        = D.deckPoly ⋆ (D.Ac ⋆ r + D.Bc ⋆ s)
 
 /-- **The transport core**: under the element form, every seam chain is
 the pushforward of a cover 1-cycle — on the nose.  The corrected lift
@@ -400,41 +400,41 @@ theorem exists_cycle_push_eq_seamC (hEF : D.BocksteinElementForm)
       v ∈ D.coverComplex.cycles ∧ D.push1 v = D.seamC ζ := by
   set za := D.liftC2 (leftHalf (D.seamC ζ)) with hza
   set zb := D.liftC2 (rightHalf (D.seamC ζ)) with hzb
-  have hA : conv D.Ac (D.liftC2 ζ) = conv D.deckPoly za :=
+  have hA : D.Ac ⋆ D.liftC2 ζ = D.deckPoly ⋆ za :=
     D.conv_Ac_liftC2_seamC hζ
-  have hB : conv D.Bc (D.liftC2 ζ) = conv D.deckPoly zb :=
+  have hB : D.Bc ⋆ D.liftC2 ζ = D.deckPoly ⋆ zb :=
     D.conv_Bc_liftC2_seamC hζ
   obtain ⟨r, s, hrs⟩ := hEF (D.liftC2 ζ) za zb hA hB
-  refine ⟨joinHalves (za + conv D.deckPoly s) (zb + conv D.deckPoly r),
+  refine ⟨joinHalves (za + D.deckPoly ⋆ s) (zb + D.deckPoly ⋆ r),
     ?_, ?_⟩
   · -- the corrected lift is a cover cycle
-    have hcommA : conv D.Ac (conv D.deckPoly r)
-        = conv D.deckPoly (conv D.Ac r) := by
+    have hcommA : D.Ac ⋆ (D.deckPoly ⋆ r)
+        = D.deckPoly ⋆ (D.Ac ⋆ r) := by
       rw [← conv_assoc, conv_comm D.Ac D.deckPoly, conv_assoc]
-    have hcommB : conv D.Bc (conv D.deckPoly s)
-        = conv D.deckPoly (conv D.Bc s) := by
+    have hcommB : D.Bc ⋆ (D.deckPoly ⋆ s)
+        = D.deckPoly ⋆ (D.Bc ⋆ s) := by
       rw [← conv_assoc, conv_comm D.Bc D.deckPoly, conv_assoc]
     have hbd : bbBoundary1Fn D.Ac D.Bc
-        (joinHalves (za + conv D.deckPoly s) (zb + conv D.deckPoly r)) = 0 := by
+        (joinHalves (za + D.deckPoly ⋆ s) (zb + D.deckPoly ⋆ r)) = 0 := by
       have hexp : bbBoundary1Fn D.Ac D.Bc
-          (joinHalves (za + conv D.deckPoly s) (zb + conv D.deckPoly r))
-          = conv D.Bc (leftHalf (joinHalves (za + conv D.deckPoly s)
-              (zb + conv D.deckPoly r)))
-            + conv D.Ac (rightHalf (joinHalves (za + conv D.deckPoly s)
-              (zb + conv D.deckPoly r))) := rfl
+          (joinHalves (za + D.deckPoly ⋆ s) (zb + D.deckPoly ⋆ r))
+          = D.Bc ⋆ leftHalf (joinHalves (za + D.deckPoly ⋆ s)
+              (zb + D.deckPoly ⋆ r))
+            + D.Ac ⋆ rightHalf (joinHalves (za + D.deckPoly ⋆ s)
+              (zb + D.deckPoly ⋆ r)) := rfl
       rw [hexp, leftHalf_joinHalves, rightHalf_joinHalves, conv_add_right,
         conv_add_right, hcommA, hcommB]
-      have hre : conv D.Bc za + conv D.deckPoly (conv D.Bc s)
-          + (conv D.Ac zb + conv D.deckPoly (conv D.Ac r))
-          = (conv D.Ac zb + conv D.Bc za)
-            + conv D.deckPoly (conv D.Ac r + conv D.Bc s) := by
+      have hre : D.Bc ⋆ za + D.deckPoly ⋆ (D.Bc ⋆ s)
+          + (D.Ac ⋆ zb + D.deckPoly ⋆ (D.Ac ⋆ r))
+          = (D.Ac ⋆ zb + D.Bc ⋆ za)
+            + D.deckPoly ⋆ (D.Ac ⋆ r + D.Bc ⋆ s) := by
         rw [conv_add_right]
         abel
       rw [hre, hrs]
       funext g
       exact CharTwo.add_self_eq_zero _
     have hgoal : D.coverComplex.boundary1
-        (joinHalves (za + conv D.deckPoly s) (zb + conv D.deckPoly r)) = 0 :=
+        (joinHalves (za + D.deckPoly ⋆ s) (zb + D.deckPoly ⋆ r)) = 0 :=
       hbd
     exact hgoal
   · -- it pushes forward to the seam chain exactly
@@ -612,7 +612,7 @@ theorem elementForm_of_orderFourLift {Ghat : Type}
       rw [← convEquiv_mapDomainRingHom q x, hx, map_zero]
     obtain ⟨u, hu⟩ := (fiberSumFn_eq_zero_iff hσne hfiber
       (fun p => Function.surjInv_eq hsurj p) (convEquiv x)).mp hfx
-    have hpull : convEquiv x = conv Dh.deckPoly (Dh.liftC2 u) := by
+    have hpull : convEquiv x = Dh.deckPoly ⋆ Dh.liftC2 u := by
       rw [hu, ← Dh.pull0_eq_conv_deckPoly_liftC2 u]
       rfl
     have hconvsq : convEquiv
@@ -655,13 +655,13 @@ theorem elementForm_of_orderFourLift {Ghat : Type}
   refine ⟨convEquiv r', convEquiv s', ?_⟩
   have hL : convEquiv (convEquiv.symm D.Ac * convEquiv.symm b
       + convEquiv.symm D.Bc * convEquiv.symm a)
-      = conv D.Ac b + conv D.Bc a := by
+      = D.Ac ⋆ b + D.Bc ⋆ a := by
     rw [map_add, convEquiv_mul, convEquiv_mul, LinearEquiv.apply_symm_apply,
       LinearEquiv.apply_symm_apply, LinearEquiv.apply_symm_apply,
       LinearEquiv.apply_symm_apply]
   have hR : convEquiv ((1 + AddMonoidAlgebra.single D.deckS (1 : ZMod 2))
       * (convEquiv.symm D.Ac * r' + convEquiv.symm D.Bc * s'))
-      = conv D.deckPoly (conv D.Ac (convEquiv r') + conv D.Bc (convEquiv s')) := by
+      = D.deckPoly ⋆ (D.Ac ⋆ convEquiv r' + D.Bc ⋆ convEquiv s') := by
     rw [convEquiv_mul, hconvεG]
     congr 1
     rw [map_add, convEquiv_mul, convEquiv_mul, LinearEquiv.apply_symm_apply,

--- a/QEC/Stabilizer/Framework/Homological/BBChainComplex.lean
+++ b/QEC/Stabilizer/Framework/Homological/BBChainComplex.lean
@@ -79,20 +79,27 @@ kernel `decide`s downstream run through. Monomials are `1`, `x`, `y`, `x^i`, `y^
 declare_syntax_cat bbPoly (behavior := both)
 
 /-- The constant monomial `1` (the point `(0, 0)`); other numerals are rejected. -/
-syntax num : bbPoly
+scoped syntax num : bbPoly
 /-- The monomial `x` or `x^i` (the point `(i, 0)`). -/
-syntax &"x" ("^" num)? : bbPoly
+scoped syntax &"x" ("^" num)? : bbPoly
 /-- The monomial `y` or `y^j` (the point `(0, j)`). -/
-syntax &"y" ("^" num)? : bbPoly
+scoped syntax &"y" ("^" num)? : bbPoly
 /-- The monomial `x^i*y^j` (the point `(i, j)`), either exponent optional. -/
-syntax &"x" ("^" num)? "*" &"y" ("^" num)? : bbPoly
+scoped syntax &"x" ("^" num)? "*" &"y" ("^" num)? : bbPoly
 /-- Polynomial sum, left-associative. -/
-syntax:65 bbPoly:65 " + " bbPoly:66 : bbPoly
+scoped syntax:65 bbPoly:65 " + " bbPoly:66 : bbPoly
 
 /-- `poly[x^3 + y + y^2]` is the indicator function
 `fun g => if g = (3, 0) ∨ g = (0, 1) ∨ g = (0, 2) then 1 else 0` of the monomials'
 exponent points, for use as a bivariate-bicycle polynomial `G → ZMod 2`. Scoped to
-`Quantum.Stabilizer.Homological.BB`. -/
+`Quantum.Stabilizer.Homological.BB`.
+
+The `+` is a union of *distinct* exponent points, not addition in `𝔽₂[G]`: the literal is
+the polynomial it spells only when the written monomials are pairwise distinct modulo the
+group orders. A syntactically repeated monomial is rejected, but a coincidence modulo the
+orders cannot be seen at macro time — `poly[1 + x^6]` is `1 + x⁶` over `ZMod 12 × ZMod 6`
+but the constant `1` (not `0`) over `ZMod 6 × ZMod 6` — so check the exponents against the
+intended group. There is no literal for the zero polynomial; write `0`. -/
 scoped syntax:max (name := polyLit) "poly[" bbPoly "]" : term
 
 /-- The exponent points `(a, b)` of a `bbPoly` sum, in the written order. -/
@@ -114,6 +121,9 @@ partial def monomialsOf : TSyntax `bbPoly → MacroM (List (Nat × Nat))
 macro_rules
   | `(poly[$p]) => do
     let mons ← monomialsOf p
+    if let some d := mons.find? fun m => mons.count m > 1 then
+      Macro.throwErrorAt p
+        s!"repeated monomial x^{d.1}*y^{d.2}: `+` in `poly[…]` is a union of distinct points"
     let g := mkIdent `g
     let some (last, init) := mons.getLast?.map fun l => (l, mons.dropLast) | Macro.throwUnsupported
     let mkEq : Nat × Nat → MacroM Term := fun (a, b) =>
@@ -173,14 +183,23 @@ private def monomialSyntax (m : Nat × Nat) : DelabM (TSyntax `bbPoly) := do
   | (a, b) => `(bbPoly| x ^ $(lit a) * y ^ $(lit b))
 
 /-- Delaborate `fun g => if g = (a₁, b₁) ∨ … then 1 else 0` back to `poly[…]`. Fires only on
-a lambda of exactly that shape with literal exponents; every other lambda is left to the
-default printer. -/
-@[delab lam]
+a lambda of exactly that shape, of type `ZMod ℓ × ZMod m → ZMod 2`, with literal exponents
+and without a `Classical` decidability instance (a `classical` indicator would print the
+same but re-elaborate to a different term); every other lambda is left to the default
+printer. Scoped with the notation. -/
+@[scoped delab lam]
 def delabPolyLit : Delab :=
   whenPPOption getPPNotation <| whenNotPPOption getPPExplicit do
     let e ← getExpr
-    let .lam _ _ body _ := e | failure
+    let .lam _ dom body _ := e | failure
     unless body.isAppOfArity ``ite 5 do failure
+    let dom ← Meta.whnfR dom
+    unless dom.isAppOfArity ``Prod 2 && (dom.getArg! 0).isAppOfArity ``ZMod 1 &&
+        (dom.getArg! 1).isAppOfArity ``ZMod 1 do failure
+    let cod ← Meta.whnfR (body.getArg! 0)
+    unless cod.isAppOfArity ``ZMod 1 && numeral? (cod.getArg! 0) == some 2 do failure
+    if ((body.getArg! 2).find? fun c => c.isConstOf ``Classical.propDecidable).isSome then
+      failure
     unless numeral? (body.getArg! 3) == some 1 && numeral? (body.getArg! 4) == some 0 do
       failure
     let some mons := exponentPoints? (body.getArg! 1) | failure
@@ -593,6 +612,31 @@ example (a b : G → ZMod 2) : a ⋆ b = conv a b := rfl
 example (a b c : G → ZMod 2) : a ⋆ b ⋆ c = conv (conv a b) c := rfl
 
 example (a b : G → ZMod 2) (g : G) : (a ⋆ b) g = conv a b g := rfl
+
+open Lean Elab Command in
+/-- Display test: elaborate `stx` and check that its pretty-printed text is `expected`
+(`exact := false`: contains `expected`). Run through `run_cmd` so no `#`-command is needed. -/
+private def checkDisplay (stx : Syntax) (expected : String) (exact : Bool := true) :
+    CommandElabM Unit :=
+  liftTermElabM do
+    let e ← Term.elabTerm stx none
+    Term.synthesizeSyntheticMVarsNoPostponing
+    let s := toString (← Meta.ppExpr (← instantiateMVars e))
+    unless (if exact then s == expected else (s.splitOn expected).length > 1) do
+      throwError "display test failed:{indentD s}\nexpected{indentD expected}"
+
+run_cmd do
+  checkDisplay (← `((poly[x^3 + y + y^2] : ZMod 12 × ZMod 6 → ZMod 2)))
+    "poly[x^3 + y + y^2]"
+run_cmd do
+  checkDisplay (← `((poly[1 + x*y^2] : ZMod 3 × ZMod 3 → ZMod 2))) "poly[1 + x*y^2]"
+-- an indicator of the same shape over another type is not a bivariate-bicycle polynomial
+run_cmd do
+  checkDisplay (← `(fun p : ℕ × ℕ => if p = (1, 2) ∨ p = (0, 3) then (1 : ℕ) else 0))
+    "if p = (1, 2) ∨ p = (0, 3) then 1 else 0" (exact := false)
+run_cmd do
+  checkDisplay (← `(fun (a b : ZMod 12 × ZMod 6 → ZMod 2) => a ⋆ b))
+    "a ⋆ b" (exact := false)
 
 end RoundTrip
 

--- a/QEC/Stabilizer/Framework/Homological/BBChainComplex.lean
+++ b/QEC/Stabilizer/Framework/Homological/BBChainComplex.lean
@@ -22,7 +22,9 @@ transpose-juggling.
 
 ## What this file provides
 
-* `conv (a b : G → ZMod 2) : G → ZMod 2` — convolution on abelian `G`
+* `conv (a b : G → ZMod 2) : G → ZMod 2` — convolution on abelian `G`, with the
+  scoped infix `a ⋆ b`
+* `poly[x^3 + y + y^2]` — scoped literal for the indicator-function polynomials
 * `conv_comm`, `conv_assoc` — algebraic properties
 * `bbBoundary1`, `bbBoundary2` — concrete boundary maps
 * `bbChainComplex ℓ m A B : HomologicalCode` — the CSS chain complex
@@ -49,11 +51,154 @@ variable {G : Type} [Fintype G] [AddCommGroup G]
 def conv (a b : G → ZMod 2) : G → ZMod 2 :=
   fun g => ∑ h : G, a h * b (g - h)
 
+/-- `a ⋆ b` is the convolution `conv a b` (the group-algebra product of `𝔽₂[G]`). Scoped
+to `Quantum.Stabilizer.Homological.BB`: active inside that namespace, and elsewhere under
+`open scoped Quantum.Stabilizer.Homological.BB`. Multiplicative precedence (`70`), so
+`(a ⋆ b) g` needs its parentheses and `a ⋆ b + c` does not. The `simp`/`rw`/`unfold`
+lists keep the bare name `conv`. -/
+scoped infixl:70 " ⋆ " => conv
+
+section PolyNotation
+
+open Lean
+
+/-! ### Polynomial literals
+
+The polynomials `A`, `B` of a bivariate bicycle code are `ZMod 2`-valued indicator
+functions on `G = ZMod ℓ × ZMod m`, the monomial `xᵃyᵇ` standing for the point `(a, b)`.
+`poly[x^3 + y + y^2]` writes such a function the way the papers do and expands to exactly
+
+```lean
+fun g => if g = (3, 0) ∨ g = (0, 1) ∨ g = (0, 2) then 1 else 0
+```
+
+(the monomials in the written order, `∨` nested to the right as usual), the form the
+kernel `decide`s downstream run through. Monomials are `1`, `x`, `y`, `x^i`, `y^j`,
+`x^i*y^j` (with `x*y^j`, `x^i*y`, `x*y` for exponent `1`). Scoped like `⋆`. -/
+
+declare_syntax_cat bbPoly (behavior := both)
+
+/-- The constant monomial `1` (the point `(0, 0)`); other numerals are rejected. -/
+syntax num : bbPoly
+/-- The monomial `x` or `x^i` (the point `(i, 0)`). -/
+syntax &"x" ("^" num)? : bbPoly
+/-- The monomial `y` or `y^j` (the point `(0, j)`). -/
+syntax &"y" ("^" num)? : bbPoly
+/-- The monomial `x^i*y^j` (the point `(i, j)`), either exponent optional. -/
+syntax &"x" ("^" num)? "*" &"y" ("^" num)? : bbPoly
+/-- Polynomial sum, left-associative. -/
+syntax:65 bbPoly:65 " + " bbPoly:66 : bbPoly
+
+/-- `poly[x^3 + y + y^2]` is the indicator function
+`fun g => if g = (3, 0) ∨ g = (0, 1) ∨ g = (0, 2) then 1 else 0` of the monomials'
+exponent points, for use as a bivariate-bicycle polynomial `G → ZMod 2`. Scoped to
+`Quantum.Stabilizer.Homological.BB`. -/
+scoped syntax:max (name := polyLit) "poly[" bbPoly "]" : term
+
+/-- The exponent points `(a, b)` of a `bbPoly` sum, in the written order. -/
+partial def monomialsOf : TSyntax `bbPoly → MacroM (List (Nat × Nat))
+  | `(bbPoly| $p + $q) => do return (← monomialsOf p) ++ (← monomialsOf q)
+  | `(bbPoly| $n:num) =>
+    if n.getNat == 1 then return [(0, 0)]
+    else Macro.throwErrorAt n "expected the monomial 1"
+  | `(bbPoly| x) => return [(1, 0)]
+  | `(bbPoly| x ^ $a:num) => return [(a.getNat, 0)]
+  | `(bbPoly| y) => return [(0, 1)]
+  | `(bbPoly| y ^ $b:num) => return [(0, b.getNat)]
+  | `(bbPoly| x * y) => return [(1, 1)]
+  | `(bbPoly| x ^ $a:num * y) => return [(a.getNat, 1)]
+  | `(bbPoly| x * y ^ $b:num) => return [(1, b.getNat)]
+  | `(bbPoly| x ^ $a:num * y ^ $b:num) => return [(a.getNat, b.getNat)]
+  | stx => Macro.throwErrorAt stx "expected a monomial 1, x^i, y^j, or x^i*y^j"
+
+macro_rules
+  | `(poly[$p]) => do
+    let mons ← monomialsOf p
+    let g := mkIdent `g
+    let some (last, init) := mons.getLast?.map fun l => (l, mons.dropLast) | Macro.throwUnsupported
+    let mkEq : Nat × Nat → MacroM Term := fun (a, b) =>
+      `($g = ($(quote a), $(quote b)))
+    let mut disj : Term ← mkEq last
+    for m in init.reverse do
+      disj ← `($(← mkEq m) ∨ $disj)
+    `(fun $g => if $disj then 1 else 0)
+
+section PolyDelab
+
+open PrettyPrinter Delaborator SubExpr
+
+/-- A literal natural number: a raw literal or the `OfNat.ofNat` form numerals elaborate to. -/
+private def numeral? (e : Expr) : Option Nat :=
+  match e with
+  | .lit (.natVal k) => some k
+  | _ =>
+    if e.isAppOfArity ``OfNat.ofNat 3 then
+      match e.getArg! 1 with
+      | .lit (.natVal k) => some k
+      | _ => none
+    else none
+
+/-- The exponent point of the disjunct `g = (a, b)` with `g` the loose bound variable `0`
+and literal `a`, `b`. -/
+private def exponentPoint? (e : Expr) : Option (Nat × Nat) := do
+  guard (e.isAppOfArity ``Eq 3)
+  guard (e.getArg! 1 == .bvar 0)
+  let pt := e.getArg! 2
+  guard (pt.isAppOfArity ``Prod.mk 4)
+  let a ← numeral? (pt.getArg! 2)
+  let b ← numeral? (pt.getArg! 3)
+  return (a, b)
+
+/-- The exponent points of a right-nested `∨` chain of such disjuncts. -/
+private partial def exponentPoints? (e : Expr) : Option (List (Nat × Nat)) :=
+  if e.isAppOfArity ``Or 2 then do
+    let m ← exponentPoint? (e.getArg! 0)
+    let ms ← exponentPoints? (e.getArg! 1)
+    return m :: ms
+  else
+    (exponentPoint? e).map ([·])
+
+/-- The `bbPoly` monomial for an exponent point. -/
+private def monomialSyntax (m : Nat × Nat) : DelabM (TSyntax `bbPoly) := do
+  let lit (k : Nat) : TSyntax `num := Syntax.mkNumLit (toString k)
+  match m with
+  | (0, 0) => `(bbPoly| 1)
+  | (1, 0) => `(bbPoly| x)
+  | (a, 0) => `(bbPoly| x ^ $(lit a))
+  | (0, 1) => `(bbPoly| y)
+  | (0, b) => `(bbPoly| y ^ $(lit b))
+  | (1, 1) => `(bbPoly| x * y)
+  | (a, 1) => `(bbPoly| x ^ $(lit a) * y)
+  | (1, b) => `(bbPoly| x * y ^ $(lit b))
+  | (a, b) => `(bbPoly| x ^ $(lit a) * y ^ $(lit b))
+
+/-- Delaborate `fun g => if g = (a₁, b₁) ∨ … then 1 else 0` back to `poly[…]`. Fires only on
+a lambda of exactly that shape with literal exponents; every other lambda is left to the
+default printer. -/
+@[delab lam]
+def delabPolyLit : Delab :=
+  whenPPOption getPPNotation <| whenNotPPOption getPPExplicit do
+    let e ← getExpr
+    let .lam _ _ body _ := e | failure
+    unless body.isAppOfArity ``ite 5 do failure
+    unless numeral? (body.getArg! 3) == some 1 && numeral? (body.getArg! 4) == some 0 do
+      failure
+    let some mons := exponentPoints? (body.getArg! 1) | failure
+    let some first := mons.head? | failure
+    let mut p ← monomialSyntax first
+    for m in mons.tail do
+      p ← `(bbPoly| $p + $(← monomialSyntax m))
+    `(poly[$p])
+
+end PolyDelab
+
+end PolyNotation
+
 @[simp] lemma conv_apply (a b : G → ZMod 2) (g : G) :
-    conv a b g = ∑ h : G, a h * b (g - h) := rfl
+    (a ⋆ b) g = ∑ h : G, a h * b (g - h) := rfl
 
 /-- Convolution is commutative on an abelian group. -/
-lemma conv_comm (a b : G → ZMod 2) : conv a b = conv b a := by
+lemma conv_comm (a b : G → ZMod 2) : a ⋆ b = b ⋆ a := by
   funext g
   simp only [conv_apply]
   -- ∑_h a h * b (g - h) = ∑_h b h * a (g - h)
@@ -68,7 +213,7 @@ lemma conv_comm (a b : G → ZMod 2) : conv a b = conv b a := by
     rw [this, mul_comm]
 
 /-- Convolution is associative. -/
-lemma conv_assoc (a b c : G → ZMod 2) : conv (conv a b) c = conv a (conv b c) := by
+lemma conv_assoc (a b c : G → ZMod 2) : (a ⋆ b) ⋆ c = a ⋆ (b ⋆ c) := by
   funext g
   -- We'll show both sides equal `∑_h ∑_k, a h * b k * c (g - h - k)`.
   -- LHS = ∑_h (conv a b) h * c (g - h) = ∑_h (∑_k a k * b (h - k)) * c (g - h)
@@ -77,7 +222,7 @@ lemma conv_assoc (a b c : G → ZMod 2) : conv (conv a b) c = conv a (conv b c) 
   -- to align with RHS.  Cleanest: reindex jointly via the bijection
   -- (h, k) ↦ (h - k, k) on G × G.
   have lhs_expand :
-      conv (conv a b) c g = ∑ h : G, ∑ k : G, a h * b k * c (g - h - k) := by
+      ((a ⋆ b) ⋆ c) g = ∑ h : G, ∑ k : G, a h * b k * c (g - h - k) := by
     simp only [conv_apply, Finset.sum_mul]
     -- LHS now: ∑ h, ∑ k, (a k * b (h - k)) * c (g - h)
     -- Goal: ∑ h, ∑ k, a h * b k * c (g - h - k)
@@ -102,7 +247,7 @@ lemma conv_assoc (a b c : G → ZMod 2) : conv (conv a b) c = conv a (conv b c) 
         rw [h1]
     rw [Finset.sum_congr rfl (fun k _ => step k)]
   have rhs_expand :
-      conv a (conv b c) g = ∑ h : G, ∑ k : G, a h * b k * c (g - h - k) := by
+      (a ⋆ (b ⋆ c)) g = ∑ h : G, ∑ k : G, a h * b k * c (g - h - k) := by
     simp only [conv_apply, Finset.mul_sum]
     refine Finset.sum_congr rfl (fun h _ => ?_)
     refine Finset.sum_congr rfl (fun k _ => ?_)
@@ -113,25 +258,25 @@ lemma conv_assoc (a b c : G → ZMod 2) : conv (conv a b) c = conv a (conv b c) 
 
 /-- Convolution distributes over addition (left). -/
 lemma conv_add_left (a b c : G → ZMod 2) :
-    conv (a + b) c = conv a c + conv b c := by
+    (a + b) ⋆ c = a ⋆ c + b ⋆ c := by
   funext g
   simp only [conv_apply, Pi.add_apply, add_mul, Finset.sum_add_distrib]
 
 /-- Convolution distributes over addition (right). -/
 lemma conv_add_right (a b c : G → ZMod 2) :
-    conv a (b + c) = conv a b + conv a c := by
+    a ⋆ (b + c) = a ⋆ b + a ⋆ c := by
   funext g
   simp only [conv_apply, Pi.add_apply, mul_add, Finset.sum_add_distrib]
 
 /-- Convolution scales (left). -/
 lemma conv_smul_left (s : ZMod 2) (a b : G → ZMod 2) :
-    conv (s • a) b = s • conv a b := by
+    (s • a) ⋆ b = s • (a ⋆ b) := by
   funext g
   simp only [conv_apply, Pi.smul_apply, smul_eq_mul, Finset.mul_sum, mul_assoc]
 
 /-- Convolution scales (right). -/
 lemma conv_smul_right (s : ZMod 2) (a b : G → ZMod 2) :
-    conv a (s • b) = s • conv a b := by
+    a ⋆ (s • b) = s • (a ⋆ b) := by
   funext g
   simp only [conv_apply, Pi.smul_apply, smul_eq_mul, Finset.mul_sum]
   congr 1; funext h
@@ -140,14 +285,14 @@ lemma conv_smul_right (s : ZMod 2) (a b : G → ZMod 2) :
 /-- In char 2, for any commuting `a, b`, `conv a b + conv b a = 0`.
 By commutativity of `conv`, this is just `2 (conv a b) = 0`. -/
 lemma conv_add_swap_eq_zero (a b : G → ZMod 2) :
-    conv a b + conv b a = 0 := by
+    a ⋆ b + b ⋆ a = 0 := by
   rw [conv_comm a b]
   ext g
   simp [Pi.add_apply, CharTwo.add_self_eq_zero]
 
 /-- Convolving with a point mass on the left translates: `δ_a ⋆ b = b (· - a)`. -/
 lemma conv_single_left [DecidableEq G] (a : G) (b : G → ZMod 2) :
-    conv (Pi.single a 1) b = fun g => b (g - a) := by
+    Pi.single a 1 ⋆ b = fun g => b (g - a) := by
   funext g
   rw [conv_apply, Finset.sum_eq_single a]
   · simp
@@ -160,7 +305,7 @@ lemma conv_single_left [DecidableEq G] (a : G) (b : G → ZMod 2) :
 rewriting at an applied occurrence). -/
 @[simp] lemma conv_single_left_apply [DecidableEq G] (a : G) (b : G → ZMod 2)
     (g : G) :
-    conv (Pi.single a 1) b g = b (g - a) := by
+    (Pi.single a 1 ⋆ b) g = b (g - a) := by
   rw [conv_single_left]
 
 /-! ## Translation of chains -/
@@ -174,7 +319,7 @@ omit [Fintype G] in
 
 /-- Convolution commutes with translation of the right factor. -/
 lemma conv_translate (a v : G → ZMod 2) (c : G) :
-    conv a (translate c v) = translate c (conv a v) := by
+    a ⋆ translate c v = translate c (a ⋆ v) := by
   funext g
   simp only [conv_apply, translate_apply]
   refine Finset.sum_congr rfl fun h _ => ?_
@@ -206,11 +351,11 @@ def rightHalf (c : G × Fin 2 → ZMod 2) : G → ZMod 2 := fun g => c (g, 1)
 
 /-- Underlying function of `∂₂`. -/
 def bbBoundary2Fn (f : G → ZMod 2) : G × Fin 2 → ZMod 2 :=
-  fun ⟨h, j⟩ => if j = 0 then conv A f h else conv B f h
+  fun ⟨h, j⟩ => if j = 0 then (A ⋆ f) h else (B ⋆ f) h
 
 /-- Underlying function of `∂₁`. -/
 def bbBoundary1Fn (c : G × Fin 2 → ZMod 2) : G → ZMod 2 :=
-  fun g => conv B (leftHalf c) g + conv A (rightHalf c) g
+  fun g => (B ⋆ leftHalf c) g + (A ⋆ rightHalf c) g
 
 /-- `∂₂` as a `ZMod 2`-linear map. -/
 noncomputable def bbBoundary2 :
@@ -311,12 +456,12 @@ lemma bbBoundary2Fn_translate (c : G) (f : G → ZMod 2) :
   obtain ⟨h, j⟩ := p
   by_cases hj : j = 0
   · subst hj
-    change conv A (translate c f) h = bbBoundary2Fn A B f (h + c, 0)
+    change (A ⋆ translate c f) h = bbBoundary2Fn A B f (h + c, 0)
     rw [conv_translate]
     rfl
   · have hj1 : j = 1 := by omega
     subst hj1
-    change conv B (translate c f) h = bbBoundary2Fn A B f (h + c, 1)
+    change (B ⋆ translate c f) h = bbBoundary2Fn A B f (h + c, 1)
     rw [conv_translate]
     rfl
 
@@ -348,10 +493,10 @@ lemma bbBoundary_comp : (bbBoundary1 A B).comp (bbBoundary2 A B) = 0 := by
   change bbBoundary1Fn A B (bbBoundary2Fn A B f) g = 0
   unfold bbBoundary1Fn bbBoundary2Fn leftHalf rightHalf
   -- ∂₁(∂₂ f)(g) = conv B (h ↦ conv A f h) g + conv A (h ↦ conv B f h) g
-  have hL : (fun h => (if (0 : Fin 2) = 0 then conv A f h else conv B f h)) =
-      conv A f := by funext h; simp
-  have hR : (fun h => (if (1 : Fin 2) = 0 then conv A f h else conv B f h)) =
-      conv B f := by funext h; simp
+  have hL : (fun h => (if (0 : Fin 2) = 0 then (A ⋆ f) h else (B ⋆ f) h)) =
+      A ⋆ f := by funext h; simp
+  have hR : (fun h => (if (1 : Fin 2) = 0 then (A ⋆ f) h else (B ⋆ f) h)) =
+      B ⋆ f := by funext h; simp
   rw [hL, hR]
   -- Goal: conv B (conv A f) g + conv A (conv B f) g = 0
   -- Use conv_assoc (right-to-left) to fold: conv B (conv A f) = conv (conv B A) f
@@ -413,6 +558,43 @@ noncomputable def bbChainComplex (A B : G → ZMod 2) : HomologicalCode where
   numQubits := bbNumQubits G
   numQubits_eq := bbCard_C1
   edgeEquiv := bbEdgeEquiv
+
+/-! ## Round-trip tests
+
+`poly[…]` expands to exactly the indicator-function normal form, and `⋆` to `conv`. -/
+
+section RoundTrip
+
+example :
+    (poly[x^3 + y + y^2] : ZMod 12 × ZMod 6 → ZMod 2) =
+      fun g => if g = (3, 0) ∨ g = (0, 1) ∨ g = (0, 2) then 1 else 0 :=
+  rfl
+
+example :
+    (poly[y^3 + x + x^2] : ZMod 12 × ZMod 6 → ZMod 2) =
+      fun g => if g = (0, 3) ∨ g = (1, 0) ∨ g = (2, 0) then 1 else 0 :=
+  rfl
+
+example :
+    (poly[1 + x^2] : ZMod 12 × ZMod 6 → ZMod 2) =
+      fun g => if g = (0, 0) ∨ g = (2, 0) then 1 else 0 :=
+  rfl
+
+example : (poly[x^6] : ZMod 12 × ZMod 6 → ZMod 2) = fun g => if g = (6, 0) then 1 else 0 :=
+  rfl
+
+example :
+    (poly[x*y^2 + x^2*y + x*y] : ZMod 3 × ZMod 3 → ZMod 2) =
+      fun g => if g = (1, 2) ∨ g = (2, 1) ∨ g = (1, 1) then 1 else 0 :=
+  rfl
+
+example (a b : G → ZMod 2) : a ⋆ b = conv a b := rfl
+
+example (a b c : G → ZMod 2) : a ⋆ b ⋆ c = conv (conv a b) c := rfl
+
+example (a b : G → ZMod 2) (g : G) : (a ⋆ b) g = conv a b g := rfl
+
+end RoundTrip
 
 end BB
 end Homological

--- a/QEC/Stabilizer/Framework/Homological/BBConvRing.lean
+++ b/QEC/Stabilizer/Framework/Homological/BBConvRing.lean
@@ -55,7 +55,7 @@ variable [AddCommGroup G]
 /-- **Convolution is the group-algebra product.** Under `convEquiv` the
 multiplication of `𝔽₂[G]` is exactly the repo's `conv`. -/
 lemma convEquiv_mul (a b : AddMonoidAlgebra (ZMod 2) G) :
-    convEquiv (a * b) = conv (convEquiv a) (convEquiv b) := by
+    convEquiv (a * b) = convEquiv a ⋆ convEquiv b := by
   classical
   funext g
   rw [convEquiv_apply, conv_apply]
@@ -79,7 +79,7 @@ lemma convEquiv_mul (a b : AddMonoidAlgebra (ZMod 2) G) :
 `conv (x^s) v = translate (-s) v`.  (`x^s := convEquiv (single s 1)`, the
 indicator of `s`.) -/
 lemma conv_convEquiv_single (s : G) (v : G → ZMod 2) :
-    conv (convEquiv (AddMonoidAlgebra.single s 1)) v = translate (-s) v := by
+    convEquiv (AddMonoidAlgebra.single s 1) ⋆ v = translate (-s) v := by
   classical
   funext g
   rw [conv_apply, translate_apply, Finset.sum_eq_single s]
@@ -95,13 +95,13 @@ lemma conv_convEquiv_single (s : G) (v : G → ZMod 2) :
 through `convEquiv`, acts on `0`/`2`-chains as `v ↦ v + translate (-σ) v`
 — the repo's `v + σv` once `σ` has order 2. -/
 lemma conv_convEquiv_one_add_single (σ : G) (v : G → ZMod 2) :
-    conv (convEquiv (1 + AddMonoidAlgebra.single σ 1)) v
+    convEquiv (1 + AddMonoidAlgebra.single σ 1) ⋆ v
       = v + translate (-σ) v := by
   classical
   have h1 : convEquiv (1 + AddMonoidAlgebra.single σ (1 : ZMod 2))
       = convEquiv 1 + convEquiv (AddMonoidAlgebra.single σ 1) := map_add _ _ _
   rw [h1, conv_add_left]
-  have hone : conv (convEquiv (1 : AddMonoidAlgebra (ZMod 2) G)) v = v := by
+  have hone : convEquiv (1 : AddMonoidAlgebra (ZMod 2) G) ⋆ v = v := by
     funext g
     rw [conv_apply, Finset.sum_eq_single (0 : G)]
     · rw [convEquiv_apply, AddMonoidAlgebra.one_def, AddMonoidAlgebra.single_apply,

--- a/QEC/Stabilizer/Framework/Homological/BBDeficitWall.lean
+++ b/QEC/Stabilizer/Framework/Homological/BBDeficitWall.lean
@@ -57,7 +57,7 @@ variable {G : Type} [Fintype G] [AddCommGroup G]
 /-- The augmentation of a convolution is the product of augmentations:
 `∑ (a ⋆ b) = (∑ a) · (∑ b)`. -/
 lemma sum_conv (a b : G → ZMod 2) :
-    ∑ g : G, conv a b g = (∑ g : G, a g) * (∑ g : G, b g) := by
+    ∑ g : G, (a ⋆ b) g = (∑ g : G, a g) * (∑ g : G, b g) := by
   simp only [conv_apply]
   rw [Finset.sum_comm, Finset.sum_mul]
   refine Finset.sum_congr rfl fun h _ => ?_

--- a/QEC/Stabilizer/Framework/Homological/BBDoubling.lean
+++ b/QEC/Stabilizer/Framework/Homological/BBDoubling.lean
@@ -285,7 +285,7 @@ def deckPoly : G → ZMod 2 :=
 
 /-- Convolution with `deckPoly` is `1 + σ` on `G`-chains. -/
 lemma conv_deckPoly_eq (w : G → ZMod 2) :
-    conv D.deckPoly w = w + D.deckShift0 w := by
+    D.deckPoly ⋆ w = w + D.deckShift0 w := by
   funext g
   simp only [deckPoly, conv_add_left, Pi.add_apply,
     conv_single_left_apply, deckShift0_apply]
@@ -293,11 +293,11 @@ lemma conv_deckPoly_eq (w : G → ZMod 2) :
 
 /-- The Bezout homotopy 2-chain map `C v = P⋆v_L + Q⋆v_R`. -/
 def bezoutC (P Q : G → ZMod 2) (v : G × Fin 2 → ZMod 2) : G → ZMod 2 :=
-  conv P (leftHalf v) + conv Q (rightHalf v)
+  P ⋆ leftHalf v + Q ⋆ rightHalf v
 
 /-- The Bezout `∂₁`-correction `E h = (Q⋆h | P⋆h)`. -/
 def bezoutE (P Q : G → ZMod 2) (h : G → ZMod 2) : G × Fin 2 → ZMod 2 :=
-  fun q => if q.2 = 0 then conv Q h q.1 else conv P h q.1
+  fun q => if q.2 = 0 then (Q ⋆ h) q.1 else (P ⋆ h) q.1
 
 omit [DecidableEq G] in
 lemma bezoutC_zero (P Q : G → ZMod 2) : bezoutC P Q 0 = 0 := by
@@ -335,13 +335,13 @@ lemma bezoutE_add (P Q : G → ZMod 2) (a b : G → ZMod 2) :
 /-- Left-block computation for the Bezout homotopy:
 `(1+σ)v_L + Q⋆(∂₁v) = A⋆(C v)` at the left block. -/
 lemma bezout_blockL (P Q : G → ZMod 2)
-    (hPQ : conv P D.Ac + conv Q D.Bc = D.deckPoly)
+    (hPQ : P ⋆ D.Ac + Q ⋆ D.Bc = D.deckPoly)
     (wL wR : G → ZMod 2) :
     wL + D.deckShift0 wL
-        + conv Q (conv D.Bc wL + conv D.Ac wR)
-      = conv D.Ac (conv P wL + conv Q wR) := by
+        + Q ⋆ (D.Bc ⋆ wL + D.Ac ⋆ wR)
+      = D.Ac ⋆ (P ⋆ wL + Q ⋆ wR) := by
   have heps : wL + D.deckShift0 wL
-      = conv (conv P D.Ac) wL + conv (conv Q D.Bc) wL := by
+      = (P ⋆ D.Ac) ⋆ wL + (Q ⋆ D.Bc) ⋆ wL := by
     rw [← conv_add_left, hPQ, D.conv_deckPoly_eq]
   rw [conv_add_right, conv_add_right, heps,
     ← conv_assoc Q D.Bc wL,
@@ -350,18 +350,18 @@ lemma bezout_blockL (P Q : G → ZMod 2)
   funext g
   simp only [Pi.add_apply]
   linear_combination
-    (CharTwo.add_self_eq_zero (conv (conv Q D.Bc) wL g))
+    (CharTwo.add_self_eq_zero (((Q ⋆ D.Bc) ⋆ wL) g))
 
 /-- Right-block computation for the Bezout homotopy:
 `(1+σ)v_R + P⋆(∂₁v) = B⋆(C v)` at the right block. -/
 lemma bezout_blockR (P Q : G → ZMod 2)
-    (hPQ : conv P D.Ac + conv Q D.Bc = D.deckPoly)
+    (hPQ : P ⋆ D.Ac + Q ⋆ D.Bc = D.deckPoly)
     (wL wR : G → ZMod 2) :
     wR + D.deckShift0 wR
-        + conv P (conv D.Bc wL + conv D.Ac wR)
-      = conv D.Bc (conv P wL + conv Q wR) := by
+        + P ⋆ (D.Bc ⋆ wL + D.Ac ⋆ wR)
+      = D.Bc ⋆ (P ⋆ wL + Q ⋆ wR) := by
   have heps : wR + D.deckShift0 wR
-      = conv (conv P D.Ac) wR + conv (conv Q D.Bc) wR := by
+      = (P ⋆ D.Ac) ⋆ wR + (Q ⋆ D.Bc) ⋆ wR := by
     rw [← conv_add_left, hPQ, D.conv_deckPoly_eq]
   rw [conv_add_right, conv_add_right, heps,
     ← conv_assoc P D.Bc wL, conv_comm P D.Bc, conv_assoc D.Bc P wL,
@@ -370,17 +370,17 @@ lemma bezout_blockR (P Q : G → ZMod 2)
   funext g
   simp only [Pi.add_apply]
   linear_combination
-    (CharTwo.add_self_eq_zero (conv (conv P D.Ac) wR g))
+    (CharTwo.add_self_eq_zero (((P ⋆ D.Ac) ⋆ wR) g))
 
 /-- The full chain-level Bezout homotopy identity
 `(1 + σ) + E∘∂₁ = ∂₂∘C` on every 1-chain. -/
 lemma bezout_chain_identity (P Q : G → ZMod 2)
-    (hPQ : conv P D.Ac + conv Q D.Bc = D.deckPoly)
+    (hPQ : P ⋆ D.Ac + Q ⋆ D.Bc = D.deckPoly)
     (v : G × Fin 2 → ZMod 2) :
     v + D.deckShift1 v + bezoutE P Q (bbBoundary1Fn D.Ac D.Bc v)
       = bbBoundary2Fn D.Ac D.Bc (bezoutC P Q v) := by
   have hb1 : bbBoundary1Fn D.Ac D.Bc v
-      = conv D.Bc (leftHalf v) + conv D.Ac (rightHalf v) := rfl
+      = D.Bc ⋆ leftHalf v + D.Ac ⋆ rightHalf v := rfl
   funext q
   obtain ⟨g, j⟩ := q
   fin_cases j
@@ -401,7 +401,7 @@ lemma bezout_chain_identity (P Q : G → ZMod 2)
 `P⋆A + Q⋆B = 1 + x^{deckS}` certifies that the deck acts trivially on
 `H₁(cover)`.  By A12 such a witness exists iff `k(cover) = k(base)`. -/
 theorem deckTrivial_of_bezout (P Q : G → ZMod 2)
-    (hPQ : conv P D.Ac + conv Q D.Bc = D.deckPoly) :
+    (hPQ : P ⋆ D.Ac + Q ⋆ D.Bc = D.deckPoly) :
     D.DeckTrivialOnH1 :=
   D.deckTrivial_of_homotopy_certificate (bezoutC P Q) (bezoutE P Q)
     (bezoutC_zero P Q) (bezoutC_add P Q) (bezoutE_zero P Q)

--- a/QEC/Stabilizer/Framework/Homological/BBDuality.lean
+++ b/QEC/Stabilizer/Framework/Homological/BBDuality.lean
@@ -64,7 +64,7 @@ lemma reflect_eq_zero_iff (a : G → ZMod 2) : reflect a = 0 ↔ a = 0 := by
     simp
 
 lemma reflect_conv [Fintype G] (a b : G → ZMod 2) :
-    reflect (conv a b) = conv (reflect a) (reflect b) := by
+    reflect (a ⋆ b) = reflect a ⋆ reflect b := by
   funext g
   simp only [reflect_apply, conv_apply]
   rw [← Equiv.sum_comp (Equiv.neg G) (fun h => a h * b (-g - h))]
@@ -142,11 +142,11 @@ lemma bbBoundary2Fn_single (f : G) (h : G) (j : Fin 2) :
       = if j = 0 then A (h - f) else B (h - f) := by
   by_cases hj : j = 0
   · rw [if_pos hj]
-    change (if j = 0 then conv A (Pi.single f 1) h else conv B (Pi.single f 1) h)
+    change (if j = 0 then (A ⋆ Pi.single f 1) h else (B ⋆ Pi.single f 1) h)
       = A (h - f)
     rw [if_pos hj, conv_comm A, conv_single_left_apply]
   · rw [if_neg hj]
-    change (if j = 0 then conv A (Pi.single f 1) h else conv B (Pi.single f 1) h)
+    change (if j = 0 then (A ⋆ Pi.single f 1) h else (B ⋆ Pi.single f 1) h)
       = B (h - f)
     rw [if_neg hj, conv_comm B, conv_single_left_apply]
 
@@ -154,12 +154,12 @@ lemma bbBoundary2Fn_single (f : G) (h : G) (j : Fin 2) :
 `dualBoundary c = (reflect A) ⋆ c_L + (reflect B) ⋆ c_R`. -/
 theorem bb_dualBoundary_eq (c : G × Fin 2 → ZMod 2) :
     (bbChainComplex A B).dualBoundary c
-      = fun f => conv (reflect A) (leftHalf c) f
-          + conv (reflect B) (rightHalf c) f := by
+      = fun f => (reflect A ⋆ leftHalf c) f
+          + (reflect B ⋆ rightHalf c) f := by
   change (fun f : G =>
       ∑ p : G × Fin 2, c p * bbBoundary2Fn A B (Pi.single f 1) p) = _
   funext f
-  have hL : conv (reflect A) (leftHalf c) f
+  have hL : (reflect A ⋆ leftHalf c) f
       = ∑ h : G, c (h, 0) * A (h - f) := by
     rw [conv_apply,
       ← Equiv.sum_comp (Equiv.subLeft f)
@@ -168,7 +168,7 @@ theorem bb_dualBoundary_eq (c : G × Fin 2 → ZMod 2) :
     simp only [Equiv.subLeft_apply, reflect_apply, neg_sub, sub_sub_cancel]
     rw [mul_comm]
     rfl
-  have hR : conv (reflect B) (rightHalf c) f
+  have hR : (reflect B ⋆ rightHalf c) f
       = ∑ h : G, c (h, 1) * B (h - f) := by
     rw [conv_apply,
       ← Equiv.sum_comp (Equiv.subLeft f)
@@ -196,7 +196,7 @@ lemma bbBoundary1Fn_single_left (g v : G) :
     funext h
     rw [rightHalf, Pi.single_apply]
     simp [Prod.ext_iff]
-  have hzero : conv A (0 : G → ZMod 2) v = 0 := by
+  have hzero : (A ⋆ (0 : G → ZMod 2)) v = 0 := by
     simp [conv_apply]
   rw [bbBoundary1Fn, hLhalf, hRhalf, conv_comm B, conv_single_left_apply,
     hzero, add_zero]
@@ -215,7 +215,7 @@ lemma bbBoundary1Fn_single_right (g v : G) :
     by_cases hh : h = g
     · simp [hh]
     · simp [hh, Prod.ext_iff]
-  have hzero : conv B (0 : G → ZMod 2) v = 0 := by
+  have hzero : (B ⋆ (0 : G → ZMod 2)) v = 0 := by
     simp [conv_apply]
   rw [bbBoundary1Fn, hLhalf, hRhalf, conv_comm A, conv_single_left_apply,
     hzero, zero_add]
@@ -225,13 +225,13 @@ lemma bbBoundary1Fn_single_right (g v : G) :
 theorem bb_cutMap_eq (s : G → ZMod 2) :
     (bbChainComplex A B).cutMap s
       = fun p : G × Fin 2 =>
-          if p.2 = 0 then conv (reflect B) s p.1 else conv (reflect A) s p.1 := by
+          if p.2 = 0 then (reflect B ⋆ s) p.1 else (reflect A ⋆ s) p.1 := by
   change (fun e : G × Fin 2 =>
       ∑ v : G, s v * bbBoundary1Fn A B (Pi.single e 1) v) = _
   funext p
   obtain ⟨g, j⟩ := p
   have key : ∀ q : G → ZMod 2,
-      conv (reflect q) s g = ∑ v : G, s v * q (v - g) := by
+      (reflect q ⋆ s) g = ∑ v : G, s v * q (v - g) := by
     intro q
     rw [conv_apply,
       ← Equiv.sum_comp (Equiv.subLeft g) (fun h => reflect q h * s (g - h))]
@@ -241,14 +241,14 @@ theorem bb_cutMap_eq (s : G → ZMod 2) :
   by_cases hj : j = 0
   · subst hj
     change ∑ v : G, s v * bbBoundary1Fn A B (Pi.single ((g, 0) : G × Fin 2) 1) v
-      = conv (reflect B) s g
+      = (reflect B ⋆ s) g
     rw [key B]
     refine Finset.sum_congr rfl fun v _ => ?_
     rw [bbBoundary1Fn_single_left]
   · have hj1 : j = 1 := by omega
     subst hj1
     change ∑ v : G, s v * bbBoundary1Fn A B (Pi.single ((g, 1) : G × Fin 2) 1) v
-      = conv (reflect A) s g
+      = (reflect A ⋆ s) g
     rw [key A]
     refine Finset.sum_congr rfl fun v _ => ?_
     rw [bbBoundary1Fn_single_right]
@@ -275,7 +275,7 @@ theorem bbDualFn_bbBoundary2Fn (f2 : G → ZMod 2) :
   funext p
   obtain ⟨g, j⟩ := p
   have hconv : ∀ q : G → ZMod 2,
-      conv q f2 (-g) = conv (reflect q) (reflect f2) g := by
+      (q ⋆ f2) (-g) = (reflect q ⋆ reflect f2) g := by
     intro q
     have hq := congrFun (reflect_conv q f2) g
     rw [reflect_apply] at hq
@@ -283,16 +283,16 @@ theorem bbDualFn_bbBoundary2Fn (f2 : G → ZMod 2) :
   by_cases hj : j = 0
   · subst hj
     change bbBoundary2Fn A B f2 (blockSwapNeg (g, 0))
-      = conv (reflect B) (reflect f2) g
+      = (reflect B ⋆ reflect f2) g
     rw [blockSwapNeg_apply_zero]
-    change conv B f2 (-g) = conv (reflect B) (reflect f2) g
+    change (B ⋆ f2) (-g) = (reflect B ⋆ reflect f2) g
     exact hconv B
   · have hj1 : j = 1 := by omega
     subst hj1
     change bbBoundary2Fn A B f2 (blockSwapNeg (g, 1))
-      = conv (reflect A) (reflect f2) g
+      = (reflect A ⋆ reflect f2) g
     rw [blockSwapNeg_apply_one]
-    change conv A f2 (-g) = conv (reflect A) (reflect f2) g
+    change (A ⋆ f2) (-g) = (reflect A ⋆ reflect f2) g
     exact hconv A
 
 /-- Φ carries cycles to dual cycles (and conversely, by involutivity). -/

--- a/QEC/Stabilizer/Framework/Homological/BBSmallCycle.lean
+++ b/QEC/Stabilizer/Framework/Homological/BBSmallCycle.lean
@@ -93,7 +93,7 @@ lemma card_support_translate1 (c : G) (u : G × Fin 2 → ZMod 2) :
 
 /-- The augmentation is multiplicative on convolutions. -/
 lemma sum_conv (a b : G → ZMod 2) :
-    ∑ g : G, conv a b g = (∑ h : G, a h) * (∑ g : G, b g) := by
+    ∑ g : G, (a ⋆ b) g = (∑ h : G, a h) * (∑ g : G, b g) := by
   simp only [conv_apply]
   rw [Finset.sum_comm]
   rw [Finset.sum_mul]
@@ -206,7 +206,7 @@ lemma cycle_total_parity (u : G × Fin 2 → ZMod 2)
       = (∑ h : G, D.B h) * (∑ g : G, leftHalf u g)
         + (∑ h : G, D.A h) * (∑ g : G, rightHalf u g) := by
     rw [show (fun g => bbBoundary1Fn D.A D.B u g)
-        = fun g => conv D.B (leftHalf u) g + conv D.A (rightHalf u) g
+        = fun g => (D.B ⋆ leftHalf u) g + (D.A ⋆ rightHalf u) g
       from rfl]
     rw [Finset.sum_add_distrib, SmallCycle.sum_conv, SmallCycle.sum_conv]
   rw [hexp, D.epsA, D.epsB, one_mul, one_mul] at h0

--- a/QEC/Stabilizer/Framework/Homological/BBTransferH1.lean
+++ b/QEC/Stabilizer/Framework/Homological/BBTransferH1.lean
@@ -30,6 +30,8 @@ namespace Stabilizer
 namespace Homological
 namespace BB
 
+open scoped Homology
+
 -- Defeq checks through `coverComplex`/`baseComplex` projections unfold deep
 -- `Prod`/`ZMod` instance chains, exactly as in `BBCover.lean`.
 set_option maxRecDepth 4096
@@ -171,9 +173,9 @@ lemma epsH1_mk (v : D.coverComplex.cycles) :
 /-- **The deck-image rank floor `E ≥ k̃ − k`** (A13 rank corollary,
 inequality half): `dim H₁(cover) − dim H₁(base) ≤ dim (1+σ)·H₁(cover)`. -/
 theorem finrank_H1_sub_le_finrank_range_epsH1 :
-    Module.finrank (ZMod 2) D.coverComplex.H1
-      - Module.finrank (ZMod 2) D.baseComplex.H1
-      ≤ Module.finrank (ZMod 2) (LinearMap.range D.epsH1) :=
+    dim₂ D.coverComplex.H1
+      - dim₂ D.baseComplex.H1
+      ≤ dim₂ (LinearMap.range D.epsH1) :=
   BBBocksteinRank.finrank_sub_le_finrank_range_comp D.pushH1 D.pullH1
     D.ker_pushH1_eq_range_pullH1
 
@@ -193,22 +195,22 @@ def BocksteinVanishes : Prop :=
 `dim (1+σ)·H₁(cover) + k = k̃` exactly (no truncated subtraction) — in
 particular `k̃ ≥ k`. -/
 theorem finrank_range_epsH1_add_eq (h : D.BocksteinVanishes) :
-    Module.finrank (ZMod 2) (LinearMap.range D.epsH1)
-        + Module.finrank (ZMod 2) D.baseComplex.H1
-      = Module.finrank (ZMod 2) D.coverComplex.H1 := by
+    dim₂ (LinearMap.range D.epsH1)
+        + dim₂ D.baseComplex.H1
+      = dim₂ D.coverComplex.H1 := by
   have hid := BBBocksteinRank.finrank_range_comp_add_eq D.pushH1 D.pullH1
     D.ker_pushH1_eq_range_pullH1
   rw [inf_of_le_right h] at hid
-  change Module.finrank (ZMod 2) (LinearMap.range (D.pullH1 ∘ₗ D.pushH1))
+  change dim₂ (LinearMap.range (D.pullH1 ∘ₗ D.pushH1))
       + _ = _
   omega
 
 /-- **The rank corollary, equality form.** Under `BocksteinVanishes`, the
 deck-image floor is tight: `dim (1+σ)·H₁(cover) = k̃ − k`. -/
 theorem finrank_range_epsH1_eq (h : D.BocksteinVanishes) :
-    Module.finrank (ZMod 2) (LinearMap.range D.epsH1)
-      = Module.finrank (ZMod 2) D.coverComplex.H1
-        - Module.finrank (ZMod 2) D.baseComplex.H1 := by
+    dim₂ (LinearMap.range D.epsH1)
+      = dim₂ D.coverComplex.H1
+        - dim₂ D.baseComplex.H1 := by
   have h := D.finrank_range_epsH1_add_eq h
   omega
 
@@ -229,8 +231,8 @@ theorem epsH1_epsH1_apply (x : D.coverComplex.H1) :
 /-- Under `BocksteinVanishes`, `dim (ker ε_*) = k`: the complementary rank
 to `finrank_range_epsH1_eq`, via rank-nullity for `ε_*`. -/
 theorem finrank_ker_epsH1_eq (h : D.BocksteinVanishes) :
-    Module.finrank (ZMod 2) (LinearMap.ker D.epsH1)
-      = Module.finrank (ZMod 2) D.baseComplex.H1 := by
+    dim₂ (LinearMap.ker D.epsH1)
+      = dim₂ D.baseComplex.H1 := by
   have hrn := LinearMap.finrank_range_add_finrank_ker D.epsH1
   have hadd := D.finrank_range_epsH1_add_eq h
   omega

--- a/QEC/Stabilizer/Framework/Homological/Code.lean
+++ b/QEC/Stabilizer/Framework/Homological/Code.lean
@@ -23,7 +23,8 @@ The CSS construction itself is in `QEC/Stabilizer/Homological/CSS.lean`.
 
 /-- `dim₂ V` is `Module.finrank (ZMod 2) V`, the `𝔽₂`-dimension of a chain space, cycle
 space, or homology group (mathlib precedent: `local notation "dim" => Module.finrank ℝ`).
-`dim₂ V` elaborates to exactly `Module.finrank (ZMod 2) V`. Scoped: enable with
+`dim₂ V` elaborates to exactly `Module.finrank (ZMod 2) V`, and the unexpander the
+`notation` command generates prints it back while the scope is open. Scoped: enable with
 `open scoped Homology`. -/
 scoped[Homology] notation "dim₂" => Module.finrank (ZMod 2)
 
@@ -34,11 +35,20 @@ namespace Homological
 open scoped BigOperators
 open scoped Homology
 
-/-- Display `Module.finrank (ZMod 2) V` as `dim₂ V`. -/
-@[app_unexpander Module.finrank]
-def unexpandDim₂ : Lean.PrettyPrinter.Unexpander
-  | `($_ (ZMod 2) $V) => `(dim₂ $V)
-  | _ => throw ()
+open Lean Elab Command in
+/-- Display test: elaborate `stx` and check that its pretty-printed text is `expected`
+(`exact := false`: contains `expected`). Run through `run_cmd` so no `#`-command is needed. -/
+private def checkDisplay (stx : Syntax) (expected : String) (exact : Bool := true) :
+    CommandElabM Unit :=
+  liftTermElabM do
+    let e ← Term.elabTerm stx none
+    Term.synthesizeSyntheticMVarsNoPostponing
+    let s := toString (← Meta.ppExpr (← instantiateMVars e))
+    unless (if exact then s == expected else (s.splitOn expected).length > 1) do
+      throwError "display test failed:{indentD s}\nexpected{indentD expected}"
+
+run_cmd do
+  checkDisplay (← `(Module.finrank (ZMod 2) (Fin 3 → ZMod 2))) "dim₂ (Fin 3 → ZMod 2)"
 
 /-- A length-3 chain complex over `ZMod 2` with finite, decidable cells.
 

--- a/QEC/Stabilizer/Framework/Homological/Code.lean
+++ b/QEC/Stabilizer/Framework/Homological/Code.lean
@@ -21,11 +21,24 @@ This file sets up the abstract structure and the homology API:
 The CSS construction itself is in `QEC/Stabilizer/Homological/CSS.lean`.
 -/
 
+/-- `dim₂ V` is `Module.finrank (ZMod 2) V`, the `𝔽₂`-dimension of a chain space, cycle
+space, or homology group (mathlib precedent: `local notation "dim" => Module.finrank ℝ`).
+`dim₂ V` elaborates to exactly `Module.finrank (ZMod 2) V`. Scoped: enable with
+`open scoped Homology`. -/
+scoped[Homology] notation "dim₂" => Module.finrank (ZMod 2)
+
 namespace Quantum
 namespace Stabilizer
 namespace Homological
 
 open scoped BigOperators
+open scoped Homology
+
+/-- Display `Module.finrank (ZMod 2) V` as `dim₂ V`. -/
+@[app_unexpander Module.finrank]
+def unexpandDim₂ : Lean.PrettyPrinter.Unexpander
+  | `($_ (ZMod 2) $V) => `(dim₂ $V)
+  | _ => throw ()
 
 /-- A length-3 chain complex over `ZMod 2` with finite, decidable cells.
 
@@ -115,32 +128,32 @@ abbrev H1 : Type :=
 
 /-- The `C₀` chain space has `Fintype.card C₀` dimensions. -/
 theorem finrank_C0 :
-    Module.finrank (ZMod 2) (X.C0 → ZMod 2) = Fintype.card X.C0 :=
+    dim₂ (X.C0 → ZMod 2) = Fintype.card X.C0 :=
   Module.finrank_fintype_fun_eq_card (R := ZMod 2) (η := X.C0)
 
 /-- The `C₁` chain space has `Fintype.card C₁` dimensions. -/
 theorem finrank_C1 :
-    Module.finrank (ZMod 2) (X.C1 → ZMod 2) = Fintype.card X.C1 :=
+    dim₂ (X.C1 → ZMod 2) = Fintype.card X.C1 :=
   Module.finrank_fintype_fun_eq_card (R := ZMod 2) (η := X.C1)
 
 /-- The `C₂` chain space has `Fintype.card C₂` dimensions. -/
 theorem finrank_C2 :
-    Module.finrank (ZMod 2) (X.C2 → ZMod 2) = Fintype.card X.C2 :=
+    dim₂ (X.C2 → ZMod 2) = Fintype.card X.C2 :=
   Module.finrank_fintype_fun_eq_card (R := ZMod 2) (η := X.C2)
 
 /-- Rank-nullity for `∂₁`: `dim C₁ = dim Z₁ + rank ∂₁`. -/
 theorem rank_nullity_boundary1 :
-    Module.finrank (ZMod 2) (X.C1 → ZMod 2) =
-      Module.finrank (ZMod 2) X.cycles +
-        Module.finrank (ZMod 2) (LinearMap.range X.boundary1) := by
+    dim₂ (X.C1 → ZMod 2) =
+      dim₂ X.cycles +
+        dim₂ (LinearMap.range X.boundary1) := by
   simpa [cycles, add_comm] using
     (LinearMap.finrank_range_add_finrank_ker X.boundary1).symm
 
 /-- Rank-nullity for `∂₂`: `dim C₂ = dim (ker ∂₂) + dim B₁`. -/
 theorem rank_nullity_boundary2 :
-    Module.finrank (ZMod 2) (X.C2 → ZMod 2) =
-      Module.finrank (ZMod 2) (LinearMap.ker X.boundary2) +
-        Module.finrank (ZMod 2) X.boundaries := by
+    dim₂ (X.C2 → ZMod 2) =
+      dim₂ (LinearMap.ker X.boundary2) +
+        dim₂ X.boundaries := by
   simpa [boundaries, add_comm] using
     (LinearMap.finrank_range_add_finrank_ker X.boundary2).symm
 
@@ -150,21 +163,21 @@ theorem finrank_H1_eq_cycles_sub_boundaries :
       (Submodule.Quotient.addCommGroup
         (X.boundarySubmoduleInCycles)).toAddCommMonoid
       (Submodule.Quotient.module X.boundarySubmoduleInCycles) =
-      Module.finrank (ZMod 2) X.cycles -
-        Module.finrank (ZMod 2) X.boundaries := by
+      dim₂ X.cycles -
+        dim₂ X.boundaries := by
   have hquot :
       @Module.finrank (ZMod 2) X.H1 _
           (Submodule.Quotient.addCommGroup
             X.boundarySubmoduleInCycles).toAddCommMonoid
           (Submodule.Quotient.module X.boundarySubmoduleInCycles) +
-          Module.finrank (ZMod 2) X.boundarySubmoduleInCycles =
-        Module.finrank (ZMod 2) X.cycles := by
+          dim₂ X.boundarySubmoduleInCycles =
+        dim₂ X.cycles := by
     simpa [H1, boundarySubmoduleInCycles] using
       (Submodule.finrank_quotient_add_finrank (R := ZMod 2)
         X.boundarySubmoduleInCycles)
   have hcomap :
-      Module.finrank (ZMod 2) X.boundarySubmoduleInCycles =
-        Module.finrank (ZMod 2) X.boundaries := by
+      dim₂ X.boundarySubmoduleInCycles =
+        dim₂ X.boundaries := by
     simpa [boundarySubmoduleInCycles] using
       (Submodule.comapSubtypeEquivOfLe X.boundaries_le_cycles).finrank_eq
   rw [hcomap] at hquot

--- a/QEC/Stabilizer/Framework/Homological/Covering.lean
+++ b/QEC/Stabilizer/Framework/Homological/Covering.lean
@@ -103,10 +103,10 @@ variable (π : G →+ H)
 /-- Pushforward intertwines convolution: `π_* (a ⋆ b) = (π_* a) ⋆ (π_* b)`.
 No injectivity or surjectivity of `π` is needed. -/
 lemma fiberSum_conv (a b : G → ZMod 2) :
-    fiberSumFn ⇑π (conv a b) = conv (fiberSumFn ⇑π a) (fiberSumFn ⇑π b) := by
+    fiberSumFn ⇑π (a ⋆ b) = fiberSumFn ⇑π a ⋆ fiberSumFn ⇑π b := by
   funext j
   -- Both sides equal `∑ h, a h * (π_* b) (j - π h)`.
-  have lhs_eq : fiberSumFn ⇑π (conv a b) j
+  have lhs_eq : fiberSumFn ⇑π (a ⋆ b) j
       = ∑ h : G, a h * fiberSumFn ⇑π b (j - π h) := by
     have key : ∀ h : G,
         (∑ g : G, if π g = j then a h * b (g - h) else 0)
@@ -122,7 +122,7 @@ lemma fiberSum_conv (a b : G → ZMod 2) :
       by_cases hm : π m = j - π h
       · rw [if_pos (hcond.mpr hm), if_pos hm]
       · rw [if_neg (fun hc => hm (hcond.mp hc)), if_neg hm, mul_zero]
-    calc fiberSumFn ⇑π (conv a b) j
+    calc fiberSumFn ⇑π (a ⋆ b) j
         = ∑ g : G, if π g = j then (∑ h : G, a h * b (g - h)) else 0 := rfl
       _ = ∑ g : G, ∑ h : G, (if π g = j then a h * b (g - h) else 0) := by
           refine Finset.sum_congr rfl fun g _ => ?_
@@ -131,7 +131,7 @@ lemma fiberSum_conv (a b : G → ZMod 2) :
           Finset.sum_comm
       _ = ∑ h : G, a h * fiberSumFn ⇑π b (j - π h) :=
           Finset.sum_congr rfl fun h _ => key h
-  have rhs_eq : conv (fiberSumFn ⇑π a) (fiberSumFn ⇑π b) j
+  have rhs_eq : (fiberSumFn ⇑π a ⋆ fiberSumFn ⇑π b) j
       = ∑ h : G, a h * fiberSumFn ⇑π b (j - π h) := by
     rw [conv_apply]
     have expand : ∀ k : H, fiberSumFn ⇑π a k * fiberSumFn ⇑π b (j - k)
@@ -150,7 +150,7 @@ lemma fiberSum_conv (a b : G → ZMod 2) :
 `a ⋆ (u ∘ π) = ((π_* a) ⋆ u) ∘ π`.  No injectivity hypothesis is needed —
 the fiber regrouping works unconditionally. -/
 lemma conv_pullback (a : G → ZMod 2) (u : H → ZMod 2) :
-    conv a (u ∘ ⇑π) = (conv (fiberSumFn ⇑π a) u) ∘ ⇑π := by
+    a ⋆ (u ∘ ⇑π) = (fiberSumFn ⇑π a ⋆ u) ∘ ⇑π := by
   funext g
   simp only [Function.comp_apply, conv_apply]
   have lhs_eq : ∀ h : G, a h * u (π (g - h)) = a h * u (π g - π h) := by
@@ -510,7 +510,7 @@ lemma fiberSum_bbBoundary1Fn
     fiberSumFn ⇑π (bbBoundary1Fn Ac Bc c)
       = bbBoundary1Fn Ab Bb (fiberSumFn (Prod.map ⇑π id) c) := by
   have hsum : bbBoundary1Fn Ac Bc c
-      = conv Bc (leftHalf c) + conv Ac (rightHalf c) := rfl
+      = Bc ⋆ leftHalf c + Ac ⋆ rightHalf c := rfl
   rw [hsum, fiberSumFn_add, fiberSum_conv π Bc (leftHalf c),
     fiberSum_conv π Ac (rightHalf c), hA, hB]
   funext j
@@ -529,7 +529,7 @@ lemma fiberSum_bbBoundary2Fn
   by_cases hb : b = 0
   · subst hb
     have hslice : (fun h => bbBoundary2Fn Ac Bc f2 (h, (0 : Fin 2)))
-        = conv Ac f2 := by
+        = Ac ⋆ f2 := by
       funext h
       simp [bbBoundary2Fn]
     rw [hslice, fiberSum_conv π Ac f2, hA]
@@ -537,7 +537,7 @@ lemma fiberSum_bbBoundary2Fn
   · have hb1 : b = 1 := by omega
     subst hb1
     have hslice : (fun h => bbBoundary2Fn Ac Bc f2 (h, (1 : Fin 2)))
-        = conv Bc f2 := by
+        = Bc ⋆ f2 := by
       funext h
       simp [bbBoundary2Fn]
     rw [hslice, fiberSum_conv π Bc f2, hB]
@@ -549,9 +549,9 @@ lemma pullback_bbBoundary1Fn
     (u : H × Fin 2 → ZMod 2) :
     bbBoundary1Fn Ac Bc (u ∘ Prod.map ⇑π id)
       = (bbBoundary1Fn Ab Bb u) ∘ ⇑π := by
-  have hL : conv Bc ((leftHalf u) ∘ ⇑π) = (conv Bb (leftHalf u)) ∘ ⇑π := by
+  have hL : Bc ⋆ ((leftHalf u) ∘ ⇑π) = (Bb ⋆ leftHalf u) ∘ ⇑π := by
     rw [conv_pullback π Bc (leftHalf u), hB]
-  have hR : conv Ac ((rightHalf u) ∘ ⇑π) = (conv Ab (rightHalf u)) ∘ ⇑π := by
+  have hR : Ac ⋆ ((rightHalf u) ∘ ⇑π) = (Ab ⋆ rightHalf u) ∘ ⇑π := by
     rw [conv_pullback π Ac (rightHalf u), hA]
   funext g
   rw [bbBoundary1Fn, leftHalf_pullback_prodMap, rightHalf_pullback_prodMap,
@@ -564,17 +564,17 @@ lemma pullback_bbBoundary2Fn
     (f2 : H → ZMod 2) :
     bbBoundary2Fn Ac Bc (f2 ∘ ⇑π)
       = (bbBoundary2Fn Ab Bb f2) ∘ Prod.map ⇑π id := by
-  have hA' : conv Ac (f2 ∘ ⇑π) = (conv Ab f2) ∘ ⇑π := by
+  have hA' : Ac ⋆ (f2 ∘ ⇑π) = (Ab ⋆ f2) ∘ ⇑π := by
     rw [conv_pullback π Ac f2, hA]
-  have hB' : conv Bc (f2 ∘ ⇑π) = (conv Bb f2) ∘ ⇑π := by
+  have hB' : Bc ⋆ (f2 ∘ ⇑π) = (Bb ⋆ f2) ∘ ⇑π := by
     rw [conv_pullback π Bc f2, hB]
   funext p
   obtain ⟨g, b⟩ := p
   fin_cases b
-  · change conv Ac (f2 ∘ ⇑π) g = bbBoundary2Fn Ab Bb f2 (π g, 0)
+  · change (Ac ⋆ (f2 ∘ ⇑π)) g = bbBoundary2Fn Ab Bb f2 (π g, 0)
     rw [hA']
     rfl
-  · change conv Bc (f2 ∘ ⇑π) g = bbBoundary2Fn Ab Bb f2 (π g, 1)
+  · change (Bc ⋆ (f2 ∘ ⇑π)) g = bbBoundary2Fn Ab Bb f2 (π g, 1)
     rw [hB']
     rfl
 

--- a/QEC/Stabilizer/Framework/Symplectic/CentralizerStructure.lean
+++ b/QEC/Stabilizer/Framework/Symplectic/CentralizerStructure.lean
@@ -208,14 +208,14 @@ only the weaker subgroup `GeneratorsIndependent`. For a concrete code it is `nat
 theorem operators_eq_stab_of_commutes_both_logicals (C : StabilizerCode n 1)
     (hindep : rowsLinearIndependent C.generatorsList)
     (g : NQubitPauliGroupElement n) (hg : g ∈ centralizer C.toStabilizerGroup)
-    (hX : g * (C.logicalOps 0).xOp = (C.logicalOps 0).xOp * g)
-    (hZ : g * (C.logicalOps 0).zOp = (C.logicalOps 0).zOp * g) :
+    (hX : g * C.logicalX 0 = C.logicalX 0 * g)
+    (hZ : g * C.logicalZ 0 = C.logicalZ 0 * g) :
     ∃ s ∈ C.toStabilizerGroup.toSubgroup, s.operators = g.operators := by
   classical
   apply exists_mem_closure_of_symp_in_span C.generatorsList g.operators
   have hn1 : 1 ≤ n := C.hk
-  set xv := toSymplectic (C.logicalOps 0).xOp.operators with hxv
-  set zv := toSymplectic (C.logicalOps 0).zOp.operators with hzv
+  set xv := toSymplectic (C.logicalX 0).operators with hxv
+  set zv := toSymplectic (C.logicalZ 0).operators with hzv
   set U : Submodule (ZMod 2) (Fin (n + n) → ZMod 2) := Submodule.span (ZMod 2) {xv, zv} with hU
   -- Pairing values of the symplectic form on the logicals.
   have hXZ : sympBilinForm n xv zv = 1 := by

--- a/QECWidgets/Demo.lean
+++ b/QECWidgets/Demo.lean
@@ -25,6 +25,7 @@ on the command. The `example`s at the bottom show the in-proof panels.
 namespace QECWidgets.Demo
 
 open Quantum Quantum.StabilizerGroup ProofWidgets
+open scoped Pauli
 
 /-! ## Single terms: generators and logicals of the Steane code -/
 
@@ -42,9 +43,9 @@ open Quantum Quantum.StabilizerGroup ProofWidgets
 
 #pauli_strip (Steane7.X1 * Steane7.Z1)
 
-#pauli_strip (⟨3,
-    (((NQubitPauliOperator.identity 7).set 0 PauliOperator.X).set 2 PauliOperator.X).set 3
-      PauliOperator.X |>.set 6 PauliOperator.X⟩ : NQubitPauliGroupElement 7)
+-- An inline literal with phase −i, written with the scoped `σ[…]` construction
+-- notation (`open scoped Pauli`): `-iσ[…]` is `phasePower = 3`.
+#pauli_strip (-iσ[XIXXIIX])
 
 /-! ## Propositions: commutation views -/
 


### PR DESCRIPTION
Second notation pass, extending PR #75 (`claude/qeclean-notation-pass-5ccdca`). **Stacks on #75**: this branch is based on it, so merge #75 first (or merge this one, which contains it).

Same ground rules as the first pass: every notation is scoped, has a delaborator/unexpander, and anything on a kernel-facing path is a pure macro onto the pre-existing normal form (no helper function on the elaboration path). Round-trip tests are plain `example … := rfl`. No renames, deletions, `sorry`, `native_decide`, or `set_option linter.* false`; no proof was changed anywhere — wherever a converted statement would have required a proof change the site was left in its original form (listed below). One commit per workstream.

## 1. Parametric Pauli literals — `σ[n | i ↦ Z, j ↦ Z]` (`fe4c852`)

`QEC/Stabilizer/Foundations/PauliGroup/Notation.lean`: symbolic form of the `σ[…]` / `iσ[…]` / `-σ[…]` / `-iσ[…]` / `P[…]` literals with the same leading tokens, `n` and the indices arbitrary terms, letters `X`/`Y`/`Z`, `.set`s applied in the written order. Expands to exactly `⟨phase, ((identity n).set i op).set j op …⟩`, so the ~97 downstream `simp [NQubitPauliOperator.set, NQubitPauliOperator.identity]` sites are untouched. The delaborators now print any X/Y/Z `.set` chain over an `identity n` that is not literal-shaped (symbolic `n`/indices, or an out-of-range literal index) in this form; an explicit `I` or a chain not rooted at `identity` stays raw. 8 new round-trip `rfl` tests.

Sites: `Toric/CodeN.lean` (`vertexStab`, `faceStab`, and the `op1`…`op4` restatements in the two typing proofs — `op0` stays `identity`), `Repetition/N.lean` (`ZPair`), `Iceberg/N.lean` (`logicalX`, `logicalZ`). Docs: notation header, `_TEMPLATE.lean` §1 parametric variant, CLAUDE.md σ bullet.

## 2. BB polynomials and convolution — `poly[x^3 + y + y^2]`, `a ⋆ b` (`18f54aa`)

`Framework/Homological/BBChainComplex.lean`, scoped to `Quantum.Stabilizer.Homological.BB` (so active in every BB file without an `open`):
- `scoped infixl:70 " ⋆ " => conv` (auto unexpander). Checked mathlib: the other `⋆` notations (`Convolution`, `Stream'.apply` is `⊛`, `StrongDual` is `local`) do not clash.
- `poly[…]`: a small `bbPoly` syntax category (`1`, `x`, `y`, `x^i`, `y^j`, `x^i*y^j`, `+`; `&"x"`/`&"y"` non-reserved so `x`/`y` stay ordinary identifiers) expanding to exactly `fun g => if g = (a₁, b₁) ∨ … then 1 else 0`, plus a `@[delab lam]` that prints that shape back. 8 round-trip tests.

Sites: the 7 polynomial definitions of `Gross/Defs.lean` (`grossA`, `grossB`, `baseA`, `baseB`, `onePlusX2`, `bSquaredPoly`, `onePlusX6`); 484 applied `conv` sites in 17 files converted textually (112 over-applied `(a ⋆ b) g`, 310 bare `a ⋆ b`, 62 parenthesised; bare `conv` kept in `simp`/`rw`/`unfold` lists and prose). `Gross/StabilizerCodeData.lean` is generated and untouched — **follow-up for qec-lab's generator**: a `((3 : ZMod 12), (0 : ZMod 6))` group-element shorthand there needs a generator change.

## 3. Symplectic inner product — `⟪p, q⟫ₛ`, `symplecticInner`, `symp` (`6826892`)

`Foundations/BinarySymplectic/SymplecticInner.lean`, scope `Quantum.NQubitPauliGroupElement` (active under `open NQubitPauliGroupElement`, which every user file already has):
- `⟪p, q⟫ₛ` is a **macro onto the pre-existing** `NQubitPauliOperator.symplecticInner p.operators q.operators`, with an `app_delab` printing that form back. Choosing the pre-existing form as the expansion (rather than the new def) is what let every site convert without touching a proof — `commutes_iff_symplectic_inner_zero`, `unfold NQubitPauliOperator.symplecticInner`, etc. apply verbatim.
- `protected def NQubitPauliGroupElement.symplecticInner p q` and `def symp g` are the plain definitions (dot notation, `symp '' S`), each with a `@[simp]` `rfl` bridge (`symplecticInner_def`, `symp_def`). `protected` keeps a bare `symplecticInner` meaning the operator-level one in the files that open both namespaces (`SymplecticOrthogonal.lean:46` unfolds it bare).

Sites: 31 statement sites of the `⟪·, ·⟫ₛ` shape (2 in `SymplecticInner.lean`, 29 in `Concatenation/Correspondence.lean`); `toSymplectic_mem_span_of_mem_closure` now reads `span (ZMod 2) (symp '' S)`. Left alone: the `symplecticInner op g.operators` sites (first argument is an operator) and the 74 `toSymplectic g.operators` composites — converting those to `symp g` changes the elaborated term and their proofs `simp only [toSymplectic, …]`.

## 4. Gate conjugation — `Coe`, `U ⊳ M`, `ᴴ`, `⊗ᵍ` (`549b23d`)

`Foundations/Gates.lean`: `instance : Coe (QuantumGate α) (Matrix α α ℂ) := ⟨Subtype.val⟩` and `scoped notation:70 U " ⊳ " M => conjBy U M` (scope `Quantum`, auto unexpander). `GateConjugation.lean`: the 9 `U P U†` lemmas restated as `U ⊳ P = Q`; the 8 `U† P U` lemmas with `Matrix.conjTranspose` (`U.valᴴ * P * U.val`). `Tensor.lean`: `X ⊗ᵍ X ⊗ᵍ X`, `1 ⊗ᵍ X ⊗ᵍ 1`, … (12 sites).

Left in the expanded form (their unchanged proofs need it): `inv_S_conj_X` (`TransversalConjugation.lean:205` uses it inside `simp [hX, inv_S_conj_X]`, which cannot rewrite with a `conjBy` LHS) and `inv_S_conj_Y` (`rw [inv_S_val]`). The adjoint lemmas use `U.valᴴ * P * U.val` rather than the coercion `Uᴴ * P * ↑U` because `binop%` does not insert the gate→matrix coercion on a bare trailing operand (`HMul (Matrix …) OneQubitGate ?` fails); `(H : Matrix _ _ ℂ)` works but is no shorter than `.val`.

## 5. Homology vocabulary — `dim₂`, positional `L`, `Z₁`/`B₁`/`H₁`, `Z¹`/`B¹` (`36a7fd1`)

- `scoped[Homology] notation "dim₂" => Module.finrank (ZMod 2)` in `Framework/Homological/Code.lean` (shared scope; toric `H1Dimension.lean` gains an import of `Code.lean`) with an unexpander; 123 sites converted in 9 files. The 6 `@Module.finrank (ZMod 2) _ _ inst inst` explicit-instance sites keep the long form (a notation cannot take `@`).
- `toricCycles (L := L)` & co. → positional `toricCycles L` (101 sites; `L` is explicit in all five).
- `scoped[ToricChain]` `Z₁`/`B₁`/`H₁` for `toricCycles`/`toricBoundaries`/`toricH1` (`Toric/Homology.lean`), `Z¹`/`B¹` for `toricDualCycles`/`toricDualBoundaries` (`LogicalCorrespondenceZ.lean`); 89 sites in the `Lattice`-namespace toric files. The `ToricCodeN` alias sites (`DistanceX/Z`, `CodeN`, `StabilizerCode`) stay positional since there `toricCycles` resolves to the `abbrev` alias, a different constant. `scoped[RotatedSurfaceChain]` `Z₁`/`B₁`/`H₁` for `rscCycles`/`rscBoundaries`/`rscH1` (12 sites). Grepped first: the tokens `Z₁ B₁ H₁ Z¹ B¹ dim₂` occur only in prose (77 docstring/comment hits, 0 in code).

## 6. Logical operators — `C.logicalX ℓ` / `C.logicalZ ℓ` (`3f08d89`)

`app_delab`s on `LogicalQubitOps.xOp`/`.zOp` in `Core/Stabilizer/StabilizerCode.lean` print `(C.logicalOps ℓ).xOp` as `C.logicalX ℓ` whenever the argument is a `StabilizerCode.logicalOps` application. 92 applied sites with a `StabilizerCode` receiver (`C`, `Cin`, `Cout`, `D.Cin`, `D.Cout`) converted in `Concatenation/{Constructor,Promotion,Independence,Correspondence}.lean` and `Symplectic/CentralizerStructure.lean` — definitionally equal, every proof unchanged. Left alone: the `logicalOps` field references inside the `StabilizerCode` structure and the private `toric_logicalOps` sites (not a `StabilizerCode`). `logicalX`/`logicalZ` stay `def`s (not made reducible).

## Verification

Seven checks on the final tree (`LEAN_NUM_THREADS=3`, BB safe-floor leaves built sequentially first):
`lake build` ✔ · `lake build QECLight` ✔ · `lake build QECBlueprint` ✔ · `lake build QECWidgets` ✔ · `lake env lean Playground.lean` ✔ · `lake env lean scripts/AxiomCheck.lean` ✔ (only `[propext, Classical.choice, Quot.sound]`) · `bash scripts/check-umbrellas.sh` ✔.

Per-file warning sets (file × warning text) of every converted file compared against a pre-change baseline build log: unchanged.


## Review fixes (commit 8b5dd8e)

A review of this PR (live-tested on its build) found that four printers were unfaithful and that some of the new API was dead or fought the simp set. The follow-up commit resolves every finding:

- **σ/P literals** — the letters printer fires only on the literal normal form (strictly increasing literal indices, no explicit `I`); everything else that re-parses prints in the symbolic form. `P[3 | 1 ↦ Z, 0 ↦ Z]` no longer displays as `P[ZZI]` (a different term), and a chain that sets `I` is left to the default printer as documented. Both delaborators are `scoped` with the notation.
- **`⟪p, q⟫ₛ`** — delaborator `scoped`; the unused group-level `symplecticInner` def and `symp` (and their `@[simp]` bridges) are gone; `toSymplectic_mem_span_of_mem_closure` is back in the lambda form its callers use.
- **`poly[…]`** — the lambda delaborator is `scoped`, checks the type `ZMod ℓ × ZMod m → ZMod 2` and rejects `Classical` decidability instances (an `ℕ × ℕ` indicator no longer prints as `poly[…]`); the `bbPoly` productions are `scoped`; repeated monomials are rejected; the docstring explains that `+` is a union of distinct exponent points, so a literal like `poly[1 + x^6]` means `1 + x⁶` over `ZMod 12 × ZMod 6` but the constant `1` over `ZMod 6 × ZMod 6`. `Witness.lean`'s `zStar` uses the literal too.
- **`logicalX`/`logicalZ`** — the display-rewriting delaborators are removed (a goal showing `C.logicalX ℓ` could not be unfolded or rewritten); both are reducible `abbrev`s now, so `simp` sees through either spelling.
- **Gates** — the unused `Coe (QuantumGate α) (Matrix α α ℂ)` instance is removed (core's subtype coercion and mathlib's `coeMatrix` already apply); `GateConjugation.lean` is back to matrix-product statements because `conjBy_def` is a `simp` lemma, which made the `⊳`-headed forms unable to rewrite simp-normal goals. The `U ⊳ M` notation itself stays.
- **Homology** — the hand-written `dim₂` unexpander was dead (its `(ZMod 2)` pattern never matches a delaborated argument; the `notation`-generated scoped unexpander does the work) and is removed; redundant `open scoped` re-opens dropped; the remaining explicit-`L` `(L := L)` sites in `Toric/H1Dimension.lean` are positional; `RotatedSurface/DistanceX.lean` uses `Z₁`/`B₁`/`H₁`; the docstrings note that `ToricChain` and `RotatedSurfaceChain` bind the same tokens (open one per file).
- **`Toric/CodeN.lean`** — the incremental `let op₀ … op₄` ladders are restored; the notation stays in `vertexStab`/`faceStab`.
- **Display tests** — every printer now has `run_cmd` tests of its output (the hashCommand linter allows no `#`-commands), covering the literal and symbolic σ/P forms, the explicit-`I` case, `⟪p, q⟫ₛ`, `poly[…]` and its non-firing on an `ℕ × ℕ` indicator, `⋆`, and `dim₂`.
- **Docs** — CLAUDE.md and `_TEMPLATE.lean` corrected (`⊗ᵍ` lives in `Tensor.lean`; `logicalX` is an abbreviation, not a notation; rotated-surface generators are not written in the symbolic form).

Left as documented limitations: `Z₁`/`B₁`/`H₁` are bound per family (ambiguous only if both scopes are opened in one file), and `dim₂` still lives in `Homological/Code.lean`, so `Toric/H1Dimension.lean` keeps that import.

Verification of the fixed tree: BB safe-floor leaves built sequentially, then `lake build`, `lake build QECLight QECBlueprint QECWidgets QEC.Stabilizer.Codes._TEMPLATE`, `lake env lean Playground.lean`, `lake env lean scripts/AxiomCheck.lean` (only `[propext, Classical.choice, Quot.sound]`), `bash scripts/check-umbrellas.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
