### PR TITLE
feat(steane7): kernel-only distance-3 proof and [[7,1,3]] packaging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,8 @@ QEC/
 Everything under `Codes/` is `native_decide`-free. The instances that carried
 one are parked on branch `claude/z3z6-parked`:
 `BivariateBicycle/{Z3Z6,Z5Z15F2A6,BaseFloors}/`, `Codes/Concat/` (both Steane
-concatenations), `RotatedSurface/Three.lean`, and `Small/Steane7Distance.lean`.
+concatenations), and `RotatedSurface/Three.lean`. (`Small/Steane7Distance.lean` was
+de-nativized and is back on `main`.)
 `Framework/` keeps the abstract machinery they exercised — notably
 `Framework/Concatenation/`, which now has no concrete instance in this tree.
 

--- a/Playground.lean
+++ b/Playground.lean
@@ -31,6 +31,7 @@ open Quantum.StabilizerGroup
 -- `open Quantum.StabilizerGroup` above activates it.
 #check (FiveQubit_5_1_3.stabilizerCodeWithDistance : Code[[5, 1, 3]])
 #check (Steane7.stabilizerCode : Code[[7, 1]])
+#check (Steane7.stabilizerCodeWithDistance : Code[[7, 1, 3]])
 
 -- The parametric toric code, for every `L ≥ 2`. (It lives under
 -- `Quantum.Stabilizer.Lattice`, not the `Quantum.StabilizerGroup` opened above.)

--- a/QEC/Stabilizer/Codes/Small.lean
+++ b/QEC/Stabilizer/Codes/Small.lean
@@ -1,5 +1,6 @@
 import QEC.Stabilizer.Codes.Small.Shor9
 import QEC.Stabilizer.Codes.Small.Steane7
+import QEC.Stabilizer.Codes.Small.Steane7Distance
 import QEC.Stabilizer.Codes.Small.Steane7TransversalGates
 import QEC.Stabilizer.Codes.Small.FourQubit_4_2_2
 import QEC.Stabilizer.Codes.Small.QuantumHamming
@@ -11,9 +12,8 @@ import QEC.Stabilizer.Codes.Small.SixQubit_6_2_2
 # Small concrete codes
 
 Single-instance stabilizer codes: Shor's [[9,1,3]], Steane [[7,1,3]] (with
-transversal gates; its distance proof `Steane7Distance.lean` is **parked on
-branch `claude/z3z6-parked`** pending de-nativization), the [[4,2,2]] code,
-quantum Hamming, the [[5,1,3]]
+transversal gates, and its distance-3 proof in `Steane7Distance.lean` via the
+Hamming-column condition), the [[4,2,2]] code, quantum Hamming, the [[5,1,3]]
 perfect code (the first non-CSS code in the repo), the [[4,1,2]]
 LNCY CSS detection code, and Knill's C_6 [[6,2,2]] CSS detection code.
 -/

--- a/QEC/Stabilizer/Codes/Small/Steane7Distance.lean
+++ b/QEC/Stabilizer/Codes/Small/Steane7Distance.lean
@@ -1,0 +1,126 @@
+import QEC.Stabilizer.Framework.Core.CSS.CSSDistance
+import QEC.Stabilizer.Codes.Small.Steane7
+
+/-!
+# The Steane code has distance 3: `[[7, 1, 3]]`
+
+`Steane7.lean` packages the Steane code as a `Code[[7, 1]]`. This file proves
+`HasCodeDistance stabilizerCode 3` and bundles the result as `stabilizerCodeWithDistance :
+Code[[7, 1, 3]]`.
+
+The argument is the textbook one. The Steane code is the CSS code of the classical `[7,4,3]`
+Hamming code, whose parity-check matrix has as columns the seven nonzero vectors of length
+three — so no column is zero and no two columns coincide. By
+`hasCodeDistance_three_of_columns` that is exactly what is needed for no Pauli of weight `1` or
+`2` to commute with every check: a weight-`≤ 2` error whose `X`-part is a Hamming codeword has no
+`X`-part at all, and likewise for its `Z`-part. The upper bound is the explicit weight-3 logical
+`X̄ · X₁ = X` on qubits `{3, 5, 6}`, which is a nontrivial logical because it still anticommutes
+with `Z̄`.
+
+Every finite check (the column conditions on the three rows, the weight of the witness, its
+anticommutation with `Z̄`) is closed by the kernel with `decide`; the file is `native_decide`-free.
+-/
+
+namespace Quantum.StabilizerGroup.Steane7
+
+open NQubitPauliGroupElement
+open scoped Pauli
+
+/-! ## The Hamming parity-check rows -/
+
+/-- The three parity-check rows of the classical `[7,4,3]` Hamming code, `r₁ = {0,1,2,4}`,
+`r₂ = {0,1,3,5}`, `r₃ = {0,2,3,6}`. Column `i` of the check matrix is the set of rows containing
+qubit `i`; the seven columns are the seven nonzero vectors of `𝔽₂³`. -/
+def row : Fin 3 → Finset (Fin 7) := ![{0, 1, 2, 4}, {0, 1, 3, 5}, {0, 2, 3, 6}]
+
+/-- The `Z`-checks are `Z` along the Hamming rows. -/
+lemma Z1_eq_zOn : Z1 = zOn {0, 1, 2, 4} :=
+  NQubitPauliGroupElement.ext _ _ rfl (funext fun i => by fin_cases i <;> rfl)
+
+lemma Z2_eq_zOn : Z2 = zOn {0, 1, 3, 5} :=
+  NQubitPauliGroupElement.ext _ _ rfl (funext fun i => by fin_cases i <;> rfl)
+
+lemma Z3_eq_zOn : Z3 = zOn {0, 2, 3, 6} :=
+  NQubitPauliGroupElement.ext _ _ rfl (funext fun i => by fin_cases i <;> rfl)
+
+/-- The `X`-checks are `X` along the same rows (the Steane code is self-dual CSS). -/
+lemma X1_eq_xOn : X1 = xOn {0, 1, 2, 4} :=
+  NQubitPauliGroupElement.ext _ _ rfl (funext fun i => by fin_cases i <;> rfl)
+
+lemma X2_eq_xOn : X2 = xOn {0, 1, 3, 5} :=
+  NQubitPauliGroupElement.ext _ _ rfl (funext fun i => by fin_cases i <;> rfl)
+
+lemma X3_eq_xOn : X3 = xOn {0, 2, 3, 6} :=
+  NQubitPauliGroupElement.ext _ _ rfl (funext fun i => by fin_cases i <;> rfl)
+
+/-- Each `Z`-check along a Hamming row is a Steane generator. -/
+lemma zOn_row_mem (r : Fin 3) : zOn (row r) ∈ generators := by
+  fin_cases r <;> simp [row, generators, ZGenerators, Z1_eq_zOn, Z2_eq_zOn, Z3_eq_zOn]
+
+/-- Each `X`-check along a Hamming row is a Steane generator. -/
+lemma xOn_row_mem (r : Fin 3) : xOn (row r) ∈ generators := by
+  fin_cases r <;> simp [row, generators, XGenerators, X1_eq_xOn, X2_eq_xOn, X3_eq_xOn]
+
+/-! ## The Hamming code has distance 3
+
+In terms of the check matrix: no column is zero, and no two columns coincide. -/
+
+/-- Every qubit lies on some Hamming row (no zero column). -/
+lemma row_cover : ∀ i : Fin 7, ∃ r, i ∈ row r := by decide
+
+/-- Any two distinct qubits are separated by some Hamming row (distinct columns). -/
+lemma row_separate : ∀ i j : Fin 7, i ≠ j → ∃ r, (i ∈ row r ↔ j ∉ row r) := by decide
+
+/-! ## A weight-3 logical operator
+
+`X̄ = X⊗⁷` times the stabilizer `X₁ = X` on `{0,1,2,4}` is `X` on the complementary qubits
+`{3, 5, 6}`: a weight-3 representative of the same logical operator. -/
+
+/-- `X` on qubits `{3, 5, 6}`, the weight-3 representative `X̄ · X₁` of logical `X`. -/
+def logicalXw3 : NQubitPauliGroupElement 7 := σ[IIIXIXX]
+
+lemma logicalXw3_eq_mul : logicalXw3 = logicalX * X1 :=
+  NQubitPauliGroupElement.ext _ _ rfl (funext fun i => by fin_cases i <;> rfl)
+
+lemma logicalXw3_weight : weight logicalXw3 = 3 := by decide
+
+/-- `X` on `{3, 5, 6}` meets `Z̄ = Z⊗⁷` on three qubits, an odd number, so they anticommute. -/
+lemma logicalXw3_anticomm_logicalZ : Anticommute logicalXw3 logicalZ := by
+  rw [NQubitPauliOperator.anticommutes_iff_symplectic_inner_one]
+  decide
+
+/-- The stabilizer code's subgroup is the closure of the six generators. -/
+lemma stabilizerCode_toSubgroup_eq :
+    stabilizerCode.toStabilizerGroup.toSubgroup = Subgroup.closure generators :=
+  stabilizerGroup_toSubgroup_eq
+
+/-- `X̄ · X₁` commutes with the stabilizer: `X̄` does, and so does the stabilizer element `X₁`. -/
+lemma logicalXw3_mem_centralizer : logicalXw3 ∈ centralizer stabilizerCode.toStabilizerGroup := by
+  rw [logicalXw3_eq_mul]
+  refine (centralizer _).mul_mem logicalX_mem_centralizer (stabilizer_le_centralizer _ ?_)
+  rw [stabilizerCode_toSubgroup_eq]
+  exact Subgroup.subset_closure (by simp [generators, XGenerators])
+
+/-- `X̄ · X₁` is a nontrivial logical operator: it lies in the centralizer and anticommutes with
+the centralizer element `Z̄`. -/
+lemma logicalXw3_isNontrivial :
+    IsNontrivialLogicalOperator logicalXw3 stabilizerCode.toStabilizerGroup :=
+  isNontrivialLogicalOperator_of_anticommute_centralizer _ logicalXw3_mem_centralizer
+    logicalZ_mem_centralizer logicalXw3_anticomm_logicalZ
+
+/-! ## Distance 3 -/
+
+/-- **The Steane code has distance 3.** Both check matrices are the Hamming matrix, whose
+columns are nonzero and pairwise distinct, so no Pauli of weight `1` or `2` is a nontrivial
+logical; `X` on `{3, 5, 6}` is one of weight `3`. -/
+theorem code_has_distance_three : HasCodeDistance stabilizerCode 3 :=
+  hasCodeDistance_three_of_columns row row generators stabilizerCode stabilizerCode_toSubgroup_eq
+    zOn_row_mem xOn_row_mem row_cover row_cover row_separate row_separate
+    ⟨logicalXw3, logicalXw3_isNontrivial, logicalXw3_weight⟩
+
+/-- The Steane code as a `[[7, 1, 3]]` code: `stabilizerCode` packaged with its distance. -/
+noncomputable def stabilizerCodeWithDistance : Code[[7, 1, 3]] where
+  toStabilizerCode := stabilizerCode
+  hasDistance := code_has_distance_three
+
+end Quantum.StabilizerGroup.Steane7

--- a/QEC/Stabilizer/Foundations/BinarySymplectic/SymplecticInner.lean
+++ b/QEC/Stabilizer/Foundations/BinarySymplectic/SymplecticInner.lean
@@ -33,6 +33,42 @@ lemma symplecticProductSingle_eq_zero_iff_commute (P Q : PauliOperator) :
     simp [symplecticProductSingle]
   rfl
 
+/-! ### Single-qubit evaluations
+
+`toSymplecticSingle P = (x-bit, z-bit)`. Pairing against `Z` reads off the `X`-bit and pairing
+against `X` reads off the `Z`-bit — the single-qubit content of "a `Z`-check detects `X`-errors
+and an `X`-check detects `Z`-errors". -/
+
+@[simp] lemma symplecticProductSingle_I_left (Q : PauliOperator) :
+    symplecticProductSingle I Q = 0 := by
+  simp [symplecticProductSingle]
+
+@[simp] lemma symplecticProductSingle_I_right (P : PauliOperator) :
+    symplecticProductSingle P I = 0 := by
+  simp [symplecticProductSingle]
+
+/-- Against `Z`, the symplectic product reads off the `X`-bit of `P`. -/
+@[simp] lemma symplecticProductSingle_Z_right (P : PauliOperator) :
+    symplecticProductSingle P Z = P.toSymplecticSingle.1 := by
+  simp [symplecticProductSingle]
+
+/-- Against `X`, the symplectic product reads off the `Z`-bit of `P`. -/
+@[simp] lemma symplecticProductSingle_X_right (P : PauliOperator) :
+    symplecticProductSingle P X = P.toSymplecticSingle.2 := by
+  simp [symplecticProductSingle]
+
+/-- The `X`-bit of a single-qubit Pauli is `0` or `1`. -/
+lemma toSymplecticSingle_fst_eq_zero_or_one (P : PauliOperator) :
+    P.toSymplecticSingle.1 = 0 ∨ P.toSymplecticSingle.1 = 1 := by
+  cases P <;> decide
+
+/-- A non-identity Pauli with `X`-bit `0` is `Z`, so its `Z`-bit is `1`. -/
+lemma toSymplecticSingle_snd_eq_one_of_fst_eq_zero {P : PauliOperator} (hP : P ≠ I)
+    (h : P.toSymplecticSingle.1 = 0) : P.toSymplecticSingle.2 = 1 := by
+  cases P
+  · exact absurd rfl hP
+  all_goals first | rfl | exact absurd h (by decide)
+
 end PauliOperator
 
 namespace NQubitPauliOperator

--- a/QEC/Stabilizer/Foundations/PauliGroup/Commutation.lean
+++ b/QEC/Stabilizer/Foundations/PauliGroup/Commutation.lean
@@ -272,6 +272,12 @@ lemma anticommutes_iff_mulOp_phasePower (p q : NQubitPauliGroupElement n) :
       simp only [mul, mul_eq, minusOne_operators, mulOp_operators_at, mulOp_identity_left_op,
         PauliOperator.mulOp_operator_comm]
 
+/-- Anticommutation only sees operator parts: elements with equal operator parts anticommute
+with the same things. -/
+lemma anticommute_congr_left {p q r : NQubitPauliGroupElement n} (h : p.operators = q.operators) :
+    Anticommute p r ↔ Anticommute q r := by
+  rw [anticommutes_iff_mulOp_phasePower, anticommutes_iff_mulOp_phasePower, h]
+
 /-- When two Pauli elements anticommute, their product's matrix is -1 times the reversed product. -/
 lemma Anticommute.toMatrix_neg (p q : NQubitPauliGroupElement n) (h : Anticommute p q) :
     (p * q).toMatrix = (-1 : ℂ) • (q * p).toMatrix := by

--- a/QEC/Stabilizer/Framework/Core/CSS/CSSDistance.lean
+++ b/QEC/Stabilizer/Framework/Core/CSS/CSSDistance.lean
@@ -5,6 +5,7 @@ import QEC.Stabilizer.Foundations.PauliGroup.NQubitOperator
 import QEC.Stabilizer.Foundations.PauliGroup.NQubitElement
 import QEC.Stabilizer.Foundations.PauliGroup.Commutation
 import QEC.Stabilizer.Foundations.PauliGroupSingle
+import QEC.Stabilizer.Foundations.BinarySymplectic.SymplecticInner
 
 namespace Quantum
 namespace StabilizerGroup
@@ -177,6 +178,182 @@ theorem hasCodeDistance_two_of_anticommute_witness {k : ℕ} (C : StabilizerCode
     with ⟨h_cent, _, _⟩
   exact no_weight_one_mem_centralizer_of_anticommute_witness C.toStabilizerGroup
     genSet h_closure h_anticomm g hg_weight h_cent
+
+/-! ## Anticommutation of weight-1 and weight-2 elements, qubit by qubit
+
+`weightOneAt i P` and `weightTwoAt i j P Q` are the identity away from the named qubits, so the
+symplectic inner product with any `g` — which decides anticommutation, by
+`anticommutes_iff_symplectic_inner_one` — collapses to one or two single-qubit terms. -/
+
+/-- A weight-one Pauli anticommutes with `g` iff its single qubit does. -/
+theorem anticommute_weightOneAt_iff (i : Fin n) (P : PauliOperator)
+    (g : NQubitPauliGroupElement n) :
+    Anticommute (weightOneAt i P) g ↔ symplecticProductSingle P (g.operators i) = 1 := by
+  rw [NQubitPauliOperator.anticommutes_iff_symplectic_inner_one,
+    NQubitPauliOperator.symplecticInner,
+    Finset.sum_eq_single i (fun k _ hk => by simp [weightOneAt, hk]) (by simp)]
+  simp [weightOneAt]
+
+/-- A weight-two Pauli anticommutes with `g` iff exactly one of its two qubits does. -/
+theorem anticommute_weightTwoAt_iff {i j : Fin n} (hij : i ≠ j) (P Q : PauliOperator)
+    (g : NQubitPauliGroupElement n) :
+    Anticommute (weightTwoAt i j P Q) g ↔
+      symplecticProductSingle P (g.operators i) +
+        symplecticProductSingle Q (g.operators j) = 1 := by
+  rw [NQubitPauliOperator.anticommutes_iff_symplectic_inner_one,
+    NQubitPauliOperator.symplecticInner,
+    Finset.sum_eq_add i j hij (fun k _ hk => by simp [weightTwoAt, hk.1, hk.2]) (by simp) (by simp)]
+  simp [weightTwoAt, hij.symm]
+
+/-! ## CSS checks as supports
+
+A CSS generator is `Z` (or `X`) along a row of the classical parity-check matrix and the
+identity elsewhere. `zOn S` / `xOn S` name that element by its support `S`, so that a CSS code's
+generators can be handed to the distance closers below as a family of `Finset`s. -/
+
+/-- The phase-0 element acting as `Z` on every qubit of `S` and trivially elsewhere. -/
+def zOn (S : Finset (Fin n)) : NQubitPauliGroupElement n :=
+  ofOperator fun k => if k ∈ S then .Z else .I
+
+/-- The phase-0 element acting as `X` on every qubit of `S` and trivially elsewhere. -/
+def xOn (S : Finset (Fin n)) : NQubitPauliGroupElement n :=
+  ofOperator fun k => if k ∈ S then .X else .I
+
+@[simp] lemma zOn_operators (S : Finset (Fin n)) (k : Fin n) :
+    (zOn S).operators k = if k ∈ S then .Z else .I := rfl
+
+@[simp] lemma xOn_operators (S : Finset (Fin n)) (k : Fin n) :
+    (xOn S).operators k = if k ∈ S then .X else .I := rfl
+
+/-- A `Z`-check on `S` detects the weight-one Pauli `P` at `i` iff `i ∈ S` and `P` has an
+`X`-component (`P = X` or `P = Y`, i.e. `X`-bit `1`). -/
+lemma anticommute_weightOneAt_zOn_iff (i : Fin n) (P : PauliOperator) (S : Finset (Fin n)) :
+    Anticommute (weightOneAt i P) (zOn S) ↔ i ∈ S ∧ P.toSymplecticSingle.1 = 1 := by
+  rw [anticommute_weightOneAt_iff]
+  by_cases hi : i ∈ S <;> simp [hi]
+
+/-- An `X`-check on `S` detects the weight-one Pauli `P` at `i` iff `i ∈ S` and `P` has a
+`Z`-component (`P = Z` or `P = Y`, i.e. `Z`-bit `1`). -/
+lemma anticommute_weightOneAt_xOn_iff (i : Fin n) (P : PauliOperator) (S : Finset (Fin n)) :
+    Anticommute (weightOneAt i P) (xOn S) ↔ i ∈ S ∧ P.toSymplecticSingle.2 = 1 := by
+  rw [anticommute_weightOneAt_iff]
+  by_cases hi : i ∈ S <;> simp [hi]
+
+/-- A `Z`-check on `S` detects a weight-two Pauli iff the `X`-bits it sees (at `i` if `i ∈ S`,
+at `j` if `j ∈ S`) sum to `1`. -/
+lemma anticommute_weightTwoAt_zOn_iff {i j : Fin n} (hij : i ≠ j) (P Q : PauliOperator)
+    (S : Finset (Fin n)) :
+    Anticommute (weightTwoAt i j P Q) (zOn S) ↔
+      (if i ∈ S then P.toSymplecticSingle.1 else 0) +
+        (if j ∈ S then Q.toSymplecticSingle.1 else 0) = 1 := by
+  rw [anticommute_weightTwoAt_iff hij]
+  by_cases hi : i ∈ S <;> by_cases hj : j ∈ S <;> simp [hi, hj]
+
+/-- An `X`-check on `S` detects a weight-two Pauli iff the `Z`-bits it sees sum to `1`. -/
+lemma anticommute_weightTwoAt_xOn_iff {i j : Fin n} (hij : i ≠ j) (P Q : PauliOperator)
+    (S : Finset (Fin n)) :
+    Anticommute (weightTwoAt i j P Q) (xOn S) ↔
+      (if i ∈ S then P.toSymplecticSingle.2 else 0) +
+        (if j ∈ S then Q.toSymplecticSingle.2 else 0) = 1 := by
+  rw [anticommute_weightTwoAt_iff hij]
+  by_cases hi : i ∈ S <;> by_cases hj : j ∈ S <;> simp [hi, hj]
+
+/-! ## Distance-3 packaging for CSS codes: the column condition
+
+The classical picture. Write a Pauli `E` as an `X`-support `A` (the qubits carrying `X` or `Y`)
+and a `Z`-support `B` (those carrying `Z` or `Y`). `E` commutes with the `Z`-check on row `S`
+iff `|A ∩ S|` is even, and with the `X`-check on `S` iff `|B ∩ S|` is even. So `E` goes
+undetected iff `A` is a codeword of the classical code with check rows `zRow` and `B` one of the
+code with check rows `xRow`. If both classical codes have distance `≥ 3` — every column of the
+check matrix is nonzero (`_cover`: each qubit lies on some row) and any two columns are distinct
+(`_sep`: any two qubits are separated by some row) — then a codeword of weight `≤ 2` is zero, so
+`|A|, |B| ≤ 2` forces `A = B = ∅`: no Pauli of weight `1` or `2` is undetected.
+
+The two theorems below are that argument at weights one and two, phrased as the anticommute
+witness functions consumed by `no_weight_one_mem_centralizer_of_anticommute_witness` and
+`no_weight_two_mem_centralizer_of_anticommute_witness`; `hasCodeDistance_three_of_columns`
+packages them with a weight-3 witness. First exerciser: the Steane `[[7,1,3]]` code
+(`Codes/Small/Steane7Distance.lean`), whose Hamming check matrix has exactly the seven nonzero
+columns of length three. -/
+
+section Columns
+
+variable {ι κ : Type*} (zRow : ι → Finset (Fin n)) (xRow : κ → Finset (Fin n))
+  (genSet : Set (NQubitPauliGroupElement n))
+
+/-- No weight-one Pauli goes undetected when every qubit lies on a `Z`-row and on an `X`-row. -/
+theorem weight_one_anticomm_witness_of_columns
+    (hz : ∀ r, zOn (zRow r) ∈ genSet) (hx : ∀ c, xOn (xRow c) ∈ genSet)
+    (hz_cover : ∀ i, ∃ r, i ∈ zRow r) (hx_cover : ∀ i, ∃ c, i ∈ xRow c) :
+    ∀ i : Fin n, ∀ P : PauliOperator, P ≠ .I →
+      ∃ g ∈ genSet, Anticommute (weightOneAt i P) g := by
+  intro i P hP
+  rcases toSymplecticSingle_fst_eq_zero_or_one P with hPx | hPx
+  · -- `P = Z`: any `X`-row through `i` detects it.
+    obtain ⟨c, hc⟩ := hx_cover i
+    exact ⟨xOn (xRow c), hx c, (anticommute_weightOneAt_xOn_iff i P _).mpr
+      ⟨hc, toSymplecticSingle_snd_eq_one_of_fst_eq_zero hP hPx⟩⟩
+  · -- `P ∈ {X, Y}`: any `Z`-row through `i` detects it.
+    obtain ⟨r, hr⟩ := hz_cover i
+    exact ⟨zOn (zRow r), hz r, (anticommute_weightOneAt_zOn_iff i P _).mpr ⟨hr, hPx⟩⟩
+
+/-- No weight-two Pauli goes undetected when, in addition, any two qubits are separated by a
+`Z`-row and by an `X`-row. -/
+theorem weight_two_anticomm_witness_of_columns
+    (hz : ∀ r, zOn (zRow r) ∈ genSet) (hx : ∀ c, xOn (xRow c) ∈ genSet)
+    (hz_cover : ∀ i, ∃ r, i ∈ zRow r)
+    (hz_sep : ∀ i j, i ≠ j → ∃ r, (i ∈ zRow r ↔ j ∉ zRow r))
+    (hx_sep : ∀ i j, i ≠ j → ∃ c, (i ∈ xRow c ↔ j ∉ xRow c)) :
+    ∀ i j : Fin n, i ≠ j → ∀ P Q : PauliOperator, P ≠ .I → Q ≠ .I →
+      ∃ g ∈ genSet, Anticommute (weightTwoAt i j P Q) g := by
+  intro i j hij P Q hP hQ
+  rcases toSymplecticSingle_fst_eq_zero_or_one P with hPx | hPx <;>
+    rcases toSymplecticSingle_fst_eq_zero_or_one Q with hQx | hQx
+  · -- `P = Q = Z`: an `X`-row separating `i` from `j` sees exactly one of them.
+    obtain ⟨c, hc⟩ := hx_sep i j hij
+    refine ⟨xOn (xRow c), hx c, (anticommute_weightTwoAt_xOn_iff hij P Q _).mpr ?_⟩
+    rw [toSymplecticSingle_snd_eq_one_of_fst_eq_zero hP hPx,
+      toSymplecticSingle_snd_eq_one_of_fst_eq_zero hQ hQx]
+    by_cases hi : i ∈ xRow c <;> simp_all
+  · -- Only `Q` has an `X`-component: a `Z`-row through `j` sees it alone.
+    obtain ⟨r, hr⟩ := hz_cover j
+    refine ⟨zOn (zRow r), hz r, (anticommute_weightTwoAt_zOn_iff hij P Q _).mpr ?_⟩
+    simp [hr, hPx, hQx]
+  · -- Only `P` has an `X`-component: a `Z`-row through `i` sees it alone.
+    obtain ⟨r, hr⟩ := hz_cover i
+    refine ⟨zOn (zRow r), hz r, (anticommute_weightTwoAt_zOn_iff hij P Q _).mpr ?_⟩
+    simp [hr, hPx, hQx]
+  · -- Both have an `X`-component: a `Z`-row separating `i` from `j` sees exactly one.
+    obtain ⟨r, hr⟩ := hz_sep i j hij
+    refine ⟨zOn (zRow r), hz r, (anticommute_weightTwoAt_zOn_iff hij P Q _).mpr ?_⟩
+    rw [hPx, hQx]
+    by_cases hi : i ∈ zRow r <;> simp_all
+
+/-- **Distance 3 from the column condition.** A CSS stabilizer code `C`, generated by `genSet`,
+whose `Z`-checks `zOn (zRow r)` and `X`-checks `xOn (xRow c)` lie in `genSet`, has distance
+exactly `3` as soon as both check matrices have nonzero, pairwise distinct columns (classical
+distance `≥ 3` on each side) and some nontrivial logical of weight `3` is exhibited. -/
+theorem hasCodeDistance_three_of_columns {k : ℕ} (C : StabilizerCode n k)
+    (h_closure : C.toStabilizerGroup.toSubgroup = Subgroup.closure genSet)
+    (hz : ∀ r, zOn (zRow r) ∈ genSet) (hx : ∀ c, xOn (xRow c) ∈ genSet)
+    (hz_cover : ∀ i, ∃ r, i ∈ zRow r) (hx_cover : ∀ i, ∃ c, i ∈ xRow c)
+    (hz_sep : ∀ i j, i ≠ j → ∃ r, (i ∈ zRow r ↔ j ∉ zRow r))
+    (hx_sep : ∀ i j, i ≠ j → ∃ c, (i ∈ xRow c ↔ j ∉ xRow c))
+    (h_witness : ∃ g, IsNontrivialLogicalOperator g C.toStabilizerGroup ∧ weight g = 3) :
+    HasCodeDistance C 3 := by
+  refine hasCodeDistance_of C 3 (by decide) h_witness ?_
+  intro w hw_pos hw_lt g hg_weight h_nontrivial
+  rcases (IsNontrivialLogicalOperator_iff g C.toStabilizerGroup).mp h_nontrivial
+    with ⟨h_cent, _, _⟩
+  interval_cases w
+  · exact no_weight_one_mem_centralizer_of_anticommute_witness C.toStabilizerGroup genSet
+      h_closure (weight_one_anticomm_witness_of_columns zRow xRow genSet hz hx hz_cover hx_cover)
+      g hg_weight h_cent
+  · exact no_weight_two_mem_centralizer_of_anticommute_witness C.toStabilizerGroup genSet
+      h_closure (weight_two_anticomm_witness_of_columns zRow xRow genSet hz hx hz_cover hz_sep
+        hx_sep) g hg_weight h_cent
+
+end Columns
 
 end StabilizerGroup
 end Quantum

--- a/QEC/Stabilizer/Framework/Core/Logical/LogicalOperators.lean
+++ b/QEC/Stabilizer/Framework/Core/Logical/LogicalOperators.lean
@@ -184,6 +184,18 @@ theorem IsNontrivialLogicalOperator_of_toSubgroup_eq (g : NQubitPauliGroupElemen
     (IsNontrivialLogicalOperator g S ↔ IsNontrivialLogicalOperator g T) :=
   RepresentsNontrivialCoset_of_toSubgroup_eq g h
 
+/-- A centralizer element that anticommutes with some other centralizer element is a nontrivial
+logical operator. It cannot lie in the stabilizer, which commutes with the whole centralizer, and
+neither can any stabilizer element sharing its operator part, since anticommutation only sees
+operator parts (`anticommute_congr_left`). This is how a low-weight representative `X̄·s`
+(`s` a stabilizer) is certified nontrivial: it still anticommutes with `Z̄`. -/
+theorem isNontrivialLogicalOperator_of_anticommute_centralizer (S : StabilizerGroup n)
+    {g h : NQubitPauliGroupElement n} (hg : g ∈ centralizer S) (hh : h ∈ centralizer S)
+    (hgh : NQubitPauliGroupElement.Anticommute g h) : IsNontrivialLogicalOperator g S :=
+  ⟨hg, not_mem_stabilizer_of_anticommutes_centralizer S g h hh hgh, fun s hs h_ops =>
+    not_mem_stabilizer_of_anticommutes_centralizer S s h hh
+      ((NQubitPauliGroupElement.anticommute_congr_left h_ops).mpr hgh) hs⟩
+
 /-- Data for one logical qubit: a pair of logical X and Z operators that commute with
     the stabilizer and anticommute with each other. -/
 structure LogicalQubitOps (n : ℕ) (S : StabilizerGroup n) where

--- a/QECBlueprint.lean
+++ b/QECBlueprint.lean
@@ -444,6 +444,26 @@ attribute [blueprint "thm:css-distance-two"
     \cref{chap:codes}. -/)]
   Quantum.StabilizerGroup.hasCodeDistance_two_of_anticommute_witness
 
+attribute [blueprint "thm:css-distance-three"
+  (title := /-- A distance-three closer for CSS codes -/)
+  (statement := /-- Let a CSS code have $Z$-checks and $X$-checks supported on the
+    rows of two classical parity-check matrices. If both matrices have
+    nonzero, pairwise distinct columns --- both classical codes have distance
+    at least $3$ --- and some nontrivial logical operator of weight $3$ exists,
+    then the code has distance exactly $3$. -/)
+  (proof := /-- A weight-one Pauli at qubit $i$ is $Z$, detected by any $X$-row
+    through $i$, or carries an $X$-component, detected by any $Z$-row through
+    $i$; nonzero columns supply the rows. For a weight-two Pauli on qubits
+    $i \ne j$, the anticommutation with a check is the sum of the two
+    single-qubit symplectic products it sees: if exactly one qubit carries an
+    $X$-component a $Z$-row through it detects the pair, and if both (or
+    neither, so both are $Z$) do, a $Z$-row (resp.\ $X$-row) containing exactly
+    one of $i, j$ --- which exists because the columns are distinct --- sees a
+    single $1$. So no Pauli of weight one or two lies in the centralizer, and
+    the exhibited weight-three logical makes the minimum exactly three by
+    \cref{def:has-code-distance}. -/)]
+  Quantum.StabilizerGroup.hasCodeDistance_three_of_columns
+
 /-! ## Chapter 6 — The homological framework -/
 
 attribute [blueprint "def:homological-code"
@@ -778,8 +798,12 @@ attribute [blueprint "def:gross-code-with-distance"
 attribute [blueprint "def:steane7"
   (title := /-- The Steane $[[7,1,3]]$ code -/)
   (statement := /-- The CSS code built from the classical $[7,4,3]$ Hamming
-    code, with all-$X$ and all-$Z$ logical operators. -/)]
-  Quantum.StabilizerGroup.Steane7.stabilizerCode
+    code, with all-$X$ and all-$Z$ logical operators, packaged with its
+    distance. The Hamming check matrix has as columns the seven nonzero
+    vectors of $\F_2^3$, so \cref{thm:css-distance-three} applies with the same
+    three rows on both sides; $X$ on qubits $\{3,5,6\}$ is the weight-three
+    logical. -/)]
+  Quantum.StabilizerGroup.Steane7.stabilizerCodeWithDistance
 
 attribute [blueprint "def:shor9"
   (title := /-- The Shor $[[9,1,3]]$ code -/)

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Contributions are welcome! If you add new modules or definitions, please:
 
 - Extend the class small-cycle theorem (analytic `d ≥ 6` for a characterized family of weight-3 BB codes) toward weight-5 / `d ≥ 10` classes
 - Certify a BB code with distance `> 12` end-to-end through the doubling framework (the `[[300,8,16]]` two-tier instance's remaining dangerous-sector work)
-- Restore the parked formalizations on `claude/z3z6-parked` (`Z3Z6/`, `Z5Z15F2A6/`, `BaseFloors/`, the two Steane concatenations, the 3×3 rotated surface, Steane7's distance proof) by replacing their `native_decide` leaves with kernel checks or certificates
+- Restore the parked formalizations on `claude/z3z6-parked` (`Z3Z6/`, `Z5Z15F2A6/`, `BaseFloors/`, the two Steane concatenations, the 3×3 rotated surface) by replacing their `native_decide` leaves with kernel checks or certificates
 
 ### Long-Term Goals
 

--- a/blueprint/src/content.tex
+++ b/blueprint/src/content.tex
@@ -212,6 +212,7 @@ $X$ and $Z$ sides become the two ends of a chain complex.
 \inputleannode{def:x-type}
 \inputleannode{def:z-type}
 \inputleannode{thm:css-distance-two}
+\inputleannode{thm:css-distance-three}
 
 \chapter{The homological framework}
 \label{chap:homological}


### PR DESCRIPTION
## Summary

Brings `Codes/Small/Steane7Distance.lean` back from `claude/z3z6-parked` **without `native_decide`**, and packages the Steane code as `Steane7.stabilizerCodeWithDistance : Code[[7, 1, 3]]`.

The parked version needed `native_decide` on a 784-case weight-2 anticommutation table. This version follows the textbook argument instead: Steane is the CSS code of the classical [7,4,3] Hamming code, whose parity-check matrix has **nonzero, pairwise distinct columns**. Both facts about the three rows close by `decide` on `Fin 7`, and a new general theorem turns them into "no Pauli of weight 1 or 2 lies in the centralizer". The weight-3 witness is `X̄·X₁ = X` on qubits `{3,5,6}`, certified nontrivial because it still anticommutes with `Z̄`.

## Reusable framework added

- **`hasCodeDistance_three_of_columns`** (`Framework/Core/CSS/CSSDistance.lean`): a CSS code generated by `Z`-checks `zOn (zRow r)` and `X`-checks `xOn (xRow c)` has distance exactly 3 as soon as both check matrices have nonzero, pairwise distinct columns (classical distance ≥ 3 on each side) and a weight-3 nontrivial logical is exhibited. `weight_one_anticomm_witness_of_columns` / `weight_two_anticomm_witness_of_columns` are the two halves. `QuantumHamming` (or any CSS code built from a distance-3 classical code) can reuse it verbatim.
- `zOn` / `xOn` — a CSS check named by its support `Finset`.
- `anticommute_weightOneAt_iff` / `anticommute_weightTwoAt_iff` — anticommutation of a weight-1/2 Pauli with `g` collapses to one/two single-qubit symplectic products (via `anticommutes_iff_symplectic_inner_one`), plus the `_zOn_iff` / `_xOn_iff` specialisations.
- `isNontrivialLogicalOperator_of_anticommute_centralizer` (`LogicalOperators.lean`) and `anticommute_congr_left` (`Commutation.lean`) — the nontriviality argument that `FiveQubit_5_1_3.lean` inlines, as reusable lemmas.
- `symplecticProductSingle_{I_left,I_right,Z_right,X_right}` simp lemmas and two `toSymplecticSingle` bit helpers (`SymplecticInner.lean`).

## Also

- `Codes/Small.lean` umbrella import + docstring; `Playground.lean` `#check (Steane7.stabilizerCodeWithDistance : Code[[7, 1, 3]])`.
- Blueprint: new node `thm:css-distance-three` (wired into `content.tex` after `thm:css-distance-two`); `def:steane7` now annotates the distance-carrying object.
- Parked-file lists in `CLAUDE.md` and `README.md` updated.

## Verification

All six pre-push checks pass (run detached with `LEAN_NUM_THREADS=3`, BB safe-floor leaves built sequentially first):
`lake build`, `lake build QECLight`, `lake build QECBlueprint`, `lake build QECWidgets`, `lake env lean Playground.lean`, `lake env lean scripts/AxiomCheck.lean` (6421 declarations, standard three axioms only), `bash scripts/check-umbrellas.sh`.

`#print axioms` on `Steane7.code_has_distance_three`, `Steane7.stabilizerCodeWithDistance` and `hasCodeDistance_three_of_columns`: `[propext, Classical.choice, Quot.sound]`. No new warnings in any touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
